### PR TITLE
fix: paginator generator nullability bug caused by documents

### DIFF
--- a/.changes/f71f083b-6e5f-4a3c-9069-464b1f9f6d36.json
+++ b/.changes/f71f083b-6e5f-4a3c-9069-464b1f9f6d36.json
@@ -1,0 +1,5 @@
+{
+    "id": "f71f083b-6e5f-4a3c-9069-464b1f9f6d36",
+    "type": "bugfix",
+    "description": "Fix paginator generator nullability unreliablity when collecting flows of collection types like map or list"
+}

--- a/.changes/f71f083b-6e5f-4a3c-9069-464b1f9f6d36.json
+++ b/.changes/f71f083b-6e5f-4a3c-9069-464b1f9f6d36.json
@@ -1,5 +1,5 @@
 {
     "id": "f71f083b-6e5f-4a3c-9069-464b1f9f6d36",
     "type": "bugfix",
-    "description": "Fix paginator generator `List<Document>` nullability"
+    "description": "Fix paginator generator `List<*>` nullability"
 }

--- a/.changes/f71f083b-6e5f-4a3c-9069-464b1f9f6d36.json
+++ b/.changes/f71f083b-6e5f-4a3c-9069-464b1f9f6d36.json
@@ -1,5 +1,5 @@
 {
     "id": "f71f083b-6e5f-4a3c-9069-464b1f9f6d36",
     "type": "bugfix",
-    "description": "Fix paginator generator `List<*>` nullability"
+    "description": "Fix paginator generator `List<*>` & `Map.Entry<String, *>` nullability"
 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -166,7 +166,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         val fullyQualifiedKeyType = keyReference.fullName
 
         val valueReference = toSymbol(shape.value)
-        val valueSuffix = if (valueReference.isNullable) "?" else ""
+        val valueSuffix = if (valueReference.isNullable || shape.isSparse) "?" else ""
         val valueType = "${valueReference.name}$valueSuffix"
         val fullyQualifiedValueType = "${valueReference.fullName}$valueSuffix"
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
@@ -274,7 +274,7 @@ private fun getItemDescriptorOrNull(paginationInfo: PaginationInfo, ctx: Codegen
     val (collectionLiteral, targetMember) = when (itemMember) {
         is MapShape -> {
             val symbol = ctx.symbolProvider.toSymbol(itemMember)
-            val entryExpression = symbol.expectProperty(SymbolProperty.ENTRY_EXPRESSION) as String + if (isSparse) "?" else ""
+            val entryExpression = symbol.expectProperty(SymbolProperty.ENTRY_EXPRESSION) as String
             entryExpression to itemMember
         }
         is CollectionShape -> {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
@@ -273,14 +273,15 @@ private fun getItemDescriptorOrNull(paginationInfo: PaginationInfo, ctx: Codegen
     val isSparse = itemMember.isSparse
     val (collectionLiteral, targetMember) = when (itemMember) {
         is MapShape -> {
-            val literal = ctx.symbolProvider.toSymbol(itemMember)
-                .expectProperty(SymbolProperty.ENTRY_EXPRESSION) as String + if (isSparse) "?" else ""
-            literal to itemMember
+            val symbol = ctx.symbolProvider.toSymbol(itemMember)
+            val entryExpression = symbol.expectProperty(SymbolProperty.ENTRY_EXPRESSION) as String + if (isSparse) "?" else ""
+            entryExpression to itemMember
         }
         is CollectionShape -> {
-            val symbol = ctx.symbolProvider.toSymbol(ctx.model.expectShape(itemMember.member.target))
+            val target = ctx.model.expectShape(itemMember.member.target)
+            val symbol = ctx.symbolProvider.toSymbol(target)
             val literal = symbol.name + if (symbol.isNullable || isSparse) "?" else ""
-            literal to ctx.model.expectShape(itemMember.member.target)
+            literal to target
         }
         else -> error("Unexpected shape type ${itemMember.type}")
     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -950,11 +950,11 @@ class PaginatorGeneratorTest {
             }
             
             structure ListFunctionsResponse {
-                Functions: FunctionConfigurationList,
+                Functions: FunctionConfigurationMap,
                 NextMarker: String
             }
             
-            map FunctionConfigurationList {
+            map FunctionConfigurationMap {
                 key: String
                 value: FunctionConfiguration
             }
@@ -979,7 +979,7 @@ class PaginatorGeneratorTest {
         val actual = testManifest.expectFileString("src/main/kotlin/com/test/paginators/Paginators.kt")
 
         val expectedCode = """
-            @JvmName("listFunctionsResponseFunctionConfigurationList")
+            @JvmName("listFunctionsResponseFunctionConfigurationMap")
             public fun Flow<ListFunctionsResponse>.functions(): Flow<Map.Entry<String, Document?>> =
                 transform() { response ->
                     response.functions?.forEach {
@@ -1026,12 +1026,12 @@ class PaginatorGeneratorTest {
             }
 
             structure ListFunctionsResponse {
-                Functions: FunctionConfigurationList,
+                Functions: FunctionConfigurationMap,
                 NextMarker: String
             }
 
             @sparse
-            map FunctionConfigurationList {
+            map FunctionConfigurationMap {
                 key: String
                 value: FunctionConfiguration
             }
@@ -1056,7 +1056,7 @@ class PaginatorGeneratorTest {
         val actual = testManifest.expectFileString("src/main/kotlin/com/test/paginators/Paginators.kt")
 
         val expectedCode = """
-            @JvmName("listFunctionsResponseFunctionConfigurationList")
+            @JvmName("listFunctionsResponseFunctionConfigurationMap")
             public fun Flow<ListFunctionsResponse>.functions(): Flow<Map.Entry<String, Document?>?> =
                 transform() { response ->
                     response.functions?.forEach {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -1057,7 +1057,84 @@ class PaginatorGeneratorTest {
 
         val expectedCode = """
             @JvmName("listFunctionsResponseFunctionConfigurationMap")
-            public fun Flow<ListFunctionsResponse>.functions(): Flow<Map.Entry<String, Document?>?> =
+            public fun Flow<ListFunctionsResponse>.functions(): Flow<Map.Entry<String, Document?>> =
+                transform() { response ->
+                    response.functions?.forEach {
+                        emit(it)
+                    }
+                }
+        """.trimIndent()
+        actual.shouldContainOnlyOnceWithDiff(expectedCode)
+    }
+
+    @Test
+    fun testRenderPaginatorWithSparseStringMap() {
+        val testModelWithItems = """
+            namespace com.test
+
+            use aws.protocols#restJson1
+
+            service Lambda {
+                operations: [ListFunctions]
+            }
+
+            @paginated(
+                inputToken: "Marker",
+                outputToken: "NextMarker",
+                pageSize: "MaxItems",
+                items: "Functions"
+            )
+            @readonly
+            @http(method: "GET", uri: "/functions", code: 200)
+            operation ListFunctions {
+                input: ListFunctionsRequest,
+                output: ListFunctionsResponse
+            }
+
+            structure ListFunctionsRequest {
+                @httpQuery("FunctionVersion")
+                FunctionVersion: String,
+                @httpQuery("Marker")
+                Marker: String,
+                @httpQuery("MasterRegion")
+                MasterRegion: String,
+                @httpQuery("MaxItems")
+                MaxItems: Integer
+            }
+
+            structure ListFunctionsResponse {
+                Functions: FunctionConfigurationMap,
+                NextMarker: String
+            }
+
+            @sparse
+            map FunctionConfigurationMap {
+                key: String
+                value: FunctionConfiguration
+            }
+
+            string FunctionConfiguration
+        """.toSmithyModel()
+        val testContextWithItems = testModelWithItems.newTestContext("Lambda", "com.test")
+
+        val codegenContextWithItems = object : CodegenContext {
+            override val model: Model = testContextWithItems.generationCtx.model
+            override val symbolProvider: SymbolProvider = testContextWithItems.generationCtx.symbolProvider
+            override val settings: KotlinSettings = testContextWithItems.generationCtx.settings
+            override val protocolGenerator: ProtocolGenerator = testContextWithItems.generator
+            override val integrations: List<KotlinIntegration> = testContextWithItems.generationCtx.integrations
+        }
+
+        val unit = PaginatorGenerator()
+        unit.writeAdditionalFiles(codegenContextWithItems, testContextWithItems.generationCtx.delegator)
+
+        testContextWithItems.generationCtx.delegator.flushWriters()
+        val testManifest = testContextWithItems.generationCtx.delegator.fileManifest as MockManifest
+        val actual = testManifest.expectFileString("src/main/kotlin/com/test/paginators/Paginators.kt")
+
+        val expectedCode = """
+            @JvmName("listFunctionsResponseFunctionConfigurationMap")
+            public fun Flow<ListFunctionsResponse>.functions(): Flow<Map.Entry<String, String?>> =
                 transform() { response ->
                     response.functions?.forEach {
                         emit(it)

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -762,4 +762,308 @@ class PaginatorGeneratorTest {
 
         actual.shouldContainOnlyOnceWithDiff(expected)
     }
+
+    @Test
+    fun testRenderPaginatorWithDocumentList() {
+        val testModelWithItems = """
+            namespace com.test
+            
+            use aws.protocols#restJson1
+            
+            service Lambda {
+                operations: [ListFunctions]
+            }
+            
+            @paginated(
+                inputToken: "Marker",
+                outputToken: "NextMarker",
+                pageSize: "MaxItems",
+                items: "Functions"
+            )
+            @readonly
+            @http(method: "GET", uri: "/functions", code: 200)
+            operation ListFunctions {
+                input: ListFunctionsRequest,
+                output: ListFunctionsResponse
+            }
+            
+            structure ListFunctionsRequest {
+                @httpQuery("FunctionVersion")
+                FunctionVersion: String,
+                @httpQuery("Marker")
+                Marker: String,
+                @httpQuery("MasterRegion")
+                MasterRegion: String,
+                @httpQuery("MaxItems")
+                MaxItems: Integer
+            }
+            
+            structure ListFunctionsResponse {
+                Functions: FunctionConfigurationList,
+                NextMarker: String
+            }
+            
+            list FunctionConfigurationList {
+                member: FunctionConfiguration
+            }
+            
+            document FunctionConfiguration
+        """.toSmithyModel()
+        val testContextWithItems = testModelWithItems.newTestContext("Lambda", "com.test")
+
+        val codegenContextWithItems = object : CodegenContext {
+            override val model: Model = testContextWithItems.generationCtx.model
+            override val symbolProvider: SymbolProvider = testContextWithItems.generationCtx.symbolProvider
+            override val settings: KotlinSettings = testContextWithItems.generationCtx.settings
+            override val protocolGenerator: ProtocolGenerator = testContextWithItems.generator
+            override val integrations: List<KotlinIntegration> = testContextWithItems.generationCtx.integrations
+        }
+
+        val unit = PaginatorGenerator()
+        unit.writeAdditionalFiles(codegenContextWithItems, testContextWithItems.generationCtx.delegator)
+
+        testContextWithItems.generationCtx.delegator.flushWriters()
+        val testManifest = testContextWithItems.generationCtx.delegator.fileManifest as MockManifest
+        val actual = testManifest.expectFileString("src/main/kotlin/com/test/paginators/Paginators.kt")
+
+        val expectedCode = """
+            @JvmName("listFunctionsResponseFunctionConfiguration")
+            public fun Flow<ListFunctionsResponse>.functions(): Flow<Document?> =
+                transform() { response ->
+                    response.functions?.forEach {
+                        emit(it)
+                    }
+                }
+        """.trimIndent()
+        actual.shouldContainOnlyOnceWithDiff(expectedCode)
+    }
+
+    @Test
+    fun testRenderPaginatorWithSparseDocumentList() {
+        val testModelWithItems = """
+            namespace com.test
+            
+            use aws.protocols#restJson1
+            
+            service Lambda {
+                operations: [ListFunctions]
+            }
+            
+            @paginated(
+                inputToken: "Marker",
+                outputToken: "NextMarker",
+                pageSize: "MaxItems",
+                items: "Functions"
+            )
+            @readonly
+            @http(method: "GET", uri: "/functions", code: 200)
+            operation ListFunctions {
+                input: ListFunctionsRequest,
+                output: ListFunctionsResponse
+            }
+            
+            structure ListFunctionsRequest {
+                @httpQuery("FunctionVersion")
+                FunctionVersion: String,
+                @httpQuery("Marker")
+                Marker: String,
+                @httpQuery("MasterRegion")
+                MasterRegion: String,
+                @httpQuery("MaxItems")
+                MaxItems: Integer
+            }
+            
+            structure ListFunctionsResponse {
+                Functions: FunctionConfigurationList,
+                NextMarker: String
+            }
+            
+            @sparse
+            list FunctionConfigurationList {
+                member: FunctionConfiguration
+            }
+            
+            document FunctionConfiguration
+        """.toSmithyModel()
+        val testContextWithItems = testModelWithItems.newTestContext("Lambda", "com.test")
+
+        val codegenContextWithItems = object : CodegenContext {
+            override val model: Model = testContextWithItems.generationCtx.model
+            override val symbolProvider: SymbolProvider = testContextWithItems.generationCtx.symbolProvider
+            override val settings: KotlinSettings = testContextWithItems.generationCtx.settings
+            override val protocolGenerator: ProtocolGenerator = testContextWithItems.generator
+            override val integrations: List<KotlinIntegration> = testContextWithItems.generationCtx.integrations
+        }
+
+        val unit = PaginatorGenerator()
+        unit.writeAdditionalFiles(codegenContextWithItems, testContextWithItems.generationCtx.delegator)
+
+        testContextWithItems.generationCtx.delegator.flushWriters()
+        val testManifest = testContextWithItems.generationCtx.delegator.fileManifest as MockManifest
+        val actual = testManifest.expectFileString("src/main/kotlin/com/test/paginators/Paginators.kt")
+
+        val expectedCode = """
+            @JvmName("listFunctionsResponseFunctionConfiguration")
+            public fun Flow<ListFunctionsResponse>.functions(): Flow<Document?> =
+                transform() { response ->
+                    response.functions?.forEach {
+                        emit(it)
+                    }
+                }
+        """.trimIndent()
+        actual.shouldContainOnlyOnceWithDiff(expectedCode)
+    }
+
+    @Test
+    fun testRenderPaginatorWithDocumentMap() {
+        val testModelWithItems = """
+            namespace com.test
+            
+            use aws.protocols#restJson1
+            
+            service Lambda {
+                operations: [ListFunctions]
+            }
+            
+            @paginated(
+                inputToken: "Marker",
+                outputToken: "NextMarker",
+                pageSize: "MaxItems",
+                items: "Functions"
+            )
+            @readonly
+            @http(method: "GET", uri: "/functions", code: 200)
+            operation ListFunctions {
+                input: ListFunctionsRequest,
+                output: ListFunctionsResponse
+            }
+            
+            structure ListFunctionsRequest {
+                @httpQuery("FunctionVersion")
+                FunctionVersion: String,
+                @httpQuery("Marker")
+                Marker: String,
+                @httpQuery("MasterRegion")
+                MasterRegion: String,
+                @httpQuery("MaxItems")
+                MaxItems: Integer
+            }
+            
+            structure ListFunctionsResponse {
+                Functions: FunctionConfigurationList,
+                NextMarker: String
+            }
+            
+            map FunctionConfigurationList {
+                key: String
+                value: FunctionConfiguration
+            }
+            
+            document FunctionConfiguration
+        """.toSmithyModel()
+        val testContextWithItems = testModelWithItems.newTestContext("Lambda", "com.test")
+
+        val codegenContextWithItems = object : CodegenContext {
+            override val model: Model = testContextWithItems.generationCtx.model
+            override val symbolProvider: SymbolProvider = testContextWithItems.generationCtx.symbolProvider
+            override val settings: KotlinSettings = testContextWithItems.generationCtx.settings
+            override val protocolGenerator: ProtocolGenerator = testContextWithItems.generator
+            override val integrations: List<KotlinIntegration> = testContextWithItems.generationCtx.integrations
+        }
+
+        val unit = PaginatorGenerator()
+        unit.writeAdditionalFiles(codegenContextWithItems, testContextWithItems.generationCtx.delegator)
+
+        testContextWithItems.generationCtx.delegator.flushWriters()
+        val testManifest = testContextWithItems.generationCtx.delegator.fileManifest as MockManifest
+        val actual = testManifest.expectFileString("src/main/kotlin/com/test/paginators/Paginators.kt")
+
+        val expectedCode = """
+            @JvmName("listFunctionsResponseFunctionConfigurationList")
+            public fun Flow<ListFunctionsResponse>.functions(): Flow<Map.Entry<String, Document?>> =
+                transform() { response ->
+                    response.functions?.forEach {
+                        emit(it)
+                    }
+                }
+        """.trimIndent()
+        actual.shouldContainOnlyOnceWithDiff(expectedCode)
+    }
+
+    @Test
+    fun testRenderPaginatorWithSparseDocumentMap() {
+        val testModelWithItems = """
+            namespace com.test
+
+            use aws.protocols#restJson1
+
+            service Lambda {
+                operations: [ListFunctions]
+            }
+
+            @paginated(
+                inputToken: "Marker",
+                outputToken: "NextMarker",
+                pageSize: "MaxItems",
+                items: "Functions"
+            )
+            @readonly
+            @http(method: "GET", uri: "/functions", code: 200)
+            operation ListFunctions {
+                input: ListFunctionsRequest,
+                output: ListFunctionsResponse
+            }
+
+            structure ListFunctionsRequest {
+                @httpQuery("FunctionVersion")
+                FunctionVersion: String,
+                @httpQuery("Marker")
+                Marker: String,
+                @httpQuery("MasterRegion")
+                MasterRegion: String,
+                @httpQuery("MaxItems")
+                MaxItems: Integer
+            }
+
+            structure ListFunctionsResponse {
+                Functions: FunctionConfigurationList,
+                NextMarker: String
+            }
+
+            @sparse
+            map FunctionConfigurationList {
+                key: String
+                value: FunctionConfiguration
+            }
+
+            document FunctionConfiguration
+        """.toSmithyModel()
+        val testContextWithItems = testModelWithItems.newTestContext("Lambda", "com.test")
+
+        val codegenContextWithItems = object : CodegenContext {
+            override val model: Model = testContextWithItems.generationCtx.model
+            override val symbolProvider: SymbolProvider = testContextWithItems.generationCtx.symbolProvider
+            override val settings: KotlinSettings = testContextWithItems.generationCtx.settings
+            override val protocolGenerator: ProtocolGenerator = testContextWithItems.generator
+            override val integrations: List<KotlinIntegration> = testContextWithItems.generationCtx.integrations
+        }
+
+        val unit = PaginatorGenerator()
+        unit.writeAdditionalFiles(codegenContextWithItems, testContextWithItems.generationCtx.delegator)
+
+        testContextWithItems.generationCtx.delegator.flushWriters()
+        val testManifest = testContextWithItems.generationCtx.delegator.fileManifest as MockManifest
+        val actual = testManifest.expectFileString("src/main/kotlin/com/test/paginators/Paginators.kt")
+
+        val expectedCode = """
+            @JvmName("listFunctionsResponseFunctionConfigurationList")
+            public fun Flow<ListFunctionsResponse>.functions(): Flow<Map.Entry<String, Document?>?> =
+                transform() { response ->
+                    response.functions?.forEach {
+                        emit(it)
+                    }
+                }
+        """.trimIndent()
+        actual.shouldContainOnlyOnceWithDiff(expectedCode)
+    }
 }


### PR DESCRIPTION
## Issue \#
The paginator generator is not code-generating nullable literals for item paginators of lists that have values that are nullable. It will only code-generate nullability if the list is marked as [sparse](https://smithy.io/2.0/spec/type-refinement-traits.html#sparse-trait) and not check if the list has values that are nullable.

Lists are not supposed to contain nullable items unless marked as `sparse`, so this is non-modeled behavior that we were not looking for but is necessary because [documents](https://smithy.io/2.0/spec/simple-types.html#document) are always nullable in smithy kotlin.

## Description of changes
The paginator generator now checks if the collection is made of nullable symbols and code generates nullability

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
