### PR TITLE
misc: upgrade to OkHttp 5.0.0-alpha.14, Okio 3.9.0, Kotlin 1.9.23

### DIFF
--- a/.changes/8e87c6dd-5138-4b79-a0c2-255ecf31898b.json
+++ b/.changes/8e87c6dd-5138-4b79-a0c2-255ecf31898b.json
@@ -1,0 +1,6 @@
+{
+    "id": "8e87c6dd-5138-4b79-a0c2-255ecf31898b",
+    "type": "misc",
+    "description": "Upgrade to latest versions of OkHttp, Okio, Kotlin",
+    "requiresMinorVersionBump": true
+}

--- a/.changes/8e87c6dd-5138-4b79-a0c2-255ecf31898b.json
+++ b/.changes/8e87c6dd-5138-4b79-a0c2-255ecf31898b.json
@@ -1,6 +1,6 @@
 {
     "id": "8e87c6dd-5138-4b79-a0c2-255ecf31898b",
     "type": "misc",
-    "description": "Upgrade to latest versions of OkHttp, Okio, Kotlin",
+    "description": "⚠️ **IMPORTANT**: Upgrade to latest versions of OkHttp, Okio, Kotlin",
     "requiresMinorVersionBump": true
 }

--- a/breaking-change-discussion-draft.md
+++ b/breaking-change-discussion-draft.md
@@ -1,0 +1,21 @@
+An upcoming release of the **AWS SDK for Kotlin** will upgrade our dependency on OkHttp to **v5.0.0-alpha.14**. This version contains a number of breaking changes and earlier versions of the SDK are not compatible with it.
+
+# Release date
+
+This feature will ship with the **v1.2.0** release planned for **4/22/2024**.
+
+# What's changing
+
+The Kotlin SDK will be upgrading its dependency on OkHttp to v5.0.0-alpha.14. If you don't directly depend on OkHttp alongside the AWS SDK for Kotlin, this change should not affect you.
+
+If you _do_ have direct dependencies on OkHttp and the AWS SDK for Kotlin, you will need to upgrade to OkHttp **v5.0.0-alpha.14** along with your upgrade to AWS SDK for Kotlin **v1.2.0**.
+
+# How to migrate
+
+1. Upgrade your AWS SDK for Kotlin dependency to **v.1.2.0**.
+2. Upgrade your OkHttp dependency to **v5.0.0-alpha.14**.
+3. Resolve any issues caused by OkHttp's breaking changes. See [their change log](https://square.github.io/okhttp/changelogs/changelog/) for information.
+
+# Feedback
+
+If you have any questions concerning this change, please feel free to engage with us in this discussion. If you encounter a bug with these changes, please [file an issue](https://github.com/awslabs/aws-sdk-kotlin/issues/new/choose).

--- a/breaking-change-discussion-draft.md
+++ b/breaking-change-discussion-draft.md
@@ -11,7 +11,7 @@ The Kotlin SDK will be upgrading its dependency on OkHttp to v5.0.0-alpha.14. If
 
 If you _do_ have direct dependencies on OkHttp and the AWS SDK for Kotlin, you will need to upgrade to OkHttp **v5.0.0-alpha.14** along with your upgrade to AWS SDK for Kotlin **v1.2.0**.
 
-If you _do_ depend on different version of the AWS SDK for Kotlin in the same project, you will need to make sure they are all upgraded to **v1.2.0** together. Versions of the SDK prior to **v1.2.0** will no longer be compatible with newer versions.
+If you _do_ depend on different versions of the AWS SDK for Kotlin in the same project, you will need to make sure they are all upgraded to **v1.2.0** together. Versions of the SDK prior to **v1.2.0** will no longer be compatible with newer versions.
 
 If you've _already_ upgraded your OkHttp version and are experiencing this error, it will be resolved by upgrading to AWS SDK for Kotlin **v1.2.0**:  `java.lang.NoClassDefFoundError: Failed resolution of: Lokhttp3/JvmCallExtensionsKt;`
 

--- a/breaking-change-discussion-draft.md
+++ b/breaking-change-discussion-draft.md
@@ -7,7 +7,7 @@ This feature will ship with the **v1.2.0** release planned for **4/22/2024**.
 # What's changing
 
 The Kotlin SDK will be upgrading its dependency on OkHttp to v5.0.0-alpha.14. If you don't directly depend on OkHttp alongside the AWS SDK for Kotlin 
-*AND* you don't depend on different versions of the AWS SDK for Kotlin in the same project, this change should not affect you.
+**AND** you don't depend on different versions of the AWS SDK for Kotlin in the same project, this change should not affect you.
 
 If you _do_ have direct dependencies on OkHttp and the AWS SDK for Kotlin, you will need to upgrade to OkHttp **v5.0.0-alpha.14** along with your upgrade to AWS SDK for Kotlin **v1.2.0**.
 

--- a/breaking-change-discussion-draft.md
+++ b/breaking-change-discussion-draft.md
@@ -6,15 +6,18 @@ This feature will ship with the **v1.2.0** release planned for **4/22/2024**.
 
 # What's changing
 
-The Kotlin SDK will be upgrading its dependency on OkHttp to v5.0.0-alpha.14. If you don't directly depend on OkHttp alongside the AWS SDK for Kotlin, this change should not affect you.
+The Kotlin SDK will be upgrading its dependency on OkHttp to v5.0.0-alpha.14. If you don't directly depend on OkHttp alongside the AWS SDK for Kotlin 
+*AND* you don't depend on different versions of the AWS SDK for Kotlin in the same project, this change should not affect you.
 
 If you _do_ have direct dependencies on OkHttp and the AWS SDK for Kotlin, you will need to upgrade to OkHttp **v5.0.0-alpha.14** along with your upgrade to AWS SDK for Kotlin **v1.2.0**.
+
+If you _do_ depend on different version of the AWS SDK for Kotlin in the same project, you will need to make sure they are all upgraded to **v1.2.0** together. Versions of the SDK prior to **v1.2.0** will no longer be compatible with newer versions.
 
 If you've _already_ upgraded your OkHttp version and are experiencing this error, it will be resolved by upgrading to AWS SDK for Kotlin **v1.2.0**:  `java.lang.NoClassDefFoundError: Failed resolution of: Lokhttp3/JvmCallExtensionsKt;`
 
 # How to migrate
 
-1. Upgrade your AWS SDK for Kotlin dependency to **v.1.2.0**.
+1. Upgrade all of your AWS SDK for Kotlin dependencies to **v.1.2.0**.
 2. Upgrade your OkHttp dependency to **v5.0.0-alpha.14**.
 3. Resolve any issues caused by OkHttp's breaking changes. See [their change log](https://square.github.io/okhttp/changelogs/changelog/) for information.
 

--- a/breaking-change-discussion-draft.md
+++ b/breaking-change-discussion-draft.md
@@ -18,7 +18,7 @@ If you've _already_ upgraded your OkHttp version and are experiencing this error
 # How to migrate
 
 1. Upgrade all of your AWS SDK for Kotlin dependencies to **v.1.2.0**.
-2. Upgrade your OkHttp dependency to **v5.0.0-alpha.14**.
+2. Upgrade your OkHttp dependency to **v5.0.0-alpha.14** if you have a direct dependency.
 3. Resolve any issues caused by OkHttp's breaking changes. See [their change log](https://square.github.io/okhttp/changelogs/changelog/) for information.
 
 # Feedback

--- a/breaking-change-discussion-draft.md
+++ b/breaking-change-discussion-draft.md
@@ -18,9 +18,6 @@ If you've _already_ upgraded your OkHttp version and are experiencing this error
 2. Upgrade your OkHttp dependency to **v5.0.0-alpha.14**.
 3. Resolve any issues caused by OkHttp's breaking changes. See [their change log](https://square.github.io/okhttp/changelogs/changelog/) for information.
 
-# Additional information
-Some common 
-
 # Feedback
 
 If you have any questions concerning this change, please feel free to engage with us in this discussion. If you encounter a bug with these changes, please [file an issue](https://github.com/awslabs/aws-sdk-kotlin/issues/new/choose).

--- a/breaking-change-discussion-draft.md
+++ b/breaking-change-discussion-draft.md
@@ -10,11 +10,16 @@ The Kotlin SDK will be upgrading its dependency on OkHttp to v5.0.0-alpha.14. If
 
 If you _do_ have direct dependencies on OkHttp and the AWS SDK for Kotlin, you will need to upgrade to OkHttp **v5.0.0-alpha.14** along with your upgrade to AWS SDK for Kotlin **v1.2.0**.
 
+If you've _already_ upgraded your OkHttp version and are experiencing this error, it will be resolved by upgrading to AWS SDK for Kotlin **v1.2.0**:  `java.lang.NoClassDefFoundError: Failed resolution of: Lokhttp3/JvmCallExtensionsKt;`
+
 # How to migrate
 
 1. Upgrade your AWS SDK for Kotlin dependency to **v.1.2.0**.
 2. Upgrade your OkHttp dependency to **v5.0.0-alpha.14**.
 3. Resolve any issues caused by OkHttp's breaking changes. See [their change log](https://square.github.io/okhttp/changelogs/changelog/) for information.
+
+# Additional information
+Some common 
 
 # Feedback
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin-version = "1.9.22"
+kotlin-version = "1.9.23"
 dokka-version = "1.9.10"
 
 aws-kotlin-repo-tools-version = "0.4.0"
@@ -7,8 +7,8 @@ aws-kotlin-repo-tools-version = "0.4.0"
 # libs
 coroutines-version = "1.7.3"
 atomicfu-version = "0.23.1"
-okhttp-version = "5.0.0-alpha.11"
-okio-version = "3.6.0"
+okhttp-version = "5.0.0-alpha.14"
+okio-version = "3.9.0"
 otel-version = "1.32.0"
 slf4j-version = "2.0.9"
 slf4j-v1x-version = "1.7.36"

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -14,8 +14,10 @@ import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.fromEpochMilliseconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.job
 import okhttp3.*
+import okhttp3.coroutines.executeAsync
 import java.util.concurrent.TimeUnit
 import kotlin.time.toJavaDuration
 import aws.smithy.kotlin.runtime.net.TlsVersion as SdkTlsVersion
@@ -48,6 +50,8 @@ public class OkHttpEngine(
 
         val engineRequest = request.toOkHttpRequest(context, callContext, metrics)
         val engineCall = client.newCall(engineRequest)
+
+        @OptIn(ExperimentalCoroutinesApi::class)
         val engineResponse = mapOkHttpExceptions { engineCall.executeAsync() }
 
         val response = engineResponse.toSdkResponse()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Upgrade to the latest versions of OkHttp, Okio, and Kotlin.

Changes include needing to opt-in to `ExperimentalCoroutinesApi` for the `executeAsync` call and no longer being able to implement `BufferedSink` because it's now a `sealed interface`. 

We can only use `Buffer` in our tests now, [which is hardcoded to always open](https://github.com/square/okio/blob/e2ac4c05093e166bcb2e56fb8f834fc4f03d299b/okio/src/jvmMain/kotlin/okio/Buffer.kt#L504), so the `isClosed` checks are no longer possible to perform.
## Issue \#

<!--- If it fixes an open issue, please link to the issue here -->
Related to https://github.com/smithy-lang/smithy-kotlin/issues/1068

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
