### PR TITLE
chore: manual version bump due to incomplete release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ kotlinx.atomicfu.enableNativeIrTransformation=false
 org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=1G
 
 # SDK
-sdkVersion=1.1.2-SNAPSHOT
+sdkVersion=1.1.3-SNAPSHOT
 
 # codegen
-codegenVersion=0.31.2-SNAPSHOT
+codegenVersion=0.31.3-SNAPSHOT


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

The 1.1.2 release was interrupted due to publishing issues. We also pushed more changes to **main** in the interim so a re-release of 1.1.2 will fail. Bumping snapshot versions to 1.1.3 (codegen 0.31.3) in preparation for another release today.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
