### PR TITLE
chore: upgrade Smithy to 1.50.0

### DIFF
--- a/.changes/56c3bdfe-3416-46c4-a9e4-7d87918ee94b.json
+++ b/.changes/56c3bdfe-3416-46c4-a9e4-7d87918ee94b.json
@@ -1,0 +1,5 @@
+{
+    "id": "56c3bdfe-3416-46c4-a9e4-7d87918ee94b",
+    "type": "misc",
+    "description": "Upgrade Smithy to version **1.50.0**"
+}

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
@@ -41,8 +41,8 @@ abstract class AwsHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
 
         val ignoredTests = TestMemberDelta(
             setOf(
-                // This test requires populating blob members with a default value of "", which the sdk doesn't do
-                "AwsJson10ClientPopulatesDefaultValuesInInput",
+                // Test broken in Smithy 1.50.0, should be fixed by https://github.com/smithy-lang/smithy/pull/2341
+                "RestJsonClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse",
             ),
         )
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -222,7 +222,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
     private fun DefaultTrait.getDefaultValue(targetShape: Shape): String? {
         val node = toNode()
         return when {
-            node.toString() == "null" || targetShape is BlobShape && node.toString() == "" -> null
+            node.toString() == "null" -> null
 
             // Check if target is an enum before treating the default like a regular number/string
             targetShape.isEnum -> {
@@ -235,7 +235,14 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
                 "${enumSymbol.fullName}.fromValue($arg)"
             }
 
+            targetShape.isBlobShape && targetShape.isStreaming ->
+                node
+                    .toString()
+                    .takeUnless { it.isEmpty() }
+                    ?.let { "ByteStream.fromString(${it.dq()})" }
+
             targetShape.isBlobShape -> "${node.toString().dq()}.encodeToByteArray()"
+
             targetShape.isDocumentShape -> getDefaultValueForDocument(node)
             targetShape.isTimestampShape -> getDefaultValueForTimestamp(node.asNumberNode().get())
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ slf4j-v1x-version = "1.7.36"
 crt-kotlin-version = "0.8.6"
 
 # codegen
-smithy-version = "1.49.0"
+smithy-version = "1.50.0"
 smithy-gradle-version = "0.9.0"
 
 # testing


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change upgrades Smithy to [**1.50.0**](https://github.com/smithy-lang/smithy/releases/tag/1.50.0), the latest version available.

**Companion PR**: https://github.com/awslabs/aws-sdk-kotlin/pull/1349

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.