### PR TITLE
fix: correctly redact sensitive data in lists/maps

### DIFF
--- a/.changes/30110eeb-0708-45b6-973f-960dc6062ce6.json
+++ b/.changes/30110eeb-0708-45b6-973f-960dc6062ce6.json
@@ -1,0 +1,5 @@
+{
+    "id": "30110eeb-0708-45b6-973f-960dc6062ce6",
+    "type": "bugfix",
+    "description": "Correctly redact sensitive data in lists and maps"
+}

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
@@ -285,11 +285,38 @@ class StructureGeneratorTest {
             @sensitive
             string Baz
             
+            list BazList {
+                member: Baz
+            }
+            
+            map BazToStringMap {
+                key: Baz
+                value: String
+            }
+            
+            map StringToBazMap {
+                key: String
+                value: Baz
+            }
+            
+            map StringToBazList {
+                key: String
+                value: BazList
+            }
+            
+            list StringToBazListList {
+                member: StringToBazList
+            }
+            
             structure Foo {
                 bar: Baz,
-                @documentation("Member documentation")
                 baz: Baz,
-                qux: String
+                qux: String,
+                quux: BazList,
+                corge: BazToStringMap,
+                grault: StringToBazMap,
+                garply: StringToBazList,
+                waldo: StringToBazListList,
             }
             
         """.prependNamespaceAndService().toSmithyModel()
@@ -306,7 +333,12 @@ class StructureGeneratorTest {
                 append("Foo(")
                 append("bar=*** Sensitive Data Redacted ***,")
                 append("baz=*** Sensitive Data Redacted ***,")
-                append("qux=${'$'}qux")
+                append("corge=*** Sensitive Data Redacted ***,")
+                append("garply=*** Sensitive Data Redacted ***,")
+                append("grault=*** Sensitive Data Redacted ***,")
+                append("quux=*** Sensitive Data Redacted ***,")
+                append("qux=${'$'}qux,")
+                append("waldo=*** Sensitive Data Redacted ***")
                 append(")")
             }
         """.formatForTest()


### PR DESCRIPTION
## Issue \#

Kotlin variant of https://github.com/smithy-lang/smithy-rs/issues/3757

## Description of changes

This change widens the criteria for considering a structure field sensitive to now include lists with members marked as sensitive and maps with either keys or values marked as sensitive.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
