### PR TITLE
fix: correctly handle async cancellation of call context in OkHttp engine

### DIFF
--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -51,6 +51,7 @@ public class OkHttpEngine(
         val engineResponse = mapOkHttpExceptions { engineCall.executeAsync() }
 
         callContext.job.invokeOnCompletion {
+            engineCall.cancel()
             engineResponse.body.close()
         }
 

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
@@ -87,4 +87,45 @@ class AsyncStressTest : AbstractEngineTest() {
             assertEquals(engineJobsBefore.size, engineJobsAfter.size, message)
         }
     }
+
+    @Test
+    fun testJobCancellation() = testEngines {
+        // https://github.com/smithy-lang/smithy-kotlin/issues/1061
+
+        test { _, client ->
+            val req = HttpRequest {
+                testSetup()
+                url.path.decoded = "slow"
+            }
+
+            // Expect CancellationException because we're cancelling
+            assertFailsWith<CancellationException> {
+                coroutineScope {
+                    val parentScope = this
+
+                    println("Invoking call on ctx $coroutineContext")
+                    val call = client.call(req)
+
+                    val bytes = async {
+                        delay(100.milliseconds)
+                        println("Body of type ${call.response.body} on ctx $coroutineContext")
+                        try {
+                            call.response.body.readAll()
+                        } catch (e: Throwable) {
+                            // IllegalStateException: "Unbalanced enter/exit" will be thrown if body closed improperly
+                            assertIsNot<IllegalStateException>(e)
+                            null
+                        }
+                    }
+
+                    val cancellation = async {
+                        delay(400.milliseconds)
+                        parentScope.cancel("Cancelling!")
+                    }
+
+                    awaitAll(bytes, cancellation)
+                }
+            }
+        }
+    }
 }

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Concurrency.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Concurrency.kt
@@ -8,6 +8,8 @@ package aws.smithy.kotlin.runtime.http.test.suite
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 internal fun Application.concurrentTests() {
     routing {
@@ -16,6 +18,18 @@ internal fun Application.concurrentTests() {
                 val respSize = 32 * 1024
                 val text = "testing"
                 call.respondText(text.repeat(respSize / text.length))
+            }
+        }
+
+        route("slow") {
+            get {
+                val chunk = ByteArray(256) { it.toByte() }
+                call.respondOutputStream {
+                    repeat(10) {
+                        delay(200.milliseconds)
+                        write(chunk)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Issue \#

Resolves #1061 

## Description of changes

Update OkHttp engine call context cancellation to first cancel the call before attempting to close any response body.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
