### PR TITLE
misc: docs accessibility fixes

### DIFF
--- a/docs/dokka-presets/scripts/accessibility.js
+++ b/docs/dokka-presets/scripts/accessibility.js
@@ -33,6 +33,10 @@ function applySkipLinks() {
         document.querySelectorAll('.sideMenuPart[data-active]').forEach(function(sideMenuPart) {
             insertSkipLink(sideMenuPart)
         });
+
+        // Insert a skip link on the first sideMenuPart
+        const firstSideMenuPart = document.getElementById("sideMenu").children[0].querySelectorAll(".sideMenuPart")[0]
+        insertSkipLink(firstSideMenuPart)
     }
 
     const observer = new MutationObserver(handleChanges);
@@ -86,11 +90,9 @@ function ensureNavButtonInteractable() {
     });
 }
 
-window.onload = function() {
-    ensureNavButtonInteractable()
-}
+document.addEventListener('DOMContentLoaded', ensureNavButtonInteractable)
+if (document.readyState === "interactive" || document.readyState === "complete" ) { ensureNavButtonInteractable() }
 
-//
 /**
  * Ensure that content (specifically, code blocks) reflows on small page sizes.
  * Fixes accessibility violation: "Ensure pages reflow without requiring two-dimensional scrolling without loss of content or functionality"
@@ -100,6 +102,8 @@ function ensureContentReflow() {
 
     // Function to insert 'toggle content' button
     function insertToggleContentButton(element) {
+        if (element.parentNode.querySelectorAll(".aws-toggle-content-btn").length > 0) { return }
+
         const initiallyVisible = window.innerWidth >= MIN_WINDOW_SIZE
 
         const toggleContent = document.createElement('button');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Round 2!**
- Ensure only one toggle-content button is inserted
	- I was sometimes seeing two toggle-content buttons 
- Insert a skip-to-main-content link on the first `sideMenuPart`
	- Clicking a `sideMenuPart` would throws the tab index back to the top, meaning you have to tab all the way through to your current `sideMenuPart` before you will reach the skip-to-main-content link. This change adds a skip-link to the first `sideMenuPart` and the `data-active` `sideMenuPart` to ensure this case is covered.
- Update invocation of `ensureNavButtonInteractable` function
	- I wasn't seeing this function's effects on the prod docs, hopefully updating the way its invoked will fix this 

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
