### PR TITLE
fix: http call waiting for idle connection monitor to finish

### DIFF
--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
 
         all {
             languageSettings.optIn("aws.smithy.kotlin.runtime.InternalApi")
+            languageSettings.optIn("okhttp3.ExperimentalOkHttpApi")
         }
     }
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
@@ -36,7 +36,6 @@ kotlin {
 
         all {
             languageSettings.optIn("aws.smithy.kotlin.runtime.InternalApi")
-            languageSettings.optIn("okhttp3.ExperimentalOkHttpApi")
         }
     }
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
@@ -5,18 +5,10 @@
 package aws.smithy.kotlin.runtime.http.engine.okhttp
 
 import aws.smithy.kotlin.runtime.telemetry.logging.logger
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import okhttp3.Call
 import okhttp3.Connection
 import okhttp3.ConnectionListener
-import okhttp3.ExperimentalOkHttpApi
 import okhttp3.internal.closeQuietly
 import okio.EOFException
 import okio.buffer
@@ -24,13 +16,19 @@ import okio.source
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 import kotlin.time.measureTime
 
-@OptIn(ExperimentalOkHttpApi::class)
 internal class ConnectionIdleMonitor(val pollInterval: Duration) : ConnectionListener() {
+    private val monitorScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val monitors = ConcurrentHashMap<Connection, Job>()
+
+    fun close(): Unit = runBlocking {
+        monitors.values.forEach { it.cancelAndJoin() }
+        monitorScope.cancel()
+    }
 
     private fun Call.callContext() =
         request()
@@ -58,12 +56,11 @@ internal class ConnectionIdleMonitor(val pollInterval: Duration) : ConnectionLis
 
     override fun connectionReleased(connection: Connection, call: Call) {
         val connId = System.identityHashCode(connection)
-        val context = call.callContext()
-        val scope = CoroutineScope(context)
-        val monitor = scope.launch(CoroutineName("okhttp-conn-monitor-for-$connId")) {
-            doMonitor(connection)
+        val callContext = call.callContext()
+        val monitor = monitorScope.launch(CoroutineName("okhttp-conn-monitor-for-$connId")) {
+            doMonitor(connection, callContext)
         }
-        context.logger<ConnectionIdleMonitor>().trace { "Launched coroutine $monitor to monitor $connection" }
+        callContext.logger<ConnectionIdleMonitor>().trace { "Launched coroutine $monitor to monitor $connection" }
 
         // Non-locking map access is okay here because this code will only execute synchronously as part of a
         // `connectionReleased` event and will be complete before any future `connectionAcquired` event could fire for
@@ -71,8 +68,8 @@ internal class ConnectionIdleMonitor(val pollInterval: Duration) : ConnectionLis
         monitors[connection] = monitor
     }
 
-    private suspend fun doMonitor(conn: Connection) {
-        val logger = coroutineContext.logger<ConnectionIdleMonitor>()
+    private suspend fun doMonitor(conn: Connection, callContext: CoroutineContext) {
+        val logger = callContext.logger<ConnectionIdleMonitor>()
 
         val socket = conn.socket()
         val source = try {
@@ -111,6 +108,7 @@ internal class ConnectionIdleMonitor(val pollInterval: Duration) : ConnectionLis
                 logger.trace { "Attempting to reset soTimeout..." }
                 try {
                     conn.socket().soTimeout = oldTimeout
+                    logger.trace { "SoTimeout reset." }
                 } catch (e: Throwable) {
                     logger.warn(e) { "Failed to reset socket timeout on $conn. Connection may be unstable now." }
                 }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.*
 import okhttp3.Call
 import okhttp3.Connection
 import okhttp3.ConnectionListener
+import okhttp3.ExperimentalOkHttpApi
 import okhttp3.internal.closeQuietly
 import okio.EOFException
 import okio.buffer
@@ -21,13 +22,13 @@ import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 import kotlin.time.measureTime
 
+@OptIn(ExperimentalOkHttpApi::class)
 internal class ConnectionIdleMonitor(val pollInterval: Duration) : ConnectionListener() {
     private val monitorScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val monitors = ConcurrentHashMap<Connection, Job>()
 
     fun close(): Unit = runBlocking {
         monitors.values.forEach { it.cancelAndJoin() }
-        monitorScope.cancel()
     }
 
     private fun Call.callContext() =

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
@@ -109,7 +109,7 @@ internal class ConnectionIdleMonitor(val pollInterval: Duration) : ConnectionLis
                 logger.trace { "Attempting to reset soTimeout..." }
                 try {
                     conn.socket().soTimeout = oldTimeout
-                    logger.trace { "SoTimeout reset." }
+                    logger.trace { "soTimeout reset." }
                 } catch (e: Throwable) {
                     logger.warn(e) { "Failed to reset socket timeout on $conn. Connection may be unstable now." }
                 }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
@@ -28,7 +28,10 @@ internal class ConnectionIdleMonitor(val pollInterval: Duration) : ConnectionLis
     private val monitors = ConcurrentHashMap<Connection, Job>()
 
     fun close(): Unit = runBlocking {
-        monitors.values.forEach { it.cancelAndJoin() }
+        val monitorJob = requireNotNull(monitorScope.coroutineContext[Job]) {
+            "Connection idle monitor scope cannot be cancelled because it does not have a job: $this"
+        }
+        monitorJob.cancelAndJoin()
     }
 
     private fun Call.callContext() =

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -80,7 +80,7 @@ public class OkHttpEngine(
 
 private fun OkHttpEngineConfig.buildClientFromConfig(
     metrics: HttpClientMetrics,
-    poolOverride: ConnectionPool? = null
+    poolOverride: ConnectionPool? = null,
 ): OkHttpClient {
     val config = this
 
@@ -145,7 +145,7 @@ private fun OkHttpEngineConfig.buildClientFromConfig(
 // TODO - Refactor in next minor version - Move this to OkHttp4Engine and make it private
 @InternalApi
 public fun OkHttpEngineConfig.buildClient(
-    metrics: HttpClientMetrics
+    metrics: HttpClientMetrics,
 ): OkHttpClient = this.buildClientFromConfig(metrics)
 
 /**
@@ -154,7 +154,7 @@ public fun OkHttpEngineConfig.buildClient(
 // Used by OkHttpEngine - OkHttp5 does have `connectionListener`
 private fun OkHttpEngineConfig.buildClientWithConnectionListener(
     metrics: HttpClientMetrics,
-    connectionListener: ConnectionIdleMonitor?
+    connectionListener: ConnectionIdleMonitor?,
 ): OkHttpClient = this.buildClientFromConfig(
     metrics,
     ConnectionPool(
@@ -162,7 +162,7 @@ private fun OkHttpEngineConfig.buildClientWithConnectionListener(
         keepAliveDuration = this.connectionIdleTimeout.inWholeMilliseconds,
         timeUnit = TimeUnit.MILLISECONDS,
         connectionListener = connectionListener ?: ConnectionListener.NONE,
-    )
+    ),
 )
 
 private fun minTlsConnectionSpec(tlsContext: TlsContext): ConnectionSpec {

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -15,9 +15,9 @@ import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.fromEpochMilliseconds
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.job
 import okhttp3.*
+import okhttp3.ConnectionPool
 import okhttp3.coroutines.executeAsync
 import java.util.concurrent.TimeUnit
 import kotlin.time.toJavaDuration
@@ -44,7 +44,8 @@ public class OkHttpEngine(
     }
 
     private val metrics = HttpClientMetrics(TELEMETRY_SCOPE, config.telemetryProvider)
-    private val client = config.buildClient(metrics)
+    private val connectionIdleMonitor = if (config.connectionIdlePollingInterval != null) ConnectionIdleMonitor(config.connectionIdlePollingInterval) else null
+    private val client = config.buildClientWithConnectionListener(metrics, connectionIdleMonitor)
 
     override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
         val callContext = callContext()
@@ -52,7 +53,6 @@ public class OkHttpEngine(
         val engineRequest = request.toOkHttpRequest(context, callContext, metrics)
         val engineCall = client.newCall(engineRequest)
 
-        @OptIn(ExperimentalCoroutinesApi::class)
         val engineResponse = mapOkHttpExceptions { engineCall.executeAsync() }
 
         val response = engineResponse.toSdkResponse()
@@ -71,17 +71,17 @@ public class OkHttpEngine(
     }
 
     override fun shutdown() {
+        connectionIdleMonitor?.close()
         client.connectionPool.evictAll()
         client.dispatcher.executorService.shutdown()
         metrics.close()
     }
 }
 
-/**
- * Convert SDK version of HTTP configuration to OkHttp specific configuration and return the configured client
- */
-@InternalApi
-public fun OkHttpEngineConfig.buildClient(metrics: HttpClientMetrics): OkHttpClient {
+private fun OkHttpEngineConfig.buildClientFromConfig(
+    metrics: HttpClientMetrics,
+    poolOverride: ConnectionPool? = null
+): OkHttpClient {
     val config = this
 
     return OkHttpClient.Builder().apply {
@@ -99,22 +99,13 @@ public fun OkHttpEngineConfig.buildClient(metrics: HttpClientMetrics): OkHttpCli
         readTimeout(config.socketReadTimeout.toJavaDuration())
         writeTimeout(config.socketWriteTimeout.toJavaDuration())
 
-        @OptIn(ExperimentalOkHttpApi::class)
-        val connectionListener = if (config.connectionIdlePollingInterval == null) {
-            ConnectionListener.NONE
-        } else {
-            ConnectionIdleMonitor(connectionIdlePollingInterval)
-        }
-
         // use our own pool configured with the timeout settings taken from config
-        @OptIn(ExperimentalOkHttpApi::class)
         val pool = ConnectionPool(
             maxIdleConnections = 5, // The default from the no-arg ConnectionPool() constructor
             keepAliveDuration = config.connectionIdleTimeout.inWholeMilliseconds,
             TimeUnit.MILLISECONDS,
-            connectionListener = connectionListener,
         )
-        connectionPool(pool)
+        connectionPool(poolOverride ?: pool)
 
         val dispatcher = Dispatcher().apply {
             maxRequests = config.maxConcurrency.toInt()
@@ -146,6 +137,33 @@ public fun OkHttpEngineConfig.buildClient(metrics: HttpClientMetrics): OkHttpCli
         addInterceptor(MetricsInterceptor)
     }.build()
 }
+
+/**
+ * Convert SDK version of HTTP configuration to OkHttp specific configuration and return the configured client
+ */
+// Used by OkHttp4Engine - OkHttp4 does NOT have `connectionListener`
+// TODO - Refactor in next minor version - Move this to OkHttp4Engine and make it private
+@InternalApi
+public fun OkHttpEngineConfig.buildClient(
+    metrics: HttpClientMetrics
+): OkHttpClient = this.buildClientFromConfig(metrics)
+
+/**
+ * Convert SDK version of HTTP configuration to OkHttp specific configuration and return the configured client
+ */
+// Used by OkHttpEngine - OkHttp5 does have `connectionListener`
+private fun OkHttpEngineConfig.buildClientWithConnectionListener(
+    metrics: HttpClientMetrics,
+    connectionListener: ConnectionIdleMonitor?
+): OkHttpClient = this.buildClientFromConfig(
+    metrics,
+    ConnectionPool(
+        maxIdleConnections = 5, // The default from the no-arg ConnectionPool() constructor
+        keepAliveDuration = this.connectionIdleTimeout.inWholeMilliseconds,
+        timeUnit = TimeUnit.MILLISECONDS,
+        connectionListener = connectionListener ?: ConnectionListener.NONE,
+    )
+)
 
 private fun minTlsConnectionSpec(tlsContext: TlsContext): ConnectionSpec {
     val minVersion = tlsContext.minVersion ?: TlsVersion.TLS_1_2

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp4/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp4/OkHttp4Engine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp4/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp4/OkHttp4Engine.kt
@@ -70,6 +70,12 @@ public class OkHttp4Engine(
             }
         }
     }
+
+    override fun shutdown() {
+        client.connectionPool.evictAll()
+        client.dispatcher.executorService.shutdown()
+        metrics.close()
+    }
 }
 
 // Copied from okhttp3 5.x:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Original issue that sparked idle connection monitoring: https://github.com/awslabs/aws-sdk-kotlin/issues/1214
OkHttp4 was broken by idle connection monitoring: https://github.com/smithy-lang/smithy-kotlin/issues/1176

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Launching the connection monitors using the call context was causing the call to wait on the connection monitor coroutines. This fix creates a coroutine scope dedicated to connection monitors. This new scope will be cancelled/joined when the HTTP engine being used is closed.
- Noticed `shutdown` was missing from `OkHttp4Engine` so added it.
- The refactoring of `OkHttpEngineConfig.buildClient` fixes https://github.com/smithy-lang/smithy-kotlin/issues/1176 by not including `connectionListener` as part of `OkHttp4Engine`

Calling `S3` `getObject` twice went from taking ~6 sec to ~370ms
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
