### PR TITLE
fix: paginators not respecting start key

### DIFF
--- a/.changes/15fb7dc6-dee9-4f40-adba-a48183d4f432.json
+++ b/.changes/15fb7dc6-dee9-4f40-adba-a48183d4f432.json
@@ -1,0 +1,8 @@
+{
+    "id": "15fb7dc6-dee9-4f40-adba-a48183d4f432",
+    "type": "bugfix",
+    "description": "Paginators not respecting start key",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1330"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
@@ -148,7 +148,7 @@ class PaginatorGenerator : KotlinIntegration {
                     write("")
                     withBlock("while (hasNextPage) {", "}") {
                         withBlock("val req = initialRequest.copy {", "}") {
-                            write("this.$markerLiteral = cursor")
+                            write("this.$markerLiteral = this.$markerLiteral ?: cursor")
                         }
                         write(
                             "val result = this@#1LPaginated.#1L(req)",

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -100,7 +100,7 @@ class PaginatorGeneratorTest {
             
                     while (hasNextPage) {
                         val req = initialRequest.copy {
-                            this.marker = cursor
+                            this.marker = this.marker ?: cursor
                         }
                         val result = this@listFunctionsPaginated.listFunctions(req)
                         cursor = result.nextMarker
@@ -211,7 +211,7 @@ class PaginatorGeneratorTest {
             
                     while (hasNextPage) {
                         val req = initialRequest.copy {
-                            this.marker = cursor
+                            this.marker = this.marker ?: cursor
                         }
                         val result = this@listFunctionsPaginated.listFunctions(req)
                         cursor = result.nextMarker
@@ -348,7 +348,7 @@ class PaginatorGeneratorTest {
             
                     while (hasNextPage) {
                         val req = initialRequest.copy {
-                            this.marker = cursor
+                            this.marker = this.marker ?: cursor
                         }
                         val result = this@listFunctionsPaginated.listFunctions(req)
                         cursor = result.nextMarker
@@ -477,7 +477,7 @@ class PaginatorGeneratorTest {
             
                     while (hasNextPage) {
                         val req = initialRequest.copy {
-                            this.marker = cursor
+                            this.marker = this.marker ?: cursor
                         }
                         val result = this@listFunctionsPaginated.listFunctions(req)
                         cursor = result.nextMarker
@@ -647,7 +647,7 @@ class PaginatorGeneratorTest {
             
                     while (hasNextPage) {
                         val req = initialRequest.copy {
-                            this.marker = cursor
+                            this.marker = this.marker ?: cursor
                         }
                         val result = this@listFunctionsPaginated.listFunctions(req)
                         cursor = result.nextMarker


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
aws-sdk-kotlin#1330

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Check if start key is exists before setting it to null


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
