### PR TITLE
feat: add more conversion methods for JVM streams

### DIFF
--- a/.changes/9a48ae92-96dc-48f4-995b-5faa00f890cd.json
+++ b/.changes/9a48ae92-96dc-48f4-995b-5faa00f890cd.json
@@ -1,0 +1,8 @@
+{
+    "id": "9a48ae92-96dc-48f4-995b-5faa00f890cd",
+    "type": "feature",
+    "description": "Add new Kotlin/JVM methods for converting `InputStream` to `ByteStream` and for writing `ByteStream` to `OutputStream`",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1352"
+    ]
+}


### PR DESCRIPTION
## Issue \#

Closes https://github.com/awslabs/aws-sdk-kotlin/issues/1352

## Description of changes

This change adds new methods for converting to/from `ByteStream` and JVM streams:
* `InputStream.asByteStream`: Wrap an `InputStream` as a `ByteStream`
* `ByteStream.fromInputStream`: Alias for `InputStream.asByteStream`
* `ByteStream.writeToOutputStream`: Writes the contents of a `ByteStream` to an `OutputStream`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
