### PR TITLE
fix: implicit task dependencies

### DIFF
--- a/tests/codegen/nullability-tests/build.gradle.kts
+++ b/tests/codegen/nullability-tests/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyProjections
 import aws.sdk.kotlin.gradle.codegen.smithyKotlinProjectionSrcDir
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
 
@@ -21,6 +22,10 @@ dependencies {
 
 tasks.generateSmithyProjections {
     smithyBuildConfigs.set(files("smithy-build.json"))
+}
+
+tasks.kotlinSourcesJar {
+    dependsOn(tasks.generateSmithyProjections)
 }
 
 val optinAnnotations = listOf("kotlin.RequiresOptIn", "aws.smithy.kotlin.runtime.InternalApi")

--- a/tests/codegen/nullability-tests/build.gradle.kts
+++ b/tests/codegen/nullability-tests/build.gradle.kts
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyProjections
 import aws.sdk.kotlin.gradle.codegen.smithyKotlinProjectionSrcDir
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
 

--- a/tests/codegen/paginator-tests/build.gradle.kts
+++ b/tests/codegen/paginator-tests/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyProjections
 import aws.sdk.kotlin.gradle.codegen.smithyKotlinProjectionSrcDir
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
 
@@ -21,6 +22,10 @@ dependencies {
 
 tasks.generateSmithyProjections {
     smithyBuildConfigs.set(files("smithy-build.json"))
+}
+
+tasks.kotlinSourcesJar {
+    dependsOn(tasks.generateSmithyProjections)
 }
 
 val optinAnnotations = listOf("kotlin.RequiresOptIn", "aws.smithy.kotlin.runtime.InternalApi")

--- a/tests/codegen/paginator-tests/build.gradle.kts
+++ b/tests/codegen/paginator-tests/build.gradle.kts
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyProjections
 import aws.sdk.kotlin.gradle.codegen.smithyKotlinProjectionSrcDir
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
 

--- a/tests/codegen/serde-tests/build.gradle.kts
+++ b/tests/codegen/serde-tests/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyProjections
 import aws.sdk.kotlin.gradle.codegen.smithyKotlinProjectionSrcDir
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
 
@@ -81,6 +82,13 @@ val stageGeneratedSources = tasks.register("stageGeneratedSources") {
             }
         }
     }
+}
+
+tasks.kotlinSourcesJar {
+    dependsOn(
+        tasks.generateSmithyProjections,
+        stageGeneratedSources,
+    )
 }
 
 kotlin.sourceSets.getByName("main") {

--- a/tests/codegen/serde-tests/build.gradle.kts
+++ b/tests/codegen/serde-tests/build.gradle.kts
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import aws.sdk.kotlin.gradle.codegen.dsl.generateSmithyProjections
 import aws.sdk.kotlin.gradle.codegen.smithyKotlinProjectionSrcDir
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
 

--- a/tests/codegen/waiter-tests/build.gradle.kts
+++ b/tests/codegen/waiter-tests/build.gradle.kts
@@ -23,6 +23,10 @@ tasks.generateSmithyProjections {
     smithyBuildConfigs.set(files("smithy-build.json"))
 }
 
+tasks.kotlinSourcesJar {
+    dependsOn(tasks.generateSmithyProjections)
+}
+
 val optinAnnotations = listOf("kotlin.RequiresOptIn", "aws.smithy.kotlin.runtime.InternalApi")
 kotlin.sourceSets.all {
     optinAnnotations.forEach { languageSettings.optIn(it) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
N/A

## Description of changes
Fix some implicit task dependencies gradle was marking as errors, e.g.
```
A problem was found with the configuration of task ':tests:codegen:nullability-tests:generateSmithyProjections' (type 'SmithyBuildTask').
  - Gradle detected a problem with the following location: '/.../smithy-kotlin/tests/codegen/nullability-tests/build/smithyprojections/nullability-tests'.
    
    Reason: Task ':tests:codegen:nullability-tests:kotlinSourcesJar' uses this output of task ':tests:codegen:nullability-tests:generateSmithyProjections' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
