### PR TITLE
fix: differentiate between string enum and int enum in client correction

### DIFF
--- a/.changes/56a90e2f-014b-4abd-8baa-5ce12dc60320.json
+++ b/.changes/56a90e2f-014b-4abd-8baa-5ce12dc60320.json
@@ -1,0 +1,5 @@
+{
+    "id": "56a90e2f-014b-4abd-8baa-5ce12dc60320",
+    "type": "bugfix",
+    "description": "Correctly handle error correction of int enums"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/ClientErrorCorrection.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/ClientErrorCorrection.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.kotlin.codegen.core.CodegenContext
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
 import software.amazon.smithy.kotlin.codegen.model.isEnum
+import software.amazon.smithy.kotlin.codegen.model.isStringEnumShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.ShapeType
 
@@ -33,8 +34,10 @@ object ClientErrorCorrection {
 
         // In IDL v1 all enums were `ShapeType.STRING` and you had to explicitly check for the @enum trait, this handles
         // the differences in IDL versions
-        if (target.isEnum) {
+        if (target.isStringEnumShape) {
             return writer.format("#T.SdkUnknown(#S)", targetSymbol, "no value provided")
+        } else if (target.isIntEnumShape) {
+            return writer.format("#T.SdkUnknown(0)", targetSymbol)
         }
 
         return when (target.type) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/ClientErrorCorrection.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/ClientErrorCorrection.kt
@@ -8,7 +8,6 @@ import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.core.CodegenContext
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
-import software.amazon.smithy.kotlin.codegen.model.isEnum
 import software.amazon.smithy.kotlin.codegen.model.isStringEnumShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.ShapeType

--- a/tests/codegen/nullability-tests/model/nullability.smithy
+++ b/tests/codegen/nullability-tests/model/nullability.smithy
@@ -54,6 +54,9 @@ structure TestStruct {
     enum: Enum
 
     @required
+    intEnum: IntEnum
+
+    @required
     union: U
 
     notRequired: String,
@@ -75,6 +78,12 @@ enum Enum {
     A,
     B,
     C
+}
+
+intEnum IntEnum {
+    ONE =   1,
+    TWO =   2,
+    THREE = 3
 }
 
 union U {

--- a/tests/codegen/nullability-tests/src/test/kotlin/smithy/kotlin/nullability/ErrorCorrectionTest.kt
+++ b/tests/codegen/nullability-tests/src/test/kotlin/smithy/kotlin/nullability/ErrorCorrectionTest.kt
@@ -83,5 +83,6 @@ class ErrorCorrectionTest {
 
         // enums become unknown variant
         assertEquals(smithy.kotlin.nullability.clientcareful.model.Enum.SdkUnknown("no value provided"), actual.enum)
+        assertEquals(smithy.kotlin.nullability.clientcareful.model.IntEnum.SdkUnknown(0), actual.intEnum)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Int enums will have an `SdkUnknown` generated with a String value of `"no value provided"`, which fails to compile. This PR separates the logic handling string enums and int enums.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Internal issue

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
