### PR TITLE
chore: address testcontainers vulnerability by replacing with docker-java

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,9 @@ allprojects {
             )
         }
     }
+
+    // Enables running `./gradlew allDeps` to get a comprehensive list of dependencies for every subproject
+    tasks.register<DependencyReportTask>("allDeps") { }
 }
 
 // configure the root multimodule docs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ kotest-version = "5.8.0"
 kotlin-compile-testing-version = "1.5.0"
 kotlinx-benchmark-version = "0.4.9"
 kotlinx-serialization-version = "1.6.0"
-testcontainers-version = "1.19.1"
+docker-client-version = "3.3.6"
 ktor-version = "2.3.6"
 kaml-version = "0.55.0"
 jsoup-version = "1.16.2"
@@ -81,8 +81,8 @@ kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.
 kotest-assertions-core-jvm = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest-version" }
 kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark-version" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-version" }
-testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers-version" }
-testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers-version" }
+docker-core = { module = "com.github.docker-java:docker-java-core", version.ref = "docker-client-version" }
+docker-transport-zerodep = { module = "com.github.docker-java:docker-java-transport-zerodep", version.ref = "docker-client-version" }
 
 ktor-http-cio = { module = "io.ktor:ktor-http-cio", version.ref = "ktor-version" }
 ktor-utils = { module = "io.ktor:ktor-utils", version.ref = "ktor-version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ kotest-version = "5.8.0"
 kotlin-compile-testing-version = "1.5.0"
 kotlinx-benchmark-version = "0.4.9"
 kotlinx-serialization-version = "1.6.0"
-docker-client-version = "3.3.6"
+docker-java-version = "3.3.6"
 ktor-version = "2.3.6"
 kaml-version = "0.55.0"
 jsoup-version = "1.16.2"
@@ -81,8 +81,8 @@ kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.
 kotest-assertions-core-jvm = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest-version" }
 kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark-version" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-version" }
