### PR TITLE
fix: correctly codegen waiters and paginators for resource operations

### DIFF
--- a/.changes/e26e1980-ee66-4d9d-99b5-6ee0f1f3901d.json
+++ b/.changes/e26e1980-ee66-4d9d-99b5-6ee0f1f3901d.json
@@ -1,0 +1,8 @@
+{
+    "id": "e26e1980-ee66-4d9d-99b5-6ee0f1f3901d",
+    "type": "bugfix",
+    "description": "Correctly generate waiters and paginators for resource operations",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#900"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
@@ -47,11 +47,12 @@ class PaginatorGenerator : KotlinIntegration {
         val service = ctx.model.expectShape<ServiceShape>(ctx.settings.service)
         val paginatedIndex = PaginatedIndex.of(ctx.model)
 
-        delegator.useFileWriter("Paginators.kt", "${ctx.settings.pkg.name}.paginators") { writer ->
-            val paginatedOperations = service.allOperations
-                .map { ctx.model.expectShape<OperationShape>(it) }
-                .filter { operationShape -> operationShape.hasTrait(PaginatedTrait.ID) }
+        val paginatedOperations = TopDownIndex
+            .of(ctx.model)
+            .getContainedOperations(ctx.settings.service)
+            .filter { it.hasTrait<PaginatedTrait>() }
 
+        delegator.useFileWriter("Paginators.kt", "${ctx.settings.pkg.name}.paginators") { writer ->
             paginatedOperations.forEach { paginatedOperation ->
                 val paginationInfo = paginatedIndex.getPaginationInfo(service, paginatedOperation).getOrNull()
                     ?: throw CodegenException("Unexpectedly unable to get PaginationInfo from $service $paginatedOperation")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGenerator.kt
@@ -44,9 +44,9 @@ internal fun CodegenContext.allWaiters(): List<WaiterInfo> {
             WaiterInfo(this, service, op, name, waiter)
         } ?: listOf()
 
-    return service
-        .allOperations
-        .map { model.expectShape<OperationShape>(it) }
+    return TopDownIndex
+        .of(model)
+        .getContainedOperations(service)
         .flatMap(::operationWaiters)
 }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
@@ -50,7 +50,7 @@ class ServiceWaitersGeneratorTest {
                 return strategy.retry(policy) { describeFooOptional(request) }
             }
         """.trimIndent()
-        generateService().shouldContain(methodHeader, methodFooter)
+        generateService("simple-service-with-operation-waiter.smithy").shouldContain(methodHeader, methodFooter)
     }
 
     @Test
@@ -124,7 +124,7 @@ class ServiceWaitersGeneratorTest {
         }
     }
 
-    private fun generateService(modelResourceName: String = "simple-service-with-operation-waiter.smithy"): String {
+    private fun generateService(modelResourceName: String): String {
         val model = loadModelFromResource(modelResourceName)
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
         val service = model.getShape(ShapeId.from(TestModelDefault.SERVICE_SHAPE_ID)).get().asServiceShape().get()

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
@@ -20,37 +20,37 @@ import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ShapeId
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 class ServiceWaitersGeneratorTest {
-    private val generated = generateService("simple-service-with-waiter.smithy")
-
     @Test
     fun testServiceGate() {
-        val enabledServiceModel = loadModelFromResource("simple-service-with-waiter.smithy")
-        val enabledServiceSettings = enabledServiceModel.newTestContext().generationCtx.settings
-        assertTrue(ServiceWaitersGenerator().enabledForService(enabledServiceModel, enabledServiceSettings))
-
-        val disabledServiceModel = loadModelFromResource("simple-service.smithy")
-        val disabledServiceSettings = disabledServiceModel.newTestContext().generationCtx.settings
-        assertFalse(ServiceWaitersGenerator().enabledForService(disabledServiceModel, disabledServiceSettings))
+        mapOf(
+            "simple-service-with-operation-waiter.smithy" to true,
+            "simple-service-with-resource-waiter.smithy" to true,
+            "simple-service.smithy" to false,
+        ).forEach { (modelName, expectEnabled) ->
+            val model = loadModelFromResource(modelName)
+            val settings = model.newTestContext().generationCtx.settings
+            val actualEnabled = ServiceWaitersGenerator().enabledForService(model, settings)
+            assertEquals(expectEnabled, actualEnabled)
+        }
     }
 
     @Test
-    fun testMainWaiterMethod() {
+    fun testWaiterSignatureWithOptionalInput() {
         val methodHeader = """
             /**
-             * Wait until a foo exists
+             * Wait until a foo exists with optional input
              */
-            public suspend fun TestClient.waitUntilFooExists(request: DescribeFooRequest = DescribeFooRequest { }): Outcome<DescribeFooResponse> {
+            public suspend fun TestClient.waitUntilFooOptionalExists(request: DescribeFooOptionalRequest = DescribeFooOptionalRequest { }): Outcome<DescribeFooOptionalResponse> {
         """.trimIndent()
         val methodFooter = """
                 val policy = AcceptorRetryPolicy(request, acceptors)
-                return strategy.retry(policy) { describeFoo(request) }
+                return strategy.retry(policy) { describeFooOptional(request) }
             }
         """.trimIndent()
-        generated.shouldContain(methodHeader, methodFooter)
+        generateService().shouldContain(methodHeader, methodFooter)
     }
 
     @Test
@@ -61,30 +61,45 @@ class ServiceWaitersGeneratorTest {
              */
             public suspend fun TestClient.waitUntilFooRequiredExists(request: DescribeFooRequiredRequest): Outcome<DescribeFooRequiredResponse> {
         """.trimIndent()
-        generated.shouldContainOnlyOnceWithDiff(methodHeader)
+        listOf(
+            generateService("simple-service-with-operation-waiter.smithy"),
+            generateService("simple-service-with-resource-waiter.smithy"),
+        ).forEach { generated ->
+            generated.shouldContain(methodHeader)
+        }
     }
 
     @Test
     fun testConvenienceWaiterMethod() {
         val expected = """
             /**
-             * Wait until a foo exists
+             * Wait until a foo exists with required input
              */
-            public suspend fun TestClient.waitUntilFooExists(block: DescribeFooRequest.Builder.() -> Unit): Outcome<DescribeFooResponse> =
-                waitUntilFooExists(DescribeFooRequest.Builder().apply(block).build())
+            public suspend fun TestClient.waitUntilFooRequiredExists(block: DescribeFooRequiredRequest.Builder.() -> Unit): Outcome<DescribeFooRequiredResponse> =
+                waitUntilFooRequiredExists(DescribeFooRequiredRequest.Builder().apply(block).build())
         """.trimIndent()
-        generated.shouldContainOnlyOnce(expected)
+        listOf(
+            generateService("simple-service-with-operation-waiter.smithy"),
+            generateService("simple-service-with-resource-waiter.smithy"),
+        ).forEach { generated ->
+            generated.shouldContain(expected)
+        }
     }
 
     @Test
     fun testAcceptorList() {
         val expected = """
-            val acceptors = listOf<Acceptor<DescribeFooRequest, DescribeFooResponse>>(
+            val acceptors = listOf<Acceptor<DescribeFooRequiredRequest, DescribeFooRequiredResponse>>(
                 SuccessAcceptor(RetryDirective.TerminateAndSucceed, true),
                 ErrorTypeAcceptor(RetryDirective.RetryError(RetryErrorType.ServerSide), "NotFound"),
             )
         """.formatForTest()
-        generated.shouldContainOnlyOnce(expected)
+        listOf(
+            generateService("simple-service-with-operation-waiter.smithy"),
+            generateService("simple-service-with-resource-waiter.smithy"),
+        ).forEach { generated ->
+            generated.shouldContainOnlyOnce(expected)
+        }
     }
 
     @Test
@@ -101,10 +116,15 @@ class ServiceWaitersGeneratorTest {
                 }
             }
         """.formatForTest()
-        generated.shouldContain(expected)
+        listOf(
+            generateService("simple-service-with-operation-waiter.smithy"),
+            generateService("simple-service-with-resource-waiter.smithy"),
+        ).forEach { generated ->
+            generated.shouldContain(expected)
+        }
     }
 
-    private fun generateService(modelResourceName: String): String {
+    private fun generateService(modelResourceName: String = "simple-service-with-operation-waiter.smithy"): String {
         val model = loadModelFromResource(modelResourceName)
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
         val service = model.getShape(ShapeId.from(TestModelDefault.SERVICE_SHAPE_ID)).get().asServiceShape().get()

--- a/codegen/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/simple-service-with-operation-waiter.smithy
+++ b/codegen/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/simple-service-with-operation-waiter.smithy
@@ -1,0 +1,82 @@
+$version: "1.0"
+namespace com.test
+
+use smithy.waiters#waitable
+
+service Test {
+    version: "1.0.0",
+    operations: [
+        DescribeFooOptional,
+        DescribeFooRequired,
+    ]
+}
+
+@waitable(
+    FooOptionalExists: {
+        documentation: "Wait until a foo exists with optional input",
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    success: true
+                }
+            },
+            {
+                state: "retry",
+                matcher: {
+                    errorType: "NotFound"
+                }
+            }
+        ]
+    }
+)
+operation DescribeFooOptional {
+    input: DescribeFooOptionalInput,
+    output: DescribeFooOutput,
+    errors: [NotFound, UnknownError]
+}
+
+@waitable(
+    FooRequiredExists: {
+        documentation: "Wait until a foo exists with required input",
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    success: true
+                }
+            },
+            {
+                state: "retry",
+                matcher: {
+                    errorType: "NotFound"
+                }
+            }
+        ]
+    }
+)
+operation DescribeFooRequired {
+    input: DescribeFooRequiredInput,
+    output: DescribeFooOutput,
+    errors: [NotFound, UnknownError]
+}
+
+structure DescribeFooOptionalInput {
+    id: String
+}
+
+structure DescribeFooOutput {
+    name: String
+}
+
+structure DescribeFooRequiredInput {
+    @required
+    id: String
+}
+
+
+@error("client")
+structure NotFound {}
+
+@error("server")
+structure UnknownError {}

--- a/codegen/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/simple-service-with-resource-waiter.smithy
+++ b/codegen/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/simple-service-with-resource-waiter.smithy
@@ -4,38 +4,18 @@ namespace com.test
 use smithy.waiters#waitable
 
 service Test {
-    version: "1.0.0",
-    operations: [
-        DescribeFoo,
-        DescribeFooRequired,
+    version: "1.0.0"
+    resources: [
+        Foo
     ]
 }
 
-@waitable(
-    FooExists: {
-        documentation: "Wait until a foo exists",
-        acceptors: [
-            {
-                state: "success",
-                matcher: {
-                    success: true
-                }
-            },
-            {
-                state: "retry",
-                matcher: {
-                    errorType: "NotFound"
-                }
-            }
-        ]
-    }
-)
-operation DescribeFoo {
-    input: DescribeFooInput,
-    output: DescribeFooOutput,
-    errors: [NotFound, UnknownError]
+resource Foo {
+    identifiers: { id: String }
+    read: DescribeFooRequired
 }
 
+@readonly
 @waitable(
     FooRequiredExists: {
         documentation: "Wait until a foo exists with required input",
@@ -61,19 +41,14 @@ operation DescribeFooRequired {
     errors: [NotFound, UnknownError]
 }
 
-structure DescribeFooInput {
+structure DescribeFooRequiredInput {
+    @required
     id: String
 }
 
 structure DescribeFooOutput {
     name: String
 }
-
-structure DescribeFooRequiredInput {
-    @required
-    id: String
-}
-
 
 @error("client")
 structure NotFound {}


### PR DESCRIPTION
## Issue \#

Addresses https://github.com/awslabs/aws-sdk-kotlin/issues/900

## Description of changes

Various parts of codegen tried to get all the operations a service supports via `ServiceShape.allOperations` which, despite the name, _does not_ return all operations of the service, merely the ones listed in the service shape. Other operations available through resources were not considered.

This change uses the `TopDownIndex`'s `getContainedOperations` method to find directly-attached operations _and_ resource operations, ensuring that waiters and paginators are correctly codegenned for resource operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
