### PR TITLE
feat: add support for string arrays in rules engine parameters & support for operationContextParams trait

### DIFF
--- a/.changes/22c07786-9168-425a-960b-e03378ee3ce3.json
+++ b/.changes/22c07786-9168-425a-960b-e03378ee3ce3.json
@@ -1,0 +1,5 @@
+{
+    "id": "22c07786-9168-425a-960b-e03378ee3ce3",
+    "type": "feature",
+    "description": "Add support for operationContextParams trait"
+}

--- a/.changes/f1afb4d6-fa61-4eba-8695-b9a8bc59418a.json
+++ b/.changes/f1afb4d6-fa61-4eba-8695-b9a8bc59418a.json
@@ -1,0 +1,5 @@
+{
+    "id": "f1afb4d6-fa61-4eba-8695-b9a8bc59418a",
+    "type": "feature",
+    "description": "Add support for string arrays in rules engine parameters"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/RulesEngineExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/RulesEngineExt.kt
@@ -8,6 +8,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
 import software.amazon.smithy.kotlin.codegen.utils.doubleQuote
 import software.amazon.smithy.kotlin.codegen.utils.toCamelCase
+import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.rulesengine.language.evaluation.value.ArrayValue
 import software.amazon.smithy.rulesengine.language.evaluation.value.BooleanValue
 import software.amazon.smithy.rulesengine.language.evaluation.value.StringValue
@@ -33,7 +34,7 @@ fun ParameterType.toSymbol(): Symbol =
     when (this) {
         ParameterType.STRING -> KotlinTypes.String
         ParameterType.BOOLEAN -> KotlinTypes.Boolean
-        ParameterType.STRING_ARRAY -> KotlinTypes.Collections.mutableList(KotlinTypes.String)
+        ParameterType.STRING_ARRAY -> KotlinTypes.Collections.list(KotlinTypes.String)
     }.asNullable()
 
 /**
@@ -43,8 +44,16 @@ fun Value.toLiteral(): String =
     when (this) {
         is StringValue -> value.doubleQuote()
         is BooleanValue -> value.toString()
-        is ArrayValue -> values.joinToString(",", "mutableListOf(", ")") { value ->
+        is ArrayValue -> values.joinToString(", ", "listOf(", ")") { value ->
             value.expectStringValue().value.doubleQuote()
         }
         else -> throw IllegalArgumentException("unrecognized parameter value type $type")
+    }
+
+/**
+ * Format a list of string nodes for codegen
+ */
+fun List<Node>.format(): String =
+    this.joinToString(", ", "listOf(", ")") { element ->
+        element.expectStringNode().value.doubleQuote()
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/RulesEngineExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/RulesEngineExt.kt
@@ -8,6 +8,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
 import software.amazon.smithy.kotlin.codegen.utils.doubleQuote
 import software.amazon.smithy.kotlin.codegen.utils.toCamelCase
+import software.amazon.smithy.rulesengine.language.evaluation.value.ArrayValue
 import software.amazon.smithy.rulesengine.language.evaluation.value.BooleanValue
 import software.amazon.smithy.rulesengine.language.evaluation.value.StringValue
 import software.amazon.smithy.rulesengine.language.evaluation.value.Value
@@ -32,7 +33,7 @@ fun ParameterType.toSymbol(): Symbol =
     when (this) {
         ParameterType.STRING -> KotlinTypes.String
         ParameterType.BOOLEAN -> KotlinTypes.Boolean
-        ParameterType.STRING_ARRAY -> KotlinTypes.Collections.MutableList
+        ParameterType.STRING_ARRAY -> KotlinTypes.Collections.mutableList(KotlinTypes.String)
     }.asNullable()
 
 /**
@@ -42,5 +43,8 @@ fun Value.toLiteral(): String =
     when (this) {
         is StringValue -> value.doubleQuote()
         is BooleanValue -> value.toString()
+        is ArrayValue -> values.joinToString(",", "mutableListOf(", ")") { value ->
+            value.expectStringValue().value.doubleQuote()
+        }
         else -> throw IllegalArgumentException("unrecognized parameter value type $type")
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/EndpointParameterIndex.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/EndpointParameterIndex.kt
@@ -12,6 +12,8 @@ import software.amazon.smithy.model.knowledge.KnowledgeIndex
 import software.amazon.smithy.model.knowledge.OperationIndex
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rulesengine.traits.ContextParamTrait
+import software.amazon.smithy.rulesengine.traits.OperationContextParamDefinition
+import software.amazon.smithy.rulesengine.traits.OperationContextParamsTrait
 import software.amazon.smithy.rulesengine.traits.StaticContextParamsTrait
 
 /**
@@ -45,13 +47,22 @@ class EndpointParameterIndex private constructor(model: Model) : KnowledgeIndex 
         }
 
     /**
+     * Get the [operationContextParams](https://smithy.io/2.0/additional-specs/rules-engine/parameters.html#smithy-rules-operationcontextparams-trait)
+     * for an operation.
+     *
+     * @param op the operation shape to get context params for.
+     */
+    fun operationContextParams(op: OperationShape): Map<String, OperationContextParamDefinition>? =
+        op.getTrait<OperationContextParamsTrait>()?.parameters
+
+    /**
      * Check if there are any context parameters bound to an operation
      *
      * @param op operation to check parameters for
-     * @return true if there are any static or input context parameters for the given operation
+     * @return true if there are any static, input, or operation context parameters for the given operation
      */
     fun hasContextParams(op: OperationShape): Boolean =
-        staticContextParams(op) != null || inputContextParams(op).isNotEmpty()
+        staticContextParams(op) != null || inputContextParams(op).isNotEmpty() || operationContextParams(op) != null
 
     companion object {
         fun of(model: Model): EndpointParameterIndex = EndpointParameterIndex(model)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -9,8 +9,8 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
+import software.amazon.smithy.kotlin.codegen.model.format
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
-import software.amazon.smithy.kotlin.codegen.utils.doubleQuote
 import software.amazon.smithy.kotlin.codegen.utils.toCamelCase
 import software.amazon.smithy.model.node.ArrayNode
 import software.amazon.smithy.model.node.BooleanNode
@@ -132,13 +132,7 @@ class DefaultEndpointProviderTestGenerator(
         when (v) {
             is StringNode -> writer.writeInline("#S", v.value)
             is BooleanNode -> writer.writeInline("#L", v.value)
-            is ArrayNode -> {
-                writer.writeInline(
-                    v.elements.joinToString(",", "mutableListOf(", ")") { element ->
-                        element.expectStringNode().value.doubleQuote()
-                    },
-                )
-            }
+            is ArrayNode -> writer.writeInline("#L", v.elements.format())
             else -> throw IllegalArgumentException("unexpected test case param value")
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -10,7 +10,9 @@ import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
+import software.amazon.smithy.kotlin.codegen.utils.doubleQuote
 import software.amazon.smithy.kotlin.codegen.utils.toCamelCase
+import software.amazon.smithy.model.node.ArrayNode
 import software.amazon.smithy.model.node.BooleanNode
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.StringNode
@@ -130,6 +132,13 @@ class DefaultEndpointProviderTestGenerator(
         when (v) {
             is StringNode -> writer.writeInline("#S", v.value)
             is BooleanNode -> writer.writeInline("#L", v.value)
+            is ArrayNode -> {
+                writer.writeInline(
+                    v.elements.joinToString(",", "mutableListOf(", ")") { element ->
+                        element.expectStringNode().value.doubleQuote()
+                    },
+                )
+            }
             else -> throw IllegalArgumentException("unexpected test case param value")
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterGenerator.kt
@@ -12,7 +12,6 @@ import software.amazon.smithy.kotlin.codegen.integration.SectionId
 import software.amazon.smithy.kotlin.codegen.model.*
 import software.amazon.smithy.kotlin.codegen.model.knowledge.EndpointParameterIndex
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
-import software.amazon.smithy.kotlin.codegen.utils.doubleQuote
 import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType
@@ -193,11 +192,7 @@ class EndpointResolverAdapterGenerator(
                 when (param.type) {
                     ParameterType.STRING -> writer.write("#S", staticParam.value.expectStringNode().value)
                     ParameterType.BOOLEAN -> writer.write("#L", staticParam.value.expectBooleanNode().value)
-                    ParameterType.STRING_ARRAY -> writer.write(
-                        staticParam.value.expectArrayNode().elements.joinToString(",", "mutableListOf(", ")") { element ->
-                            element.expectStringNode().value.doubleQuote()
-                        },
-                    )
+                    ParameterType.STRING_ARRAY -> writer.write("#L", staticParam.value.expectArrayNode().elements.format())
                     else -> throw CodegenException("unexpected static context param type ${param.type}")
                 }
                 continue

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterGenerator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.kotlin.codegen.integration.SectionId
 import software.amazon.smithy.kotlin.codegen.model.*
 import software.amazon.smithy.kotlin.codegen.model.knowledge.EndpointParameterIndex
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
+import software.amazon.smithy.kotlin.codegen.utils.doubleQuote
 import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType
@@ -192,6 +193,11 @@ class EndpointResolverAdapterGenerator(
                 when (param.type) {
                     ParameterType.STRING -> writer.write("#S", staticParam.value.expectStringNode().value)
                     ParameterType.BOOLEAN -> writer.write("#L", staticParam.value.expectBooleanNode().value)
+                    ParameterType.STRING_ARRAY -> writer.write(
+                        staticParam.value.expectArrayNode().elements.joinToString(",", "mutableListOf(", ")") { element ->
+                            element.expectStringNode().value.doubleQuote()
+                        },
+                    )
                     else -> throw CodegenException("unexpected static context param type ${param.type}")
                 }
                 continue

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -40,11 +40,14 @@ private val suffixSequence = sequenceOf("") + generateSequence(2) { it + 1 }.map
  * @param ctx The surrounding [CodegenContext].
  * @param writer The [KotlinWriter] to generate code into.
  * @param shape The modeled [Shape] on which this JMESPath expression is operating.
+ * @param topLevelParentName The name used to reference the top level "parent" of an expression during codegen.
+ * Defaults to `it`. E.g. `it.field`.
  */
 class KotlinJmespathExpressionVisitor(
     val ctx: CodegenContext,
     val writer: KotlinWriter,
     shape: Shape,
+    private val topLevelParentName: String = "it",
 ) : ExpressionVisitor<VisitedExpression> {
     private val tempVars = mutableSetOf<String>()
 
@@ -172,7 +175,8 @@ class KotlinJmespathExpressionVisitor(
 
     override fun visitExpressionType(expression: ExpressionTypeExpression): VisitedExpression = throw CodegenException("ExpressionTypeExpression is unsupported")
 
-    override fun visitField(expression: FieldExpression): VisitedExpression = subfield(expression, "it")
+    override fun visitField(expression: FieldExpression): VisitedExpression =
+        if (shapeCursor.size == 1) subfield(expression, topLevelParentName) else subfield(expression, "it")
 
     override fun visitFilterProjection(expression: FilterProjectionExpression): VisitedExpression {
         val left = expression.left.accept(this)
@@ -444,6 +448,10 @@ class KotlinJmespathExpressionVisitor(
     private fun projection(expression: ProjectionExpression, parentName: String): VisitedExpression {
         val left = when (expression.left) {
             is SliceExpression -> slice(expression.left as SliceExpression, parentName)
+            is FieldExpression -> subfield(expression.left as FieldExpression, parentName)
+            is IndexExpression -> index(expression.left as IndexExpression, parentName)
+            is Subexpression -> subexpression(expression.left as Subexpression, parentName)
+            is ProjectionExpression -> projection(expression.left as ProjectionExpression, parentName)
             else -> expression.left.accept(this)
         }
         requireNotNull(left.shape) { "projection is operating on nothing" }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
@@ -166,7 +166,7 @@ class EndpointParametersGeneratorTest {
          
             public val requiredStringField: String? = requireNotNull(builder.requiredStringField) { "endpoint provider parameter #requiredStringField is required" }
             
-            public val stringArrayField: kotlin.collections.MutableList<kotlin.String>? = builder.stringArrayField
+            public val stringArrayField: kotlin.collections.List<kotlin.String>? = builder.stringArrayField
          
             public val stringField: String? = builder.stringField
         """.formatForTest()
@@ -315,7 +315,7 @@ class EndpointParametersGeneratorTest {
          
                 public var requiredStringField: String? = null
                 
-                public var stringArrayField: kotlin.collections.MutableList<kotlin.String>? = null
+                public var stringArrayField: kotlin.collections.List<kotlin.String>? = null
          
                 public var stringField: String? = null
          

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
@@ -29,6 +29,10 @@ class EndpointParametersGeneratorTest {
                         "type": "Boolean",
                         "required": false
                     },
+                    "StringArrayField": {
+                        "type": "stringArray",
+                        "required": false
+                    },
                     "RequiredStringField": {
                         "type": "String",
                         "required": true
@@ -161,6 +165,8 @@ class EndpointParametersGeneratorTest {
             public val requiredBooleanField: Boolean? = requireNotNull(builder.requiredBooleanField) { "endpoint provider parameter #requiredBooleanField is required" }
          
             public val requiredStringField: String? = requireNotNull(builder.requiredStringField) { "endpoint provider parameter #requiredStringField is required" }
+            
+            public val stringArrayField: kotlin.collections.MutableList<kotlin.String>? = builder.stringArrayField
          
             public val stringField: String? = builder.stringField
         """.formatForTest()
@@ -195,6 +201,7 @@ class EndpointParametersGeneratorTest {
                 if (this.documentedField != other.documentedField) return false
                 if (this.requiredBooleanField != other.requiredBooleanField) return false
                 if (this.requiredStringField != other.requiredStringField) return false
+                if (this.stringArrayField != other.stringArrayField) return false
                 if (this.stringField != other.stringField) return false
                 return true
             }
@@ -218,6 +225,7 @@ class EndpointParametersGeneratorTest {
                 result = 31 * result + (documentedField?.hashCode() ?: 0)
                 result = 31 * result + (requiredBooleanField?.hashCode() ?: 0)
                 result = 31 * result + (requiredStringField?.hashCode() ?: 0)
+                result = 31 * result + (stringArrayField?.hashCode() ?: 0)
                 result = 31 * result + (stringField?.hashCode() ?: 0)
                 return result
             }
@@ -242,6 +250,7 @@ class EndpointParametersGeneratorTest {
                 append("documentedField=${'$'}documentedField,")
                 append("requiredBooleanField=${'$'}requiredBooleanField,")
                 append("requiredStringField=${'$'}requiredStringField,")
+                append("stringArrayField=${'$'}stringArrayField,")
                 append("stringField=${'$'}stringField)")
             }
         """.formatForTest()
@@ -265,6 +274,7 @@ class EndpointParametersGeneratorTest {
                     documentedField = this@TestEndpointParameters.documentedField
                     requiredBooleanField = this@TestEndpointParameters.requiredBooleanField
                     requiredStringField = this@TestEndpointParameters.requiredStringField
+                    stringArrayField = this@TestEndpointParameters.stringArrayField
                     stringField = this@TestEndpointParameters.stringField
                     block()
                 }
@@ -304,6 +314,8 @@ class EndpointParametersGeneratorTest {
                 public var requiredBooleanField: Boolean? = null
          
                 public var requiredStringField: String? = null
+                
+                public var stringArrayField: kotlin.collections.MutableList<kotlin.String>? = null
          
                 public var stringField: String? = null
          

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterTest.kt
@@ -1,0 +1,127 @@
+package software.amazon.smithy.kotlin.codegen.rendering.endpoints
+
+import software.amazon.smithy.kotlin.codegen.test.*
+import kotlin.test.*
+
+class EndpointResolverAdapterTest {
+    private val generatedClass: String
+
+    init {
+        val model =
+            """
+            namespace com.test
+            
+            use smithy.rules#endpointRuleSet
+            use smithy.rules#operationContextParams
+            
+            @endpointRuleSet(
+                version: "1.0",
+                parameters: {
+                    Foo: {
+                        type: "stringArray",
+                        documentation: "A foo",
+                        required: false,
+                    }
+                }
+                rules: []
+            )
+            service Test {
+                version: "1.0.0",
+                operations: [ DeleteObjects ],
+            }
+            
+            @operationContextParams(
+                Foo: {
+                    path: "Delete.Objects[*].Key"
+                }
+            )
+            operation DeleteObjects {
+                input: DeleteObjectsRequest
+            }
+            
+            structure DeleteObjectsRequest {
+                Delete: Delete
+            }
+            
+            structure Delete {
+                Objects: ObjectIdentifierList
+            }
+            
+            list ObjectIdentifierList {
+                member: ObjectIdentifier
+            }
+            
+            structure ObjectIdentifier {
+                Key: String
+            }
+        """.toSmithyModel()
+
+        val testCtx = model.newTestContext()
+        val writer = testCtx.newWriter()
+        EndpointResolverAdapterGenerator(testCtx.generationCtx, writer).render()
+        generatedClass = writer.toString()
+    }
+
+    @Test
+    fun testClass() {
+        val expected = """
+            internal class EndpointResolverAdapter(
+                private val config: TestClient.Config
+            ): EndpointResolver {
+        """.trimIndent()
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testResolve() {
+        val expected = """
+            override suspend fun resolve(request: ResolveEndpointRequest): Endpoint {
+                val params = resolveEndpointParams(config, request)
+                val endpoint = config.endpointProvider.resolveEndpoint(params)
+                return endpoint
+            }
+        """.formatForTest("    ")
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testResolveEndpointParams() {
+        val expected = """
+            internal fun resolveEndpointParams(config: TestClient.Config, request: ResolveEndpointRequest): TestEndpointParameters {
+                return TestEndpointParameters {
+                    val opName = request.context[SdkClientOption.OperationName]
+                    opContextBindings[opName]?.invoke(this, request)
+                }
+            }
+        """.trimIndent()
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testOpContextBindingsMap() {
+        val expected = """
+            private val opContextBindings = mapOf<String, BindOperationContextParamsFn> (
+                "DeleteObjects" to ::bindDeleteObjectsEndpointContext,
+            )
+        """.trimIndent()
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testOpContextBindingsFunction() {
+        val expected = """
+            private fun bindDeleteObjectsEndpointContext(builder: TestEndpointParameters.Builder, request: ResolveEndpointRequest): Unit {
+                @Suppress("UNCHECKED_CAST")
+                val input = request.context[HttpOperationContext.OperationInput] as DeleteObjectsRequest
+                val delete = input.delete
+                val objects = delete?.objects
+                val projection = objects?.flatMap {
+                    val key = it?.key
+                    listOfNotNull(key)
+                }
+                builder.foo = projection
+            }
+        """.trimIndent()
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+}

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/OperationContextParamsTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/OperationContextParamsTest.kt
@@ -1,0 +1,117 @@
+package software.amazon.smithy.kotlin.codegen.rendering.endpoints
+
+import software.amazon.smithy.kotlin.codegen.test.*
+import kotlin.test.Test
+
+class OperationContextParamsTest {
+    private fun codegen(paramType: String, jmesPath: String, input: String): String {
+        val template =
+            """
+            namespace com.test
+            
+            use smithy.rules#endpointRuleSet
+            use smithy.rules#operationContextParams
+            
+            @endpointRuleSet(
+                version: "1.0",
+                parameters: {
+                    Foo: {
+                        type: "$paramType",
+                        documentation: "A foo",
+                        required: false,
+                    }
+                }
+                rules: []
+            )
+            service Test {
+                version: "1.0.0",
+                operations: [ TestOperation ],
+            }
+            
+            @operationContextParams(
+                Foo: {
+                    path: "$jmesPath"
+                }
+            )
+            operation TestOperation {
+                input: TestOperationRequest
+            }
+        """
+
+        val model = buildString {
+            append(template)
+            append(input)
+        }.toSmithyModel()
+
+        val testCtx = model.newTestContext()
+        val writer = testCtx.newWriter()
+        EndpointResolverAdapterGenerator(testCtx.generationCtx, writer).render()
+        return writer.toString()
+    }
+
+    @Test
+    fun testWildCardPath() {
+        val input = """
+            structure TestOperationRequest {
+                Delete: Delete
+            }
+            
+            structure Delete {
+                Objects: ObjectIdentifierList
+            }
+            
+            list ObjectIdentifierList {
+                member: ObjectIdentifier
+            }
+            
+            structure ObjectIdentifier {
+                Key: String
+            }
+        """.trimIndent()
+
+        val path = "Delete.Objects[*].Key"
+        val pathResultType = "stringArray"
+
+        val expected = """
+            @Suppress("UNCHECKED_CAST")
+            val input = request.context[HttpOperationContext.OperationInput] as TestOperationRequest
+            val delete = input.delete
+            val objects = delete?.objects
+            val projection = objects?.flatMap {
+                val key = it?.key
+                listOfNotNull(key)
+            }
+            builder.foo = projection
+        """.formatForTest("    ")
+
+        codegen(pathResultType, path, input).shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testKeysFunctionPath() {
+        val input = """
+            structure TestOperationRequest {
+                Object: Object
+            }
+            
+            structure Object {
+                Key1: String,
+                Key2: String,
+                Key3: String,
+            }
+        """.trimIndent()
+
+        val path = "keys(Object)"
+        val pathResultType = "stringArray"
+
+        val expected = """
+            @Suppress("UNCHECKED_CAST")
+            val input = request.context[HttpOperationContext.OperationInput] as TestOperationRequest
+            val object = input.object
+            val keys = listOf("Key1", "Key2", "Key3")
+            builder.foo = keys
+        """.formatForTest("    ")
+
+        codegen(pathResultType, path, input).shouldContainOnlyOnceWithDiff(expected)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Add support for string arrays in [rules engine parameters](https://smithy.io/2.0/additional-specs/rules-engine/specification.html#parameter-object)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
