### PR TITLE
fix: disable smoke tests temporarily until other codegen issues are fixed

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -12,4 +12,4 @@ software.amazon.smithy.kotlin.codegen.rendering.endpoints.discovery.EndpointDisc
 software.amazon.smithy.kotlin.codegen.rendering.endpoints.SdkEndpointBuiltinIntegration
 software.amazon.smithy.kotlin.codegen.rendering.compression.RequestCompressionIntegration
 software.amazon.smithy.kotlin.codegen.rendering.auth.SigV4AsymmetricAuthSchemeIntegration
-software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestsIntegration
+# software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestsIntegration


### PR DESCRIPTION
## Issue \#

(internal)

## Description of changes

Smoke test codegen is broken for some services. Disabling the integration until the underlying codegen issues are fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
