### PR TITLE
fix: stop including playground.js in Dokka pages and correctly filter for internal APIs

### DIFF
--- a/dokka-smithy/src/main/kotlin/aws/smithy/kotlin/dokka/DisablePlaygroundIntegration.kt
+++ b/dokka-smithy/src/main/kotlin/aws/smithy/kotlin/dokka/DisablePlaygroundIntegration.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.dokka
+
+import org.jetbrains.dokka.pages.RootPageNode
+import org.jetbrains.dokka.plugability.DokkaContext
+import org.jetbrains.dokka.transformers.pages.PageTransformer
+
+@Suppress("UNUSED_PARAMETER") // `context` is required by the `provides` DSL method for installing transformers
+class DisablePlaygroundIntegration(context: DokkaContext) : PageTransformer {
+    override fun invoke(input: RootPageNode) = input.transformContentPagesTree { page ->
+        page.modified(
+            content = page.content,
+            embeddedResources = page.embeddedResources.filterNot { "unpkg.com" in it },
+        )
+    }
+}

--- a/dokka-smithy/src/main/kotlin/aws/smithy/kotlin/dokka/FilterInternalApis.kt
+++ b/dokka-smithy/src/main/kotlin/aws/smithy/kotlin/dokka/FilterInternalApis.kt
@@ -16,14 +16,14 @@ import org.jetbrains.dokka.plugability.DokkaContext
 class FilterInternalApis(context: DokkaContext) : SuppressedByConditionDocumentableFilterTransformer(context) {
     override fun shouldBeSuppressed(d: Documentable): Boolean {
         val isInternal = when (d) {
-            is DClass -> d.isInternalSdk()
-            is DObject -> d.isInternalSdk()
-            is DTypeAlias -> d.isInternalSdk()
-            is DFunction -> d.isInternalSdk()
-            is DProperty -> d.isInternalSdk()
-            is DEnum -> d.isInternalSdk()
-            is DEnumEntry -> d.isInternalSdk()
-            is DTypeParameter -> d.isInternalSdk()
+            is DClass -> d.isInternalSdk
+            is DObject -> d.isInternalSdk
+            is DTypeAlias -> d.isInternalSdk
+            is DFunction -> d.isInternalSdk
+            is DProperty -> d.isInternalSdk
+            is DEnum -> d.isInternalSdk
+            is DEnumEntry -> d.isInternalSdk
+            is DTypeParameter -> d.isInternalSdk
             else -> false
         }
 
@@ -33,12 +33,10 @@ class FilterInternalApis(context: DokkaContext) : SuppressedByConditionDocumenta
     }
 }
 
-fun <T> T.isInternalSdk() where T : WithExtraProperties<out Documentable> =
-    internalAnnotation != null
-
-val <T> T.internalAnnotation where T : WithExtraProperties<out Documentable>
-    get() = extra[Annotations]?.let { annotations ->
-        annotations.directAnnotations.values.flatten().firstOrNull {
-            it.dri.toString() == "aws.smithy.kotlin.runtime.InternalApi///PointingToDeclaration/"
-        }
-    }
+private val <T> T.isInternalSdk: Boolean where T : WithExtraProperties<out Documentable>
+    get() = extra[Annotations]
+        ?.directAnnotations
+        .orEmpty()
+        .values
+        .flatten()
+        .any { it.dri.classNames == "InternalApi" }

--- a/dokka-smithy/src/main/kotlin/aws/smithy/kotlin/dokka/SmithyDokkaPlugin.kt
+++ b/dokka-smithy/src/main/kotlin/aws/smithy/kotlin/dokka/SmithyDokkaPlugin.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.dokka
 
+import org.jetbrains.dokka.CoreExtensions
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.plugability.DokkaPlugin
 import org.jetbrains.dokka.plugability.DokkaPluginApiPreview
@@ -28,6 +29,12 @@ class SmithyDokkaPlugin : DokkaPlugin() {
     // https://github.com/Kotlin/dokka/issues/2741
     val disableSearch by extending {
         dokkaBase.htmlPreprocessors providing ::NoOpSearchbarDataInstaller override dokkaBase.baseSearchbarDataInstaller
+    }
+
+    val disablePlaygroundIntegration by extending {
+        CoreExtensions.pageTransformer providing ::DisablePlaygroundIntegration order {
+            after(dokkaBase.defaultSamplesTransformer)
+        }
     }
 
     @OptIn(DokkaPluginApiPreview::class)


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change fixes two Dokka problems:
* Stop including **playground.js** in generated HTML pages
* Correctly filter for internal-only APIs which shouldn't get Dokka pages

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
