### PR TITLE
misc: replace use of `Stream::toList()` as it's only available since Java 16

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -21,6 +21,7 @@ import software.amazon.smithy.rulesengine.language.EndpointRuleSet
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
 import software.amazon.smithy.rulesengine.traits.EndpointTestCase
 import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait
+import java.util.stream.Collectors
 
 /**
  * Get all shapes of a particular type from the model.

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -33,7 +33,7 @@ import java.util.stream.Collectors
  * shape's closure for example)
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-inline fun <reified T : Shape> Model.shapes(): List<T> = shapes(T::class.java).toList()
+inline fun <reified T : Shape> Model.shapes(): List<T> = shapes(T::class.java).collect(Collectors.toList())
 
 /**
  * Extension function to return a shape of expected type.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR replaces the use of the `.toList()` method since it's only available in Java 16+, but we support Java 8 at a minimum. Trying to build smithy-kotlin on a machine without Java 16+ installed results in the following error:
```
e: file://smithy-kotlin/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt:35:80 Unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
public inline fun <T> Enumeration<TypeVariable(T)>.toList(): List<TypeVariable(T)> defined in kotlin.collections
public fun <T> Array<out TypeVariable(T)>.toList(): List<TypeVariable(T)> defined in kotlin.collections
public fun BooleanArray.toList(): List<Boolean> defined in kotlin.collections
public fun ByteArray.toList(): List<Byte> defined in kotlin.collections
public fun CharArray.toList(): List<Char> defined in kotlin.collections
public fun CharSequence.toList(): List<Char> defined in kotlin.text
public fun DoubleArray.toList(): List<Double> defined in kotlin.collections
public fun FloatArray.toList(): List<Float> defined in kotlin.collections
public fun IntArray.toList(): List<Int> defined in kotlin.collections
public fun LongArray.toList(): List<Long> defined in kotlin.collections
public fun <T> Pair<TypeVariable(T), TypeVariable(T)>.toList(): List<TypeVariable(T)> defined in kotlin
public fun ShortArray.toList(): List<Short> defined in kotlin.collections
public fun <T> Triple<TypeVariable(T), TypeVariable(T), TypeVariable(T)>.toList(): List<TypeVariable(T)> defined in kotlin
public fun <T> Iterable<TypeVariable(T)>.toList(): List<TypeVariable(T)> defined in kotlin.collections
public fun <K, V> Map<out TypeVariable(K), TypeVariable(V)>.toList(): List<Pair<TypeVariable(K), TypeVariable(V)>> defined in kotlin.collections
public fun <T> Sequence<TypeVariable(T)>.toList(): List<TypeVariable(T)> defined in kotlin.sequences
```

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
