### PR TITLE
fix: temporarily disable smoke test codegen

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -12,4 +12,4 @@ software.amazon.smithy.kotlin.codegen.rendering.endpoints.discovery.EndpointDisc
 software.amazon.smithy.kotlin.codegen.rendering.endpoints.SdkEndpointBuiltinIntegration
 software.amazon.smithy.kotlin.codegen.rendering.compression.RequestCompressionIntegration
 software.amazon.smithy.kotlin.codegen.rendering.auth.SigV4AsymmetricAuthSchemeIntegration
-software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestsIntegration
+# software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestsIntegration


### PR DESCRIPTION
## Issue \#

(n/a)

## Description of changes

This change disables the smoke test integration to resolve a release issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
