### PR TITLE
fix: correctly mark more CRT exceptions as retriable

### DIFF
--- a/.changes/1d38a75d-17ac-4e03-b287-f937356bd525.json
+++ b/.changes/1d38a75d-17ac-4e03-b287-f937356bd525.json
@@ -1,0 +1,5 @@
+{
+    "id": "1d38a75d-17ac-4e03-b287-f937356bd525",
+    "type": "bugfix",
+    "description": "Correctly mark more CRT exceptions as retriable"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/ConnectionManager.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/ConnectionManager.kt
@@ -77,8 +77,12 @@ internal class ConnectionManager(
             }
             val httpEx = when (ex) {
                 is HttpException -> ex
-                is TimeoutCancellationException -> HttpException("timed out waiting for an HTTP connection to be acquired from the pool", errorCode = HttpErrorCode.CONNECTION_ACQUIRE_TIMEOUT)
-                else -> HttpException(ex)
+                is TimeoutCancellationException -> HttpException(
+                    "timed out waiting for an HTTP connection to be acquired from the pool",
+                    errorCode = HttpErrorCode.CONNECTION_ACQUIRE_TIMEOUT,
+                    retryable = true,
+                )
+                else -> HttpException(ex, retryable = true)
             }
 
             throw httpEx

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -119,15 +119,19 @@ internal suspend fun HttpStream.sendChunkedBody(body: HttpBody) {
     }
 }
 
+internal fun crtException(errorCode: Int, errorName: String? = CRT.errorName(errorCode), cause: Throwable? = null) =
+    HttpException(
+        message = fmtCrtErrorMessage(errorCode),
+        cause = cause,
+        errorCode = mapCrtErrorCode(errorName),
+        retryable = isRetryable(errorCode, errorName),
+    )
+
 internal inline fun <T> mapCrtException(block: () -> T): T =
     try {
         block()
     } catch (ex: CrtRuntimeException) {
-        throw HttpException(
-            message = fmtCrtErrorMessage(ex.errorCode),
-            errorCode = mapCrtErrorCode(ex.errorName),
-            retryable = isRetryable(ex.errorCode, ex.errorName),
-        )
+        throw crtException(ex.errorCode, ex.errorName, ex)
     }
 
 internal fun fmtCrtErrorMessage(errorCode: Int): String {


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Some of the places CRT exceptions are thrown don't correctly set the `ErrorMetadata.Retryable` attribute. This change updates some of those exceptions in the **smithy-kotlin** HTTP engine layer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
