### PR TITLE
fix: documentation trait handling empty list items

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
@@ -102,11 +102,9 @@ class DocumentationPreprocessor : KotlinIntegration {
                     }
                 }
                 "li" -> {
-                    val childNode = if (node.childNodes().isNotEmpty()) node.childNode(0) else null
-
                     // If this list item holds a sublist, then we essentially just want to line break right away and
                     // render the nested list as normal.
-                    val prefix = if (childNode?.nodeName() == "ul") "\n" else ""
+                    val prefix = if (node.childNodes().firstOrNull()?.nodeName() == "ul") "\n" else ""
                     builder.append("$listPrefix+ $prefix")
                 }
                 "ul", "ol" -> {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
@@ -39,11 +39,7 @@ class DocumentationPreprocessor : KotlinIntegration {
         val parsed = parseClean(doc)
 
         val renderer = MarkdownRenderer()
-        try {
-            parsed.body().traverse(renderer)
-        } catch (e: IndexOutOfBoundsException) {
-            throw Exception("These are the docs causing issues: \n" + doc)
-        }
+        parsed.body().traverse(renderer)
         return renderer.text()
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
@@ -39,7 +39,11 @@ class DocumentationPreprocessor : KotlinIntegration {
         val parsed = parseClean(doc)
 
         val renderer = MarkdownRenderer()
-        parsed.body().traverse(renderer)
+        try {
+            parsed.body().traverse(renderer)
+        } catch (e: IndexOutOfBoundsException) {
+            throw Exception("These are the docs causing issues: \n" + doc)
+        }
         return renderer.text()
     }
 
@@ -102,9 +106,11 @@ class DocumentationPreprocessor : KotlinIntegration {
                     }
                 }
                 "li" -> {
+                    val childNode = if (node.childNodes().isNotEmpty()) node.childNode(0) else null
+
                     // If this list item holds a sublist, then we essentially just want to line break right away and
                     // render the nested list as normal.
-                    val prefix = if (node.childNode(0).nodeName() == "ul") "\n" else ""
+                    val prefix = if (childNode?.nodeName() == "ul") "\n" else ""
                     builder.append("$listPrefix+ $prefix")
                 }
                 "ul", "ol" -> {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
@@ -95,6 +95,17 @@ class DocumentationPreprocessorTest {
     }
 
     @Test
+    fun `it renders lists with empty list items`() {
+        val input = "<p>an unordered list with empty list items:</p><ul><li></li><li></li></ul>"
+        val expected = """
+        an unordered list with empty list items:
+        + 
+        +
+        """.trimIndent()
+        inputTest(input, expected)
+    }
+
+    @Test
     fun `it renders basic formatters`() {
         val input = "<strong>bold text</strong><br/><em>italic text</em>"
         val expected = """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Graceful handling of empty list items in documentation trait 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
