### PR TITLE
misc: set up resolves-conflict-dependencies for K2 upgrade

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -63,10 +63,14 @@
       ],
       "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.*": [
         "KotlinStdlibCommon-1.9.x",
-        "KotlinStdlibJdk8-1.9.x"
+        "KotlinStdlibJdk8-1.9.x",
+        "KotlinxCoroutinesCoreJvm-1.7.x"
       ],
       "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.*": [
         "KotlinStdlibJdk8-1.9.x"
+      ],
+      "org.jetbrains.kotlin:kotlin-stdlib:1.9.*": [
+        "KotlinStdlib-1.9.x"
       ]
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR sets up our internal `resolves-conflict-dependencies` transformation to stay on 1.9.x as a preliminary step to upgrading aws-crt-kotlin to Kotlin 2.0.0. 

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
