### PR TITLE
chore: temporarily omit Micrometer telemetry provider from Brazil

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -25,6 +25,7 @@
     "ignore": [
       "aws.smithy.kotlin:http-test",
       "aws.smithy.kotlin:smithy-test",
+      "aws.smithy.kotlin:telemetry-provider-micrometer",
       "aws.smithy.kotlin:testing",
       "aws.smithy.kotlin:bom",
       "aws.smithy.kotlin:version-catalog"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change temporarily adds **telemetry-provider-micrometer** to the ignorelist for Brazil.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
