### PR TITLE
fix(codegen): resource operations not generating paginators or waiters

### DIFF
--- a/.changes/c855db56-72aa-4f1e-9200-46122fdaec75.json
+++ b/.changes/c855db56-72aa-4f1e-9200-46122fdaec75.json
@@ -1,0 +1,5 @@
+{
+    "id": "c855db56-72aa-4f1e-9200-46122fdaec75",
+    "type": "bugfix",
+    "description": "Fix not generating waiters and paginators for operations that come from resources"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
@@ -25,6 +25,7 @@ import software.amazon.smithy.kotlin.codegen.utils.getOrNull
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.PaginatedIndex
 import software.amazon.smithy.model.knowledge.PaginationInfo
+import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.OperationShape
@@ -38,7 +39,9 @@ import software.amazon.smithy.model.traits.PaginatedTrait
  */
 class PaginatorGenerator : KotlinIntegration {
     override fun enabledForService(model: Model, settings: KotlinSettings): Boolean =
-        model.operationShapes.any { it.hasTrait<PaginatedTrait>() }
+        TopDownIndex.of(model)
+            .getContainedOperations(settings.service)
+            .any { it.hasTrait<PaginatedTrait>() }
 
     override fun writeAdditionalFiles(ctx: CodegenContext, delegator: KotlinDelegator) {
         val service = ctx.model.expectShape<ServiceShape>(ctx.settings.service)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGenerator.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.model.getTrait
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.waiters.*
@@ -20,7 +21,9 @@ import software.amazon.smithy.waiters.*
  */
 class ServiceWaitersGenerator : KotlinIntegration {
     override fun enabledForService(model: Model, settings: KotlinSettings): Boolean =
-        model.operationShapes.any { it.waitableTrait != null }
+        TopDownIndex.of(model)
+            .getContainedOperations(settings.service)
+            .any { it.waitableTrait != null }
 
     override fun writeAdditionalFiles(ctx: CodegenContext, delegator: KotlinDelegator) {
         delegator.useFileWriter("Waiters.kt", "${ctx.settings.pkg.name}.waiters") { writer ->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->


## Description of changes
<!--- Why is this change required? What problem does it solve? -->

Operations with the paginated trait or waiter trait that come from resources are not considered as part of the integration enable checks. In general we should almost never be iterating `model.operationShapes` directly. Especially since a "model" can technically contain multiple services and we always want to be working with some defined service shape closure.


```smithy
$version: "2"
namespace example.weather

service Weather {
    version: "2006-03-01"
    resources: [City]
    operations: [GetCurrentTime]
}

resource City {
    identifiers: { cityId: CityId }
    read: GetCity
    list: ListCities
}

@paginated(...)
operation ListCities { ... }

...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
