### PR TITLE
fix: correctly codegen maps which use nested maps that contain enum keys

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
@@ -302,7 +302,7 @@ open class DeserializeStructGenerator(
                         "val #L = #T<#T, #T#L>()",
                         memberName,
                         KotlinTypes.Collections.mutableMapOf,
-                        keySymbol,
+                        ctx.symbolProvider.toSymbol(mapShape.key),
                         ctx.symbolProvider.toSymbol(mapShape.value),
                         nullabilitySuffix(mapShape.isSparse),
                     )


### PR DESCRIPTION
## Issue \#

Missed in #1052 which addresses #1045 

## Description of changes

Correctly handle nested maps in codegen. (e.g., `Map<OuterEnumType, Map<InnerEnumType, String>>`) and add a unit test to verify.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
