### PR TITLE
fix: address various Dependabot warnings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ kotlin-compile-testing-version = "1.5.0"
 kotlinx-benchmark-version = "0.4.9"
 kotlinx-serialization-version = "1.6.0"
 docker-java-version = "3.3.6"
-ktor-version = "2.3.6"
+ktor-version = "2.3.12"
 kaml-version = "0.55.0"
 jsoup-version = "1.16.2"
 

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -43,8 +43,11 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(libs.docker.core)
-                // Fixing a CVE https://github.com/docker-java/docker-java/issues/2177
-                implementation("com.fasterxml.jackson.core:jackson-databind:2.12.7.1")
+                // FIXME docker-java has a ton of dependencies with vulnerabilities, and they don't seem motivated to fix them.
+                // So we must override their dependencies with the latest patched versions. https://github.com/docker-java/docker-java/issues/1974
+                implementation("com.fasterxml.jackson.core:jackson-databind:2.12.7.1") // https://github.com/docker-java/docker-java/issues/2177
+                implementation("org.apache.commons:commons-compress:1.26.0") // https://github.com/docker-java/docker-java/pull/2256
+                implementation("org.bouncycastle:bcpkix-jdk18on:1.78") // https://github.com/docker-java/docker-java/pull/2326
 
                 implementation(libs.docker.transport.zerodep)
             }

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -43,6 +43,9 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(libs.docker.core)
+                // Fixing a CVE https://github.com/docker-java/docker-java/issues/2177
+                implementation("com.fasterxml.jackson.core:jackson-databind:2.12.7.1")
+
                 implementation(libs.docker.transport.zerodep)
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates various dependencies to address vulnerabilities reported by Dependabot, especially from [docker-java, since they have many vulnerable dependencies.](https://github.com/docker-java/docker-java/issues/1974)

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
