### PR TITLE
feat: add support for operationContextParams trait

### DIFF
--- a/.changes/22c07786-9168-425a-960b-e03378ee3ce3.json
+++ b/.changes/22c07786-9168-425a-960b-e03378ee3ce3.json
@@ -1,0 +1,5 @@
+{
+    "id": "22c07786-9168-425a-960b-e03378ee3ce3",
+    "type": "feature",
+    "description": "Add support for operationContextParams trait"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/EndpointParameterIndex.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/EndpointParameterIndex.kt
@@ -12,12 +12,14 @@ import software.amazon.smithy.model.knowledge.KnowledgeIndex
 import software.amazon.smithy.model.knowledge.OperationIndex
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rulesengine.traits.ContextParamTrait
+import software.amazon.smithy.rulesengine.traits.OperationContextParamDefinition
+import software.amazon.smithy.rulesengine.traits.OperationContextParamsTrait
 import software.amazon.smithy.rulesengine.traits.StaticContextParamsTrait
 
 /**
  * Provides endpoint parameter binding knowledge index
  */
-class EndpointParameterIndex private constructor(model: Model) : KnowledgeIndex {
+class EndpointParameterIndex private constructor(private val model: Model) : KnowledgeIndex {
     private val opIndex = OperationIndex.of(model)
 
     /**
@@ -45,13 +47,22 @@ class EndpointParameterIndex private constructor(model: Model) : KnowledgeIndex 
         }
 
     /**
+     * Get the [operationContextParams](https://smithy.io/2.0/additional-specs/rules-engine/parameters.html#smithy-rules-operationcontextparams-trait)
+     * for an operation.
+     *
+     * @param op the operation shape to get context params for.
+     */
+    fun operationContextParams(op: OperationShape): MutableMap<String, OperationContextParamDefinition>? =
+        model.operationShapes.find { op.id == it.id }?.getTrait<OperationContextParamsTrait>()?.parameters
+
+    /**
      * Check if there are any context parameters bound to an operation
      *
      * @param op operation to check parameters for
-     * @return true if there are any static or input context parameters for the given operation
+     * @return true if there are any static, input, or operation context parameters for the given operation
      */
     fun hasContextParams(op: OperationShape): Boolean =
-        staticContextParams(op) != null || inputContextParams(op).isNotEmpty()
+        staticContextParams(op) != null || inputContextParams(op).isNotEmpty() || operationContextParams(op) != null
 
     companion object {
         fun of(model: Model): EndpointParameterIndex = EndpointParameterIndex(model)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/EndpointParameterIndex.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/EndpointParameterIndex.kt
@@ -52,7 +52,7 @@ class EndpointParameterIndex private constructor(model: Model) : KnowledgeIndex 
      *
      * @param op the operation shape to get context params for.
      */
-    fun operationContextParams(op: OperationShape): MutableMap<String, OperationContextParamDefinition>? =
+    fun operationContextParams(op: OperationShape): Map<String, OperationContextParamDefinition>? =
         op.getTrait<OperationContextParamsTrait>()?.parameters
 
     /**

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/EndpointParameterIndex.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/EndpointParameterIndex.kt
@@ -19,7 +19,7 @@ import software.amazon.smithy.rulesengine.traits.StaticContextParamsTrait
 /**
  * Provides endpoint parameter binding knowledge index
  */
-class EndpointParameterIndex private constructor(private val model: Model) : KnowledgeIndex {
+class EndpointParameterIndex private constructor(model: Model) : KnowledgeIndex {
     private val opIndex = OperationIndex.of(model)
 
     /**
@@ -53,7 +53,7 @@ class EndpointParameterIndex private constructor(private val model: Model) : Kno
      * @param op the operation shape to get context params for.
      */
     fun operationContextParams(op: OperationShape): MutableMap<String, OperationContextParamDefinition>? =
-        model.operationShapes.find { op.id == it.id }?.getTrait<OperationContextParamsTrait>()?.parameters
+        op.getTrait<OperationContextParamsTrait>()?.parameters
 
     /**
      * Check if there are any context parameters bound to an operation

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterGenerator.kt
@@ -14,7 +14,6 @@ import software.amazon.smithy.kotlin.codegen.model.*
 import software.amazon.smithy.kotlin.codegen.model.knowledge.EndpointParameterIndex
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.waiters.KotlinJmespathExpressionVisitor
-import software.amazon.smithy.kotlin.codegen.utils.doubleQuote
 import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -41,7 +41,7 @@ private val suffixSequence = sequenceOf("") + generateSequence(2) { it + 1 }.map
  * @param writer The [KotlinWriter] to generate code into.
  * @param shape The modeled [Shape] on which this JMESPath expression is operating.
  * @param topLevelParentName The name used to reference the top level "parent" of an expression during codegen.
- * Defaults to `it`. E.g. `it.field`. Won't be used otherwise.
+ * Defaults to `it`. E.g. `it.field`.
  */
 class KotlinJmespathExpressionVisitor(
     val ctx: CodegenContext,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -40,11 +40,13 @@ private val suffixSequence = sequenceOf("") + generateSequence(2) { it + 1 }.map
  * @param ctx The surrounding [CodegenContext].
  * @param writer The [KotlinWriter] to generate code into.
  * @param shape The modeled [Shape] on which this JMESPath expression is operating.
+ * @param parentName The name used to reference the "parent" of an expression during codegen. Defaults to `it`. E.g. `it.field`.
  */
 class KotlinJmespathExpressionVisitor(
     val ctx: CodegenContext,
     val writer: KotlinWriter,
     shape: Shape,
+    private val parentName: String = "it",
 ) : ExpressionVisitor<VisitedExpression> {
     private val tempVars = mutableSetOf<String>()
 
@@ -172,7 +174,7 @@ class KotlinJmespathExpressionVisitor(
 
     override fun visitExpressionType(expression: ExpressionTypeExpression): VisitedExpression = throw CodegenException("ExpressionTypeExpression is unsupported")
 
-    override fun visitField(expression: FieldExpression): VisitedExpression = subfield(expression, "it")
+    override fun visitField(expression: FieldExpression): VisitedExpression = subfield(expression, parentName)
 
     override fun visitFilterProjection(expression: FilterProjectionExpression): VisitedExpression {
         val left = expression.left.accept(this)

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterTest.kt
@@ -1,0 +1,126 @@
+package software.amazon.smithy.kotlin.codegen.rendering.endpoints
+
+import software.amazon.smithy.kotlin.codegen.test.*
+import kotlin.test.*
+
+class EndpointResolverAdapterTest {
+    private val generatedClass: String
+
+    init {
+        val model =
+            """
+            namespace com.test
+            
+            use smithy.rules#endpointRuleSet
+            use smithy.rules#operationContextParams
+            
+            @endpointRuleSet(
+                version: "1.0",
+                parameters: {
+                    Foo: {
+                        type: "stringArray",
+                        documentation: "A foo",
+                        required: false,
+                    }
+                }
+                rules: []
+            )
+            service Test {
+                version: "1.0.0",
+                operations: [ DeleteObjects ],
+            }
+            
+            @operationContextParams(
+                Foo: {
+                    path: "Delete.Objects[*].Key"
+                }
+            )
+            operation DeleteObjects {
+                input: DeleteObjectsRequest
+            }
+            
+            structure DeleteObjectsRequest {
+                Delete: Delete
+            }
+            
+            structure Delete {
+                Objects: ObjectIdentifierList
+            }
+            
+            list ObjectIdentifierList {
+                member: ObjectIdentifier
+            }
+            
+            structure ObjectIdentifier {
+                Key: String
+            }
+        """.toSmithyModel()
+
+        val testCtx = model.newTestContext()
+        val writer = testCtx.newWriter()
+        EndpointResolverAdapterGenerator(testCtx.generationCtx, writer).render()
+        generatedClass = writer.toString()
+    }
+
+    @Test
+    fun testClass() {
+        val expected = """
+            internal class EndpointResolverAdapter(
+                private val config: TestClient.Config
+            ): EndpointResolver {
+        """.trimIndent()
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testResolve() {
+        val expected = """
+            override suspend fun resolve(request: ResolveEndpointRequest): Endpoint {
+                val params = resolveEndpointParams(config, request)
+                val endpoint = config.endpointProvider.resolveEndpoint(params)
+                return endpoint
+            }
+        """.formatForTest("    ")
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testResolveEndpointParams() {
+        val expected = """
+            internal fun resolveEndpointParams(config: TestClient.Config, request: ResolveEndpointRequest): TestEndpointParameters {
+                return TestEndpointParameters {
+                    val opName = request.context[SdkClientOption.OperationName]
+                    opContextBindings[opName]?.invoke(this, request)
+                }
+            }
+        """.trimIndent()
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testOpContextBindingsMap() {
+        val expected = """
+            private val opContextBindings = mapOf<String, BindOperationContextParamsFn> (
+                "DeleteObjects" to ::bindDeleteObjectsEndpointContext,
+            )
+        """.trimIndent()
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testOpContextBindingsFunction() {
+        val expected = """
+            private fun bindDeleteObjectsEndpointContext(builder: TestEndpointParameters.Builder, request: ResolveEndpointRequest): Unit {
+                val input = request.context[HttpOperationContext.OperationInput] as DeleteObjectsRequest
+                val delete = input.delete
+                val objects = delete?.objects
+                val projection = objects?.flatMap {
+                    val key = it?.key
+                    listOfNotNull(key)
+                }
+                builder.foo = projection
+            }
+        """.trimIndent()
+        generatedClass.shouldContainOnlyOnceWithDiff(expected)
+    }
+}

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointResolverAdapterTest.kt
@@ -111,6 +111,7 @@ class EndpointResolverAdapterTest {
     fun testOpContextBindingsFunction() {
         val expected = """
             private fun bindDeleteObjectsEndpointContext(builder: TestEndpointParameters.Builder, request: ResolveEndpointRequest): Unit {
+                @Suppress("UNCHECKED_CAST")
                 val input = request.context[HttpOperationContext.OperationInput] as DeleteObjectsRequest
                 val delete = input.delete
                 val objects = delete?.objects

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/OperationContextParamsTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/OperationContextParamsTest.kt
@@ -1,0 +1,115 @@
+package software.amazon.smithy.kotlin.codegen.rendering.endpoints
+
+import software.amazon.smithy.kotlin.codegen.test.*
+import kotlin.test.Test
+
+class OperationContextParamsTest {
+    private fun codegen(paramType: String, jmesPath: String, input: String): String {
+        val template =
+            """
+            namespace com.test
+            
+            use smithy.rules#endpointRuleSet
+            use smithy.rules#operationContextParams
+            
+            @endpointRuleSet(
+                version: "1.0",
+                parameters: {
+                    Foo: {
+                        type: "$paramType",
+                        documentation: "A foo",
+                        required: false,
+                    }
+                }
+                rules: []
+            )
+            service Test {
+                version: "1.0.0",
+                operations: [ TestOperation ],
+            }
+            
+            @operationContextParams(
+                Foo: {
+                    path: "$jmesPath"
+                }
+            )
+            operation TestOperation {
+                input: TestOperationRequest
+            }
+        """
+
+        val model = buildString {
+            append(template)
+            append(input)
+        }.toSmithyModel()
+
+        val testCtx = model.newTestContext()
+        val writer = testCtx.newWriter()
+        EndpointResolverAdapterGenerator(testCtx.generationCtx, writer).render()
+        return writer.toString()
+    }
+
+    @Test
+    fun testWildCardPath() {
+        val input = """
+            structure TestOperationRequest {
+                Delete: Delete
+            }
+            
+            structure Delete {
+                Objects: ObjectIdentifierList
+            }
+            
+            list ObjectIdentifierList {
+                member: ObjectIdentifier
+            }
+            
+            structure ObjectIdentifier {
+                Key: String
+            }
+        """.trimIndent()
+
+        val path = "Delete.Objects[*].Key"
+        val pathResultType = "stringArray"
+
+        val expected = """
+            val input = request.context[HttpOperationContext.OperationInput] as TestOperationRequest
+            val delete = input.delete
+            val objects = delete?.objects
+            val projection = objects?.flatMap {
+                val key = it?.key
+                listOfNotNull(key)
+            }
+            builder.foo = projection
+        """.formatForTest("    ")
+
+        codegen(pathResultType, path, input).shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun testKeysFunctionPath() {
+        val input = """
+            structure TestOperationRequest {
+                Object: Object
+            }
+            
+            structure Object {
+                Key1: String,
+                Key2: String,
+                Key3: String,
+            }
+        """.trimIndent()
+
+        val path = "keys(Object)"
+        val pathResultType = "stringArray"
+
+        val expected = """
+            val input = request.context[HttpOperationContext.OperationInput] as TestOperationRequest
+            val object = input.object
+            val keys = listOf("Key1", "Key2", "Key3")
+            builder.foo = keys
+        """.formatForTest("    ")
+
+        codegen(pathResultType, path, input).shouldContainOnlyOnceWithDiff(expected)
+    }
+}

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/OperationContextParamsTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/OperationContextParamsTest.kt
@@ -73,6 +73,7 @@ class OperationContextParamsTest {
         val pathResultType = "stringArray"
 
         val expected = """
+            @Suppress("UNCHECKED_CAST")
             val input = request.context[HttpOperationContext.OperationInput] as TestOperationRequest
             val delete = input.delete
             val objects = delete?.objects
@@ -104,6 +105,7 @@ class OperationContextParamsTest {
         val pathResultType = "stringArray"
 
         val expected = """
+            @Suppress("UNCHECKED_CAST")
             val input = request.context[HttpOperationContext.OperationInput] as TestOperationRequest
             val object = input.object
             val keys = listOf("Key1", "Key2", "Key3")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Add support for the [operationContextParams](https://smithy.io/2.0/additional-specs/rules-engine/parameters.html#smithy-rules-operationcontextparams-trait) trait



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
