### PR TITLE
fix: handle bad time formats in clock skew interceptor

### DIFF
--- a/.changes/e3e20544-5633-4722-8923-106117678325.json
+++ b/.changes/e3e20544-5633-4722-8923-106117678325.json
@@ -1,0 +1,8 @@
+{
+    "id": "e3e20544-5633-4722-8923-106117678325",
+    "type": "bugfix",
+    "description": "Gracefully degrade in clock skew interceptor when receiving a `Date` header value with a malformed date",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1293"
+    ]
+}

--- a/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/ClockSkewInterceptor.kt
+++ b/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/ClockSkewInterceptor.kt
@@ -17,9 +17,11 @@ import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.http.response.header
 import aws.smithy.kotlin.runtime.telemetry.logging.logger
 import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.ParseException
 import aws.smithy.kotlin.runtime.time.until
 import kotlinx.atomicfu.*
 import kotlin.coroutines.coroutineContext
+import kotlin.math.log
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
@@ -85,7 +87,12 @@ public class ClockSkewInterceptor : HttpInterceptor {
         val logger = coroutineContext.logger<ClockSkewInterceptor>()
 
         val serverTime = context.protocolResponse?.header("Date")?.let {
-            Instant.fromRfc5322(it)
+            try {
+                Instant.fromRfc5322(it)
+            } catch (e: ParseException) {
+                logger.warn(e) { "Service returned malformed \"Date\" header value \"$it\", skipping skew calculation" }
+                return context.response
+            }
         } ?: run {
             logger.debug { "service did not return \"Date\" header, skipping skew calculation" }
             return context.response

--- a/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/ClockSkewInterceptor.kt
+++ b/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/ClockSkewInterceptor.kt
@@ -21,7 +21,6 @@ import aws.smithy.kotlin.runtime.time.ParseException
 import aws.smithy.kotlin.runtime.time.until
 import kotlinx.atomicfu.*
 import kotlin.coroutines.coroutineContext
-import kotlin.math.log
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 


### PR DESCRIPTION
## Issue \#

Resolves https://github.com/awslabs/aws-sdk-kotlin/issues/1293

## Description of changes

The `ClockSkewInterceptor` cannot currently handle receiving out-of-spec HTTP `Date` header values and throws an exception, even if the response would've been successful. This change wraps the date parsing logic and logs a warning if an error occurs, which no longer interrupts response processing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