-docker-core = { module = "com.github.docker-java:docker-java-core", version.ref = "docker-client-version" }
-docker-transport-zerodep = { module = "com.github.docker-java:docker-java-transport-zerodep", version.ref = "docker-client-version" }
+docker-core = { module = "com.github.docker-java:docker-java-core", version.ref = "docker-java-version" }
+docker-transport-zerodep = { module = "com.github.docker-java:docker-java-transport-zerodep", version.ref = "docker-java-version" }
 
 ktor-http-cio = { module = "io.ktor:ktor-http-cio", version.ref = "ktor-version" }
 ktor-utils = { module = "io.ktor:ktor-utils", version.ref = "ktor-version" }

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -114,9 +114,13 @@ tasks.jvmTest {
     // set test environment for proxy tests
     systemProperty("MITM_PROXY_SCRIPTS_ROOT", projectDir.resolve("proxy-scripts").absolutePath)
     systemProperty("SSL_CONFIG_PATH", startTestServers.sslConfigPath)
+
     val enableProxyTestsProp = "aws.test.http.enableProxyTests"
     val runningInCodeBuild = System.getenv().containsKey("CODEBUILD_BUILD_ID")
-    systemProperty(enableProxyTestsProp, System.getProperties().getOrDefault(enableProxyTestsProp, !runningInCodeBuild))
+    val runningInLinux = System.getProperty("os.name").contains("Linux", ignoreCase = true)
+    val shouldRunProxyTests = !runningInCodeBuild && runningInLinux
+
+    systemProperty(enableProxyTestsProp, System.getProperties().getOrDefault(enableProxyTestsProp, shouldRunProxyTests))
 }
 
 gradle.buildFinished {

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -42,8 +42,8 @@ kotlin {
 
         jvmTest {
             dependencies {
-                implementation(libs.testcontainers)
-                implementation(libs.testcontainers.junit.jupiter)
+                implementation(libs.docker.core)
+                implementation(libs.docker.transport.zerodep)
             }
         }
 

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/MitmContainer.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/MitmContainer.kt
@@ -19,12 +19,17 @@ private val PROXY_SCRIPT_ROOT = System.getProperty("MITM_PROXY_SCRIPTS_ROOT") //
 // Port used for communication with container
 private val exposedPort = ExposedPort.tcp(CONTAINER_PORT)
 
+/**
+ * A Docker container which runs the **mitmproxy** image. Upon instantiating this class, a docker container will be
+ * created and ran with a logger attached echoing logs out to **STDOUT**. The container will be stopped and removed when
+ * [close] is called.
+ */
 class MitmContainer(vararg options: String) : Closeable {
     private val delegate: Docker.Container
 
     init {
         val cmd = listOf(
-            "mitmdump",
+            "mitmdump", // https://docs.mitmproxy.org/stable/#mitmdump
             "--flow-detail",
             "2",
             "-s",
@@ -32,7 +37,7 @@ class MitmContainer(vararg options: String) : Closeable {
             *options,
         ).also { println("Initializing container with command: $it") }
 
-        // Make proxy scripts from host available to container
+        // Make proxy scripts from host filesystem available in container's filesystem
         val binding = Bind(PROXY_SCRIPT_ROOT, Volume(CONTAINER_MOUNT_POINT), AccessMode.ro)
 
         delegate = Docker.Instance.createContainer(IMAGE_NAME, cmd, binding, exposedPort)
@@ -48,6 +53,9 @@ class MitmContainer(vararg options: String) : Closeable {
         }
     }
 
+    /**
+     * Gets the host port that can be used to communicate to the MITM proxy
+     */
     val hostPort: Int
         get() = delegate.hostPort
 

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/MitmContainer.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/MitmContainer.kt
@@ -39,7 +39,6 @@ class MitmContainer(vararg options: String) : Closeable {
 
         try {
             delegate.apply {
-                attachLogger(::println)
                 start()
                 waitUntilReady()
             }

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/MitmContainer.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/MitmContainer.kt
@@ -35,8 +35,10 @@ class MitmContainer(vararg options: String) : Closeable {
         // Make proxy scripts from host available to container
         val binding = Bind(PROXY_SCRIPT_ROOT, Volume(CONTAINER_MOUNT_POINT), AccessMode.ro)
 
+        delegate = Docker.Instance.createContainer(IMAGE_NAME, cmd, binding, exposedPort)
+
         try {
-            delegate = Docker.Instance.createContainer(IMAGE_NAME, cmd, binding, exposedPort).apply {
+            delegate.apply {
                 attachLogger(::println)
                 start()
                 waitUntilReady()

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/MitmContainer.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/MitmContainer.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.test
+
+import aws.smithy.kotlin.runtime.http.test.util.Docker
+import com.github.dockerjava.api.model.AccessMode
+import com.github.dockerjava.api.model.Bind
+import com.github.dockerjava.api.model.ExposedPort
+import com.github.dockerjava.api.model.Volume
+import java.io.Closeable
+
+private const val CONTAINER_MOUNT_POINT = "/home/mitmproxy/scripts"
+private const val CONTAINER_PORT = 8080
+private const val IMAGE_NAME = "mitmproxy/mitmproxy:8.1.0"
+private val PROXY_SCRIPT_ROOT = System.getProperty("MITM_PROXY_SCRIPTS_ROOT") // defined by gradle script
+
+// Port used for communication with container
+private val exposedPort = ExposedPort.tcp(CONTAINER_PORT)
+
+class MitmContainer(vararg options: String) : Closeable {
+    private val delegate: Docker.Container
+
+    init {
+        val cmd = listOf(
+            "mitmdump",
+            "--flow-detail",
+            "2",
+            "-s",
+            "$CONTAINER_MOUNT_POINT/fakeupstream.py",
+            *options,
+        ).also { println("Initializing container with command: $it") }
+
+        // Make proxy scripts from host available to container
+        val binding = Bind(PROXY_SCRIPT_ROOT, Volume(CONTAINER_MOUNT_POINT), AccessMode.ro)
+
+        try {
+            delegate = Docker.Instance.createContainer(IMAGE_NAME, cmd, binding, exposedPort).apply {
+                attachLogger(::println)
+                start()
+                waitUntilReady()
+            }
+        } catch (e: Throwable) {
+            close()
+            throw e
+        }
+    }
+
+    val hostPort: Int
+        get() = delegate.hostPort
+
+    override fun close() = delegate.close()
+}

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
@@ -4,8 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.test.util
 
-import aws.smithy.kotlin.runtime.util.OsFamily
-import aws.smithy.kotlin.runtime.util.PlatformProvider
 import com.github.dockerjava.api.async.ResultCallback
 import com.github.dockerjava.api.command.AsyncDockerCmd
 import com.github.dockerjava.api.command.SyncDockerCmd

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
@@ -23,6 +23,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTimedValue
 
+private val DOCKER_HOST = URI.create("unix:///var/run/docker.sock")
 private val MAX_POLL_TIME = 10.seconds
 private const val POLL_CONNECT_TIMEOUT_MS = 100
 private val POLL_INTERVAL = 250.milliseconds
@@ -38,15 +39,8 @@ class Docker {
     private val client = run {
         val config = DefaultDockerClientConfig.createDefaultConfigBuilder().build()
 
-        // Default Docker host locations according to Docker reference guide:
-        // https://docs.docker.com/reference/cli/dockerd/#bind-docker-to-another-hostport-or-a-unix-socket
-        val dockerHostString = when (PlatformProvider.System.osInfo().family) {
-            OsFamily.Windows -> "tcp://localhost:2376"
-            else -> "unix:///var/run/docker.sock"
-        }
-
         val httpClient = ZerodepDockerHttpClient.Builder()
-            .dockerHost(URI.create(dockerHostString))
+            .dockerHost(DOCKER_HOST)
             .build()
 
         DockerClientImpl.getInstance(config, httpClient)

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
@@ -94,7 +94,7 @@ class Docker {
     private fun ensureImageExists(imageName: String, loggingHandler: (String) -> Unit) {
         val exists = client
             .listImagesCmd()
-            .withImageNameFilter(imageName)
+            .withReferenceFilter(imageName)
             .execAndMeasure { "Checking for $imageName locally (exists = ${it.any()})" }
             .any()
 

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.test.util
+
+import aws.smithy.kotlin.runtime.util.OsFamily
+import aws.smithy.kotlin.runtime.util.PlatformProvider
+import com.github.dockerjava.api.async.ResultCallback
+import com.github.dockerjava.api.command.AsyncDockerCmd
+import com.github.dockerjava.api.command.SyncDockerCmd
+import com.github.dockerjava.api.model.*
+import com.github.dockerjava.core.DefaultDockerClientConfig
+import com.github.dockerjava.core.DockerClientImpl
+import com.github.dockerjava.zerodep.ZerodepDockerHttpClient
+import java.io.Closeable
+import java.io.IOException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.URI
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTimedValue
+
+private val MAX_POLL_TIME = 10.seconds
+private const val POLL_CONNECT_TIMEOUT_MS = 100
+private val POLL_INTERVAL = 250.milliseconds
+
+/**
+ * Wrapper class for the Docker client
+ */
+class Docker {
+    companion object {
+        val Instance by lazy { Docker() }
+    }
+
+    private val client = run {
+        val config = DefaultDockerClientConfig.createDefaultConfigBuilder().build()
+
+        // Default Docker host locations according to Docker reference guide:
+        // https://docs.docker.com/reference/cli/dockerd/#bind-docker-to-another-hostport-or-a-unix-socket
+        val dockerHostString = when (PlatformProvider.System.osInfo().family) {
+            OsFamily.Windows -> "tcp://localhost:2376"
+            else -> "unix:///var/run/docker.sock"
+        }
+
+        val httpClient = ZerodepDockerHttpClient.Builder()
+            .dockerHost(URI.create(dockerHostString))
+            .build()
+
+        DockerClientImpl.getInstance(config, httpClient)
+    }
+
+    fun createContainer(imageName: String, cmd: List<String>, bind: Bind, exposedPort: ExposedPort): Container {
+        val portBinding = PortBinding(Ports.Binding.empty(), exposedPort)
+
+        val hostConfig = HostConfig
+            .newHostConfig()
+            .withBinds(bind)
+            .withPortBindings(portBinding)
+
+        val id = client
+            .createContainerCmd(imageName)
+            .withHostConfig(hostConfig)
+            .withExposedPorts(exposedPort)
+            .withCmd(cmd)
+            .execAndMeasure { "Created container ${it.id}" }
+            .id
+            .substring(0..<12) // Short container IDs are 12 chars vs full container IDs at 64 chars
+
+        return Container(id, exposedPort)
+    }
+
+    inner class Container(val id: String, val exposedPort: ExposedPort) : Closeable {
+        private val poller = Poller(MAX_POLL_TIME, POLL_INTERVAL)
+
+        fun attachLogger(handler: (String) -> Unit) {
+            val logger = object : ResultCallback.Adapter<Frame>() {
+                override fun onNext(frame: Frame?) {
+                    frame?.payload?.decodeToString()?.let(handler)
+                }
+            }
+
+            client
+                .attachContainerCmd(id)
+                .withFollowStream(true)
+                .withStdOut(true)
+                .withStdErr(true)
+                .withLogs(true)
+                .execAndMeasure(logger) { "Attached logger to container $id" }
+                .awaitStarted()
+        }
+
+        override fun close() {
+            client
+                .removeContainerCmd(id)
+                .withForce(true)
+                .exec()
+                .also { println("Container $id removed") }
+        }
+
+        val hostPort: Int by lazy {
+            poller.pollNotNull("Port $exposedPort in container $id") {
+                client
+                    .inspectContainerCmd(id)
+                    .exec()
+                    .networkSettings
+                    .ports
+                    .bindings[exposedPort]
+                    ?.first()
+                    ?.hostPortSpec
+                    ?.toInt()
+            }
+        }
+
+        private fun isReady() =
+            Socket().use { socket ->
+                val endpoint = InetSocketAddress(InetAddress.getLocalHost(), hostPort)
+                try {
+                    socket.connect(endpoint, POLL_CONNECT_TIMEOUT_MS)
+                    true
+                } catch (e: IOException) {
+                    false
+                }
+            }
+
+        fun start() {
+            client.startContainerCmd(id).execAndMeasure { "Container $id running" }
+        }
+
+        fun waitUntilReady() = poller.pollTrue("Socket localHost:$hostPort → $exposedPort on container $id", ::isReady)
+    }
+}
+
+private fun <T> SyncDockerCmd<T>.execAndMeasure(msg: (T) -> String): T {
+    val (value, duration) = measureTimedValue {
+        exec()
+    }
+    println("${msg(value)} in $duration")
+    return value
+}
+
+private fun <C : AsyncDockerCmd<C, T>?, T, I : ResultCallback<T>> AsyncDockerCmd<C, T>.execAndMeasure(
+    input: I,
+    msg: (I) -> String,
+): I {
+    val (value, duration) = measureTimedValue {
+        exec(input)
+    }
+    println("${msg(value)} in $duration")
+    return value
+}

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Docker.kt
@@ -103,7 +103,8 @@ class Docker {
 
             client
                 .pullImageCmd(imageName)
-                .execAndMeasure(loggerAdapter) { "Pulled missing image $imageName" }
+                .execAndMeasure(loggerAdapter) { "Started image pull for $imageName" }
+                .awaitCompletion()
         }
     }
 

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Poller.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/util/Poller.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.test.util
+
+import aws.smithy.kotlin.runtime.time.Instant
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlin.time.Duration
+
+/**
+ * A utility class for polling a resource until some specific condition is met
+ * @param maxWait The maximum amount of time the poller will wait for a condition to be met
+ * @param interval The amount of time to delay between polls
+ */
+class Poller(val maxWait: Duration, val interval: Duration) {
+    /**
+     * Poll [resource] by executing [action] until it returns true
+     */
+    fun pollTrue(resource: String, action: () -> Boolean) {
+        poll(resource, action) { it }
+    }
+
+    /**
+     * Poll [resource] by executing [action] until it returns non-null
+     */
+    fun <T : Any> pollNotNull(resource: String, action: () -> T?): T = poll(resource, action) { it != null }!!
+
+    /**
+     * Poll [resource] by executing [action] until [condition] is met on the result
+     */
+    fun <T> poll(resource: String, action: () -> T, condition: (T) -> Boolean): T = runBlocking {
+        val startTime = Instant.now()
+        val stopTime = startTime + maxWait
+
+        var result = action()
+        var ready = condition(result)
+        while (!ready && (Instant.now() + interval < stopTime)) {
+            delay(interval)
+            result = action()
+            ready = condition(result)
+        }
+
+        check(ready) { "$resource not ready within $maxWait" }
+
+        val elapsed = Instant.now() - startTime
+        println("$resource is ready after $elapsed")
+
+        result
+    }
+}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -2086,6 +2086,7 @@ public final class aws/smithy/kotlin/runtime/time/Instant : java/lang/Comparable
 	public final fun getEpochSeconds ()J
 	public final fun getNanosecondsOfSecond ()I
 	public fun hashCode ()I
+	public final fun minus-5sfh64U (Laws/smithy/kotlin/runtime/time/Instant;)J
 	public final fun minus-LRDsOJo (J)Laws/smithy/kotlin/runtime/time/Instant;
 	public final fun plus-LRDsOJo (J)Laws/smithy/kotlin/runtime/time/Instant;
 	public fun toString ()Ljava/lang/String;

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
@@ -44,6 +44,12 @@ public expect class Instant : Comparable<Instant> {
      */
     public operator fun minus(duration: Duration): Instant
 
+    /**
+     * Returns the duration between [other] and this instant. NOTE: The duration will be negative if [other] occurred
+     * after this instant.
+     */
+    public operator fun minus(other: Instant): Duration
+
     public companion object {
         /**
          * Parse an ISO-8601 formatted string into an [Instant]

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
@@ -22,6 +22,8 @@ import java.time.format.SignStyle
 import java.time.temporal.ChronoField
 import java.time.temporal.ChronoUnit
 import kotlin.time.Duration
+import kotlin.time.toKotlinDuration
+import java.time.Duration as jtDuration
 import java.time.Instant as jtInstant
 
 public actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
@@ -56,6 +58,9 @@ public actual class Instant(internal val value: jtInstant) : Comparable<Instant>
      * If the [duration] is negative, the returned instant is later than this instant.
      */
     public actual operator fun minus(duration: Duration): Instant = plus(-duration)
+
+    public actual operator fun minus(other: Instant): Duration =
+        jtDuration.between(other.value, value).toKotlinDuration()
 
     /**
      * Encode the [Instant] as a string into the format specified by [TimestampFormat]

--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/time/InstantNative.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/time/InstantNative.kt
@@ -40,6 +40,10 @@ public actual class Instant : Comparable<Instant> {
         TODO("Not yet implemented")
     }
 
+    public actual operator fun minus(other: Instant): Duration {
+        TODO("Not yet implemented")
+    }
+
     public actual companion object {
         /**
          * Parse an ISO-8601 formatted string into an [Instant]


### PR DESCRIPTION
## Issue \#

https://github.com/smithy-lang/smithy-kotlin/security/dependabot/9

## Description of changes

The Testcontainers utility we use for proxy testing has a dependency on a vulnerable version of Apache Commons Compress (see https://github.com/testcontainers/testcontainers-java/issues/8338, [CVE-2024-25710](https://www.cve.org/CVERecord?id=CVE-2024-25710), and [CVE-2024-26308](https://www.cve.org/CVERecord?id=CVE-2024-26308)). The library maintainers [refuse to upgrade to a safe version because of API compatibility](https://github.com/testcontainers/testcontainers-java/pull/8354#issuecomment-1957345903), which indicates their maintenance policy isn't robust enough for our usage.

This PR replaces Testcontainers with the [Docker Java client](https://github.com/docker-java/docker-java) and adds utility classes `MitmContainer`, `Docker`, and `Poller` to replace the functionality provided by Testcontainers's abstractions.

**Note**: I've only tested this on my dev box (EC2 instance running AL2) so far...we'll want to test in a few places to ensure it's as available as the previous solution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
