### PR TITLE
fix: apply clock skew interceptor to clients created via `invoke`

### DIFF
--- a/.changes/5498a35b-f57f-4c0c-bbf7-43e07830be01.json
+++ b/.changes/5498a35b-f57f-4c0c-bbf7-43e07830be01.json
@@ -1,0 +1,8 @@
+{
+    "id": "5498a35b-f57f-4c0c-bbf7-43e07830be01",
+    "type": "bugfix",
+    "description": "Add config finalization to service clients via new abstract factory class; apply clock skew interceptor to clients created via `invoke`",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1211"
+    ]
+}

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/middleware/ClockSkew.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/middleware/ClockSkew.kt
@@ -15,7 +15,12 @@ import software.amazon.smithy.kotlin.codegen.rendering.ServiceClientGenerator
  */
 class ClockSkew : KotlinIntegration {
     override val sectionWriters: List<SectionWriterBinding>
-        get() = listOf(SectionWriterBinding(ServiceClientGenerator.Sections.FinalizeConfig, clockSkewSectionWriter))
+        get() = listOf(
+            SectionWriterBinding(
+                ServiceClientGenerator.Sections.CompanionObject.FinalizeConfig,
+                clockSkewSectionWriter,
+            )
+        )
 
     private val clockSkewSectionWriter = AppendingSectionWriter { writer ->
         val interceptorSymbol = RuntimeTypes.AwsProtocolCore.ClockSkewInterceptor

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/middleware/ClockSkew.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/middleware/ClockSkew.kt
@@ -19,7 +19,7 @@ class ClockSkew : KotlinIntegration {
             SectionWriterBinding(
                 ServiceClientGenerator.Sections.CompanionObject.FinalizeConfig,
                 clockSkewSectionWriter,
-            )
+            ),
         )
 
     private val clockSkewSectionWriter = AppendingSectionWriter { writer ->

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -189,6 +189,7 @@ object RuntimeTypes {
     object SmithyClient : RuntimeTypePackage(KotlinDependency.SMITHY_CLIENT) {
         val SdkClient = symbol("SdkClient")
         val AbstractSdkClientBuilder = symbol("AbstractSdkClientBuilder")
+        val AbstractSdkClientFactory = symbol("AbstractSdkClientFactory")
         val LogMode = symbol("LogMode")
         val RetryClientConfig = symbol("RetryClientConfig")
         val RetryStrategyClientConfig = symbol("RetryStrategyClientConfig")

--- a/runtime/smithy-client/api/smithy-client.api
+++ b/runtime/smithy-client/api/smithy-client.api
@@ -5,6 +5,12 @@ public abstract class aws/smithy/kotlin/runtime/client/AbstractSdkClientBuilder 
 	protected abstract fun newClient (Laws/smithy/kotlin/runtime/client/SdkClientConfig;)Laws/smithy/kotlin/runtime/client/SdkClient;
 }
 
+public abstract class aws/smithy/kotlin/runtime/client/AbstractSdkClientFactory : aws/smithy/kotlin/runtime/client/SdkClientFactory {
+	public fun <init> ()V
+	protected fun finalizeConfig (Laws/smithy/kotlin/runtime/client/SdkClient$Builder;)V
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/client/SdkClient;
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/client/IdempotencyTokenConfig {
 	public abstract fun getIdempotencyTokenProvider ()Laws/smithy/kotlin/runtime/client/IdempotencyTokenProvider;
 }

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/AbstractSdkClientFactory.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/AbstractSdkClientFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.client
+
+public abstract class AbstractSdkClientFactory<
+    TConfig : SdkClientConfig,
+    TConfigBuilder : SdkClientConfig.Builder<TConfig>,
+    TClient : SdkClient,
+    TClientBuilder : SdkClient.Builder<TConfig, TConfigBuilder, TClient>,
+    > : SdkClientFactory<TConfig, TConfigBuilder, TClient, TClientBuilder> {
+
+    /**
+     * Inject any client-specific config
+     */
+    protected open fun finalizeConfig(builder: TClientBuilder) { }
+
+    public override operator fun invoke(block: TConfigBuilder.() -> Unit): TClient = builder().apply {
+        config.apply(block)
+        finalizeConfig(this)
+    }.build()
+}


### PR DESCRIPTION
## Issue \#

Addresses https://github.com/awslabs/aws-sdk-kotlin/issues/1211

## Description of changes

This change supports adding the clock skew interceptor to clients created via `invoke` (as opposed to via `fromEnvironment`) by creating a new `AbstractSdkClientFactory` superclass with a _non-_`suspend` `finalizeConfig` method and adjusting codegen accordingly.

**Companion PR**: https://github.com/awslabs/aws-sdk-kotlin/pull/1284

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
