### PR TITLE
chore: enable Dependabot automatic version upgrade PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# for information about dependabot.yml format/options
+
+version: 2
+
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: "software.amazon.smithy:*"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change should enable Dependabot to send PRs to us when new versions of Smithy are launched. Only Smithy is allowlisted for now—we can see if it makes sense to enable for other dependencies in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.