### PR TITLE
fix: lazily resolve proxy environment variables

### DIFF
--- a/.changes/6ffd0a2b-9801-4814-a6d1-9d84196ff130.json
+++ b/.changes/6ffd0a2b-9801-4814-a6d1-9d84196ff130.json
@@ -1,0 +1,8 @@
+{
+    "id": "6ffd0a2b-9801-4814-a6d1-9d84196ff130",
+    "type": "bugfix",
+    "description": "Lazily resolve proxy environment variables",
+    "issues": [
+        "https://github.com/awslabs/aws-sdk-kotlin/issues/1281"
+    ]
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
@@ -135,15 +135,18 @@ class HttpEngineConfigImplTest {
     // reproduces https://github.com/awslabs/aws-sdk-kotlin/issues/1281
     @Test
     fun testCanConfigureProxySelectorWithInvalidEnvVarsPresent() {
-        val testPlatformProvider = TestPlatformProvider(env = mapOf("http_proxy" to "invalid", "https_proxy" to "invalid"))
+        try {
+            System.setProperty("http.proxyHost", "invalid")
+            System.setProperty("https.proxyHost", "invalid")
 
-        val builder = HttpEngineConfigImpl.BuilderImpl()
-        builder.httpClient {
-            proxySelector = EnvironmentProxySelector(testPlatformProvider)
-        }
-
-        builder.httpClient {
-            proxySelector = ProxySelector.NoProxy
+            val builder = HttpEngineConfigImpl.BuilderImpl()
+            builder.httpClient {
+                proxySelector = ProxySelector.NoProxy
+            }
+            builder.buildHttpEngineConfig()
+        } finally {
+            System.clearProperty("http.proxyHost")
+            System.clearProperty("https.proxyHost")
         }
     }
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
@@ -9,7 +9,6 @@ import aws.smithy.kotlin.runtime.http.config.HttpEngineConfig
 import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngine
 import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngineConfig
 import aws.smithy.kotlin.runtime.io.closeIfCloseable
-import aws.smithy.kotlin.runtime.util.TestPlatformProvider
 import org.junit.jupiter.api.Test
 import kotlin.test.*
 

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
@@ -9,6 +9,7 @@ import aws.smithy.kotlin.runtime.http.config.HttpEngineConfig
 import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngine
 import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngineConfig
 import aws.smithy.kotlin.runtime.io.closeIfCloseable
+import aws.smithy.kotlin.runtime.util.TestPlatformProvider
 import org.junit.jupiter.api.Test
 import kotlin.test.*
 
@@ -128,6 +129,21 @@ class HttpEngineConfigImplTest {
                     httpClient { maxConcurrency = 256u }
                 }
             }
+        }
+    }
+
+    // reproduces https://github.com/awslabs/aws-sdk-kotlin/issues/1281
+    @Test
+    fun testCanConfigureProxySelectorWithInvalidEnvVarsPresent() {
+        val testPlatformProvider = TestPlatformProvider(env = mapOf("http_proxy" to "invalid", "https_proxy" to "invalid"))
+
+        val builder = HttpEngineConfigImpl.BuilderImpl()
+        builder.httpClient {
+            proxySelector = EnvironmentProxySelector(testPlatformProvider)
+        }
+
+        builder.httpClient {
+            proxySelector = ProxySelector.NoProxy
         }
     }
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
@@ -136,10 +136,12 @@ class HttpEngineConfigImplTest {
     @Test
     fun testCanConfigureProxySelectorWithInvalidEnvVarsPresent() {
         try {
-            System.setProperty("http.proxyHost", "invalid")
-            System.setProperty("https.proxyHost", "invalid")
+            System.setProperty("http.proxyHost", "invalid!")
+            System.setProperty("https.proxyHost", "invalid!")
 
             val builder = HttpEngineConfigImpl.BuilderImpl()
+            builder.buildHttpEngineConfig()
+
             builder.httpClient {
                 proxySelector = ProxySelector.NoProxy
             }

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -63,13 +63,6 @@ public final class aws/smithy/kotlin/runtime/http/engine/EngineAttributes {
 	public final fun getTimeToFirstByte ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 }
 
-public final class aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector : aws/smithy/kotlin/runtime/http/engine/ProxySelector {
-	public fun <init> ()V
-	public fun <init> (Laws/smithy/kotlin/runtime/util/PlatformEnvironProvider;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/util/PlatformEnvironProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun select (Laws/smithy/kotlin/runtime/net/url/Url;)Laws/smithy/kotlin/runtime/http/engine/ProxyConfig;
-}
-
 public abstract interface class aws/smithy/kotlin/runtime/http/engine/HttpClientEngine : kotlinx/coroutines/CoroutineScope {
 	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig;
 	public abstract fun roundTrip (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/request/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -63,6 +63,13 @@ public final class aws/smithy/kotlin/runtime/http/engine/EngineAttributes {
 	public final fun getTimeToFirstByte ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 }
 
+public final class aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector : aws/smithy/kotlin/runtime/http/engine/ProxySelector {
+	public fun <init> ()V
+	public fun <init> (Laws/smithy/kotlin/runtime/util/PlatformEnvironProvider;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/util/PlatformEnvironProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun select (Laws/smithy/kotlin/runtime/net/url/Url;)Laws/smithy/kotlin/runtime/http/engine/ProxyConfig;
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/http/engine/HttpClientEngine : kotlinx/coroutines/CoroutineScope {
 	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig;
 	public abstract fun roundTrip (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/request/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
@@ -30,8 +30,7 @@ import aws.smithy.kotlin.runtime.util.PropertyProvider
  * - `https_proxy`, `HTTPS_PROXY`
  * - `no_proxy`, `NO_PROXY`
  */
-@InternalApi
-public class EnvironmentProxySelector(provider: PlatformEnvironProvider = PlatformProvider.System) : ProxySelector {
+internal class EnvironmentProxySelector(provider: PlatformEnvironProvider = PlatformProvider.System) : ProxySelector {
     private val httpProxy by lazy { resolveProxyByProperty(provider, Scheme.HTTP) ?: resolveProxyByEnvironment(provider, Scheme.HTTP) }
     private val httpsProxy by lazy { resolveProxyByProperty(provider, Scheme.HTTPS) ?: resolveProxyByEnvironment(provider, Scheme.HTTPS) }
     private val noProxyHosts by lazy { resolveNoProxyHosts(provider) }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
@@ -6,7 +6,6 @@
 package aws.smithy.kotlin.runtime.http.engine
 
 import aws.smithy.kotlin.runtime.ClientException
-import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.net.Host
 import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.net.url.Url

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
@@ -30,11 +30,9 @@ import aws.smithy.kotlin.runtime.util.PropertyProvider
  * - `no_proxy`, `NO_PROXY`
  */
 internal class EnvironmentProxySelector(provider: PlatformEnvironProvider = PlatformProvider.System) : ProxySelector {
-    private val httpProxy =
-        resolveProxyByProperty(provider, Scheme.HTTP) ?: resolveProxyByEnvironment(provider, Scheme.HTTP)
-    private val httpsProxy =
-        resolveProxyByProperty(provider, Scheme.HTTPS) ?: resolveProxyByEnvironment(provider, Scheme.HTTPS)
-    private val noProxyHosts = resolveNoProxyHosts(provider)
+    private val httpProxy by lazy { resolveProxyByProperty(provider, Scheme.HTTP) ?: resolveProxyByEnvironment(provider, Scheme.HTTP) }
+    private val httpsProxy by lazy { resolveProxyByProperty(provider, Scheme.HTTPS) ?: resolveProxyByEnvironment(provider, Scheme.HTTPS) }
+    private val noProxyHosts by lazy { resolveNoProxyHosts(provider) }
 
     override fun select(url: Url): ProxyConfig {
         if (httpProxy == null && httpsProxy == null || noProxy(url)) return ProxyConfig.Direct

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
@@ -6,6 +6,7 @@
 package aws.smithy.kotlin.runtime.http.engine
 
 import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.net.Host
 import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.net.url.Url
@@ -29,7 +30,8 @@ import aws.smithy.kotlin.runtime.util.PropertyProvider
  * - `https_proxy`, `HTTPS_PROXY`
  * - `no_proxy`, `NO_PROXY`
  */
-internal class EnvironmentProxySelector(provider: PlatformEnvironProvider = PlatformProvider.System) : ProxySelector {
+@InternalApi
+public class EnvironmentProxySelector(provider: PlatformEnvironProvider = PlatformProvider.System) : ProxySelector {
     private val httpProxy by lazy { resolveProxyByProperty(provider, Scheme.HTTP) ?: resolveProxyByEnvironment(provider, Scheme.HTTP) }
     private val httpsProxy by lazy { resolveProxyByProperty(provider, Scheme.HTTPS) ?: resolveProxyByEnvironment(provider, Scheme.HTTPS) }
     private val noProxyHosts by lazy { resolveNoProxyHosts(provider) }

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
@@ -103,7 +103,8 @@ class EnvironmentProxySelectorTest {
         failCases.forEachIndexed { idx, failCase ->
             val testProvider = TestPlatformEnvironmentProvider(failCase.env, failCase.props)
             val exception = assertFailsWith<ClientException>("[idx=$idx] expected ClientException") {
-                EnvironmentProxySelector(testProvider)
+                val selector = EnvironmentProxySelector(testProvider)
+                selector.select(Url.parse("http://localhost:8000")) // call `select` because proxy selector resolves env vars lazily
             }
 
             val expectedError = (failCase.env + failCase.props).map { (k, v) -> """$k="$v"""" }.joinToString(", ")

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
@@ -102,8 +102,8 @@ class EnvironmentProxySelectorTest {
     fun testSelectFailures() {
         failCases.forEachIndexed { idx, failCase ->
             val testProvider = TestPlatformEnvironmentProvider(failCase.env, failCase.props)
+            val selector = EnvironmentProxySelector(testProvider)
             val exception = assertFailsWith<ClientException>("[idx=$idx] expected ClientException") {
-                val selector = EnvironmentProxySelector(testProvider)
                 selector.select(Url.parse("http://localhost:8000")) // call `select` because proxy selector resolves env vars lazily
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR updates the `EnvironmentProxySelector` to lazily resolve environment variables rather than immediately parsing them during initialization

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Resolves https://github.com/awslabs/aws-sdk-kotlin/issues/1281

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
