### PR TITLE
feat: support for OkHttp thread metrics

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ okio-version = "3.6.0"
 otel-version = "1.32.0"
 slf4j-version = "2.0.9"
 slf4j-v1x-version = "1.7.36"
-crt-kotlin-version = "0.8.2"
+crt-kotlin-version = "0.8.3"
 
 # codegen
 smithy-version = "1.42.0"

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -76,7 +76,9 @@ public class OkHttpEngine(
 }
 
 private fun Dispatcher.getThreadState(): ThreadState? = (executorService as? ThreadPoolExecutor)?.let { executor ->
-    ThreadState(executor.poolSize.toLong(), executor.activeCount.toLong())
+    val active = executor.activeCount.toLong()
+    val idle = executor.poolSize.toLong() - active
+    ThreadState(idle, active)
 }
 
 private fun OkHttpEngineConfig.buildDispatcher() = Dispatcher().apply {

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
@@ -25,12 +25,12 @@ public object HttpClientMetricAttributes {
     public val AcquiredConnection: Attributes = attributesOf { "state" to "acquired" }
     public val QueuedRequest: Attributes = attributesOf { "state" to "queued" }
     public val InFlightRequest: Attributes = attributesOf { "state" to "in-flight" }
-    public val TotalThread: Attributes = attributesOf { "state" to "total" }
+    public val IdleThread: Attributes = attributesOf { "state" to "idle" }
     public val ActiveThread: Attributes = attributesOf { "state" to "active" }
 }
 
 @InternalApi
-public data class ThreadState(val total: Long, val active: Long)
+public data class ThreadState(val idle: Long, val active: Long)
 
 /**
  * Container for common HTTP engine related metrics. Engine implementations can re-use this and update
@@ -130,7 +130,7 @@ public class HttpClientMetrics(
                 "smithy.client.http.threads.count",
                 { measurement -> recordThreadState(measurement, callback) },
                 "{thread}",
-                "Current state of HTTP engine threads (active, running)",
+                "Current state of HTTP engine threads (idle, active)",
             )
         },
     )
@@ -201,7 +201,7 @@ public class HttpClientMetrics(
 
     private fun recordThreadState(measurement: LongAsyncMeasurement, callback: () -> ThreadState?) {
         callback()?.let { threadState ->
-            measurement.record(threadState.total, HttpClientMetricAttributes.TotalThread)
+            measurement.record(threadState.idle, HttpClientMetricAttributes.IdleThread)
             measurement.record(threadState.active, HttpClientMetricAttributes.ActiveThread)
         }
     }


### PR DESCRIPTION
## Issue \#

#894 

## Description of changes

This change adds metrics for the OkHttp engine's thread pool. It should be considered WIP until the following open questions are addressed:

* How can we best test this in an automated fashion?
* This change only adds support for OkHttp. CRT doesn't seem to have support for interrogating metrics about HTTP client thread counts. Is that good enough for now or should we push for enhanced support in CRT?
* The additions to `HttpClientMetrics` eschew the existing pattern of pushing metrics to intermediate refs and the polling them from the async counter in favor of pulling the source data directly via a passed callback. This seems cleaner to me since it removes unnecessary state but I'm curious whether others think it's a good idea (and whether we'd potentially want to extend it to other async counters as appropriate).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
