### PR TITLE
fix: Close CRT HttpStream on call completion

### DIFF
--- a/.changes/1ab4f8b7-5721-4024-a4dc-d0c595495bd2.json
+++ b/.changes/1ab4f8b7-5721-4024-a4dc-d0c595495bd2.json
@@ -1,0 +1,5 @@
+{
+    "id": "1ab4f8b7-5721-4024-a4dc-d0c595495bd2",
+    "type": "bugfix",
+    "description": "Close HttpStreams in CrtHttpEngine after call completion"
+}

--- a/docs/dokka-presets/scripts/accessibility.js
+++ b/docs/dokka-presets/scripts/accessibility.js
@@ -83,7 +83,9 @@ function ensureNavButtonInteractable() {
         // Make the navButton focusable, add accessibility information
         navButton.setAttribute('tabindex', '0');
         navButton.setAttribute('role', 'button');
-        navButton.setAttribute('aria-expanded', 'false');
+
+        const sideMenuPartParent = navButton.closest(".sideMenuPart")
+        navButton.setAttribute('aria-expanded', sideMenuPartParent.classList.contains('hidden') ? 'false' : 'true');
 
         // Grab the page ID, use it for aria-label and aria-controls
         const sectionName = navButton.parentElement.parentElement.getAttribute('pageid')

--- a/docs/dokka-presets/scripts/accessibility.js
+++ b/docs/dokka-presets/scripts/accessibility.js
@@ -83,10 +83,7 @@ function ensureNavButtonInteractable() {
         // Make the navButton focusable, add accessibility information
         navButton.setAttribute('tabindex', '0');
         navButton.setAttribute('role', 'button');
-
-        const sideMenuPartParent = navButton.closest(".sideMenuPart")
-        const navButtonExpanded = sideMenuPartParent ? (sideMenuPartParent.classList.contains('hidden') ? 'false' : 'true') : 'false'
-        navButton.setAttribute('aria-expanded', navButtonExpanded);
+        navButton.setAttribute('aria-expanded', 'false');
 
         // Grab the page ID, use it for aria-label and aria-controls
         const sectionName = navButton.parentElement.parentElement.getAttribute('pageid')

--- a/docs/dokka-presets/scripts/accessibility.js
+++ b/docs/dokka-presets/scripts/accessibility.js
@@ -85,7 +85,8 @@ function ensureNavButtonInteractable() {
         navButton.setAttribute('role', 'button');
 
         const sideMenuPartParent = navButton.closest(".sideMenuPart")
-        navButton.setAttribute('aria-expanded', sideMenuPartParent.classList.contains('hidden') ? 'false' : 'true');
+        const navButtonExpanded = sideMenuPartParent ? (sideMenuPartParent.classList.contains('hidden') ? 'false' : 'true') : 'false'
+        navButton.setAttribute('aria-expanded', navButtonExpanded);
 
         // Grab the page ID, use it for aria-label and aria-controls
         const sectionName = navButton.parentElement.parentElement.getAttribute('pageid')

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
@@ -79,6 +79,10 @@ public class CrtHttpEngine(public override val config: CrtHttpEngineConfig) : Ht
             }
         }
 
+        callContext.job.invokeOnCompletion {
+            stream.close()
+        }
+
         if (request.isChunked) {
             withContext(SdkDispatchers.IO) {
                 stream.sendChunkedBody(request.body)

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -149,7 +149,11 @@ internal class SdkStreamResponseHandler(
         }
 
         // short circuit, stop buffering data and discard remaining incoming bytes
-        if (isCancelled) return bodyBytesIn.len
+        if (isCancelled) {
+            crtStream?.close()
+            stream.close()
+            return bodyBytesIn.len
+        }
 
         val buffer = SdkBuffer().apply {
             val bytes = bodyBytesIn.readAll()

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -166,9 +166,11 @@ internal class SdkStreamResponseHandler(
         // stream is only valid until the end of this callback, ensure any further data being read downstream
         // doesn't call incrementWindow on a resource that has been free'd
         lock.withLock {
+            crtStream?.close()
             crtStream = null
             streamCompleted = true
         }
+        stream.close()
 
         // close the body channel
         if (errorCode != 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`HttpStream` returned from `makeRequest` ["must be closed by the user thread making this request when it's done"](https://github.com/awslabs/aws-crt-java/blob/main/src/main/java/software/amazon/awssdk/crt/http/HttpClientConnection.java#L39-L40)

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
