### PR TITLE
fix: correctly deserialize string-based enums in XML protocols

### DIFF
--- a/.changes/6a37ba36-d945-422c-a4ba-811ef498ca71.json
+++ b/.changes/6a37ba36-d945-422c-a4ba-811ef498ca71.json
@@ -1,0 +1,8 @@
+{
+    "id": "6a37ba36-d945-422c-a4ba-811ef498ca71",
+    "type": "bugfix",
+    "description": "Correctly deserialize string-based enums in XML protocols",
+    "issues": [
+        "https://github.com/smithy-lang/smithy-kotlin/issues/1125"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlParserGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlParserGenerator.kt
@@ -16,7 +16,6 @@ import software.amazon.smithy.kotlin.codegen.model.traits.SyntheticClone
 import software.amazon.smithy.kotlin.codegen.model.traits.UnwrappedXmlOutput
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.model.shapes.*
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.SparseTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.model.traits.XmlAttributeTrait

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlParserGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlParserGenerator.kt
@@ -580,7 +580,6 @@ open class XmlParserGenerator(
             target.type == ShapeType.BLOB -> writer.format("#T { it.#T() } ", RuntimeTypes.Serde.parse, RuntimeTypes.Core.Text.Encoding.decodeBase64Bytes)
             target.type == ShapeType.BOOLEAN -> writer.format("#T()", RuntimeTypes.Serde.parseBoolean)
             target.type == ShapeType.STRING && !target.hasTrait<EnumTrait>() -> {
-                println("Shape ${member.defaultName()} is a string! textExprIsResult is $textExprIsResult")
                 if (!textExprIsResult) {
                     writer.write(textExpr)
                     return
@@ -603,14 +602,11 @@ open class XmlParserGenerator(
             target.type == ShapeType.BIG_DECIMAL -> writer.format("#T()", RuntimeTypes.Serde.parseBigDecimal)
             target.type == ShapeType.BIG_INTEGER -> writer.format("#T()", RuntimeTypes.Serde.parseBigInteger)
             target.type == ShapeType.ENUM || (target.type == ShapeType.STRING && target.hasTrait<EnumTrait>()) -> {
-                println("Shape ${member.defaultName()} is an enum! textExprIsResult is $textExprIsResult")
                 if (!textExprIsResult) {
                     writer.write("#T.fromValue(#L)", ctx.symbolProvider.toSymbol(target), textExpr)
                     return
                 } else {
-                    writer.format("#T { #T.fromValue(it) } ", RuntimeTypes.Serde.parse, ctx.symbolProvider.toSymbol(target)).also {
-                        println("Shape ${member.defaultName()} is an enum, parseFn is $it")
-                    }
+                    writer.format("#T { #T.fromValue(it) } ", RuntimeTypes.Serde.parse, ctx.symbolProvider.toSymbol(target))
                 }
             }
             target.type == ShapeType.INT_ENUM -> {
@@ -618,7 +614,6 @@ open class XmlParserGenerator(
             }
             else -> error("unknown primitive member shape $member")
         }
-        println("parseFn for ${member.defaultName()}: $parseFn")
 
         val escapedErrMessage = "expected $target".replace("$", "$$")
         writer.write(textExpr)

--- a/tests/compile/build.gradle.kts
+++ b/tests/compile/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     testImplementation(project(":runtime:protocol:http"))
     testImplementation(project(":runtime:protocol:http-client-engines:http-client-engine-default"))
     testImplementation(project(":runtime:serde:serde-json"))
+    testImplementation(project(":runtime:serde:serde-xml"))
     testImplementation(project(":runtime:observability:telemetry-api"))
     testImplementation(project(":runtime:observability:telemetry-defaults"))
 

--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
@@ -175,6 +175,55 @@ class SmithySdkTest {
 
         assertEquals(KotlinCompilation.ExitCode.OK, compilationResult.exitCode, compileOutputStream.toString())
     }
+
+    // https://github.com/smithy-lang/smithy-kotlin/issues/1125
+    @Test
+    fun `it compiles models with string enums`() {
+        val model = """
+            namespace com.test
+
+            use aws.protocols#restXml
+
+            @restXml
+            service Example {
+                version: "1.0.0",
+                operations: [
+                    Foo,
+                ]
+            }
+
+            @http(method: "POST", uri: "/foo-no-input")
+            operation Foo {
+                output: FooResponse
+            }
+
+            structure FooResponse {
+                payload: StringBasedEnumList
+            }
+            
+            @enum([
+                {
+                    value: "blarg",
+                    name: "Blarg"
+                },
+                {
+                    value: "blergh",
+                    name: "Blergh"
+                }
+            ])
+            string StringBasedEnum
+            
+            list StringBasedEnumList {
+                member: StringBasedEnum
+            }
+        """.asSmithy()
+
+        val compileOutputStream = ByteArrayOutputStream()
+        val compilationResult = compileSdkAndTest(model = model, outputSink = compileOutputStream, emitSourcesToTmp = Debug.emitSourcesToTemp)
+        compileOutputStream.flush()
+
+        assertEquals(KotlinCompilation.ExitCode.OK, compilationResult.exitCode, compileOutputStream.toString())
+    }
 }
 
 /**

--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/util/CodegenTestIntegration.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/util/CodegenTestIntegration.kt
@@ -5,6 +5,7 @@
 package software.amazon.smithy.kotlin.codegen.util
 
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
+import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
 import software.amazon.smithy.kotlin.codegen.core.withBlock
@@ -20,7 +21,10 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait
  * Integration that registers protocol generators this package provides
  */
 class CodegenTestIntegration : KotlinIntegration {
-    override val protocolGenerators: List<ProtocolGenerator> = listOf(RestJsonTestProtocolGenerator())
+    override val protocolGenerators: List<ProtocolGenerator> = listOf(
+        RestJsonTestProtocolGenerator(),
+        RestXmlTestProtocolGenerator()
+    )
 }
 
 /**
@@ -70,3 +74,48 @@ class MockRestJsonProtocolClientGenerator(
     middleware: List<ProtocolMiddleware>,
     httpBindingResolver: HttpBindingResolver,
 ) : HttpProtocolClientGenerator(ctx, middleware, httpBindingResolver)
+
+/**
+ * A partial ProtocolGenerator to generate minimal sdks for tests of restXml models.
+ */
+class RestXmlTestProtocolGenerator(
+    override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS,
+    override val protocol: ShapeId = RestXmlTrait.ID,
+) : HttpBindingProtocolGenerator() {
+
+    override fun getProtocolHttpBindingResolver(model: Model, serviceShape: ServiceShape): HttpBindingResolver =
+        HttpTraitResolver(model, serviceShape, ProtocolContentTypes.consistent("application/xml"))
+
+    override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext) {
+        // NOOP
+    }
+
+    override fun getHttpProtocolClientGenerator(ctx: ProtocolGenerator.GenerationContext): HttpProtocolClientGenerator =
+        MockRestXmlProtocolClientGenerator(ctx, getHttpMiddleware(ctx), getProtocolHttpBindingResolver(ctx.model, ctx.service))
+
+    override fun structuredDataSerializer(ctx: ProtocolGenerator.GenerationContext): StructuredDataSerializerGenerator =
+        XmlSerializerGenerator(this, TimestampFormatTrait.Format.EPOCH_SECONDS)
+
+    override fun structuredDataParser(ctx: ProtocolGenerator.GenerationContext): StructuredDataParserGenerator =
+        XmlParserGenerator(TimestampFormatTrait.Format.EPOCH_SECONDS)
+
+    override fun operationErrorHandler(ctx: ProtocolGenerator.GenerationContext, op: OperationShape): Symbol =
+        op.errorHandler(ctx.settings) { writer ->
+            writer.withBlock(
+                "private fun ${op.errorHandlerName()}(context: #T, call: #T, payload: #T?): Nothing {",
+                "}",
+                RuntimeTypes.Core.ExecutionContext,
+                RuntimeTypes.Http.HttpCall,
+                KotlinTypes.ByteArray,
+            ) {
+                write("error(\"not needed for compile tests\")")
+            }
+        }
+}
+
+class MockRestXmlProtocolClientGenerator(
+    ctx: ProtocolGenerator.GenerationContext,
+    middleware: List<ProtocolMiddleware>,
+    httpBindingResolver: HttpBindingResolver,
+) : HttpProtocolClientGenerator(ctx, middleware, httpBindingResolver)
+

--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/util/CodegenTestIntegration.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/util/CodegenTestIntegration.kt
@@ -23,7 +23,7 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait
 class CodegenTestIntegration : KotlinIntegration {
     override val protocolGenerators: List<ProtocolGenerator> = listOf(
         RestJsonTestProtocolGenerator(),
-        RestXmlTestProtocolGenerator()
+        RestXmlTestProtocolGenerator(),
     )
 }
 
@@ -118,4 +118,3 @@ class MockRestXmlProtocolClientGenerator(
     middleware: List<ProtocolMiddleware>,
     httpBindingResolver: HttpBindingResolver,
 ) : HttpProtocolClientGenerator(ctx, middleware, httpBindingResolver)
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We were not distinguishing between strings and string-based enums when generating the parser for XML protocols. This PR updates the codegen to treat string shapes with the `EnumTrait` as enums.  

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Closes https://github.com/smithy-lang/smithy-kotlin/issues/1125

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
