### PR TITLE
fix: respect prefix/suffix wildcards in nonProxyHosts

### DIFF
--- a/.changes/cbfc3f67-c8b3-49ad-8e06-0e9bdece01e9.json
+++ b/.changes/cbfc3f67-c8b3-49ad-8e06-0e9bdece01e9.json
@@ -1,0 +1,8 @@
+{
+    "id": "cbfc3f67-c8b3-49ad-8e06-0e9bdece01e9",
+    "type": "bugfix",
+    "description": "Respect `*` wildcard in `http.nonProxyHosts` when used as prefix or suffix",
+    "issues": [
+        "smithy-lang/smithy-kotlin#1092"
+    ]
+}

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelector.kt
@@ -105,6 +105,10 @@ internal data class NonProxyHost(val hostMatch: String, val port: Int? = null) {
 
         val name = url.host.toString()
 
+        // handle start/end wildcard cases
+        if (hostMatch.endsWith("*")) return name.startsWith(hostMatch.removeSuffix("*"))
+        if (hostMatch.startsWith("*")) return name.endsWith(hostMatch.removePrefix("*"))
+
         if (hostMatch.length > name.length) return false
 
         val match = name.endsWith(hostMatch)

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
@@ -41,6 +41,8 @@ class EnvironmentProxySelectorTest {
         "https.proxyPort" to "80",
     )
     private val httpProxyProps = mapOf("http.proxyHost" to "test.proxy.aws")
+    private val wildcardPrefixNonProxyProps = mapOf("http.nonProxyHosts" to "*amazon.com")
+    private val wildcardSuffixNonProxyProps = mapOf("http.nonProxyHosts" to "amazon.co*")
 
     private val expectedProxyConfig = ProxyConfig.Http(Url.parse("http://test.proxy.aws"))
 
@@ -57,6 +59,20 @@ class EnvironmentProxySelectorTest {
 
         TestCase(ProxyConfig.Direct, props = mapOf("http.nonProxyHosts" to "aws.amazon.com") + httpsProxyProps),
         TestCase(ProxyConfig.Direct, props = mapOf("http.nonProxyHosts" to ".amazon.com") + httpsProxyProps),
+
+        // no proxy w/ wildcards
+
+        TestCase(ProxyConfig.Direct, "https://aws.amazon.com", props = wildcardPrefixNonProxyProps + httpsProxyProps),
+        TestCase(ProxyConfig.Direct, "https://blamazon.com", props = wildcardPrefixNonProxyProps + httpsProxyProps),
+        TestCase(ProxyConfig.Direct, "https://amazon.com", props = wildcardPrefixNonProxyProps + httpsProxyProps),
+        TestCase(expectedProxyConfig, "https://aws.com", props = wildcardPrefixNonProxyProps + httpsProxyProps),
+        TestCase(expectedProxyConfig, "https://amazon.com.br", props = wildcardPrefixNonProxyProps + httpsProxyProps),
+
+        TestCase(ProxyConfig.Direct, "https://amazon.com", props = wildcardSuffixNonProxyProps + httpsProxyProps),
+        TestCase(ProxyConfig.Direct, "https://amazon.com.br", props = wildcardSuffixNonProxyProps + httpsProxyProps),
+        TestCase(ProxyConfig.Direct, "https://amazon.co.jp", props = wildcardSuffixNonProxyProps + httpsProxyProps),
+        TestCase(expectedProxyConfig, "https://aws.amazon.com", props = wildcardSuffixNonProxyProps + httpsProxyProps),
+        TestCase(expectedProxyConfig, "https://blamazon.com", props = wildcardSuffixNonProxyProps + httpsProxyProps),
 
         // multiple no proxy hosts normalization
         TestCase(ProxyConfig.Direct, env = mapOf("no_proxy" to "example.com,.amazon.com") + httpsProxyEnv),


### PR DESCRIPTION
## Issue \#

#1092

## Description of changes

We currently support the `*` wildcard in `http.nonProxyHosts` _only_ in the global case (i.e., `http.nonProxyHosts=*`) but not when used as a prefix/suffix (e.g., `http.nonProxyHosts=amazon.com*`). This change adds the necessary support and tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
