### PR TITLE
fix: `rpcv2Cbor` event stream requests sending incorrect `:content-type`

### DIFF
--- a/.changes/51a98f59-4a7f-4d14-8f26-4eb70a3eb1dc.json
+++ b/.changes/51a98f59-4a7f-4d14-8f26-4eb70a3eb1dc.json
@@ -1,0 +1,5 @@
+{
+    "id": "51a98f59-4a7f-4d14-8f26-4eb70a3eb1dc",
+    "type": "bugfix",
+    "description": "Fix application of `:content-type` for event stream inputs in the `smithy.protocols#rpcv2Cbor` protocol"
+}

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/RpcV2Cbor.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/RpcV2Cbor.kt
@@ -139,7 +139,12 @@ class RpcV2Cbor : AwsHttpBindingProtocolGenerator() {
         writer: KotlinWriter,
         resolver: HttpBindingResolver,
     ) {
-        writer.write("builder.headers.setMissing(\"Content-Type\", #S)", resolver.determineRequestContentType(op))
+        val contentTypeHeader = when {
+            op.isInputEventStream(ctx.model) -> "application/vnd.amazon.eventstream"
+            else -> "application/cbor"
+        }
+
+        writer.write("builder.headers.setMissing(\"Content-Type\", #S)", contentTypeHeader)
     }
 
     class RpcV2CborHttpBindingResolver(
@@ -152,7 +157,6 @@ class RpcV2Cbor : AwsHttpBindingProtocolGenerator() {
         "application/cbor",
         TimestampFormatTrait.Format.UNKNOWN,
     ) {
-
         override fun httpTrait(operationShape: OperationShape): HttpTrait = HttpTrait
             .builder()
             .code(200)
@@ -160,9 +164,6 @@ class RpcV2Cbor : AwsHttpBindingProtocolGenerator() {
             .uri(UriPattern.parse("/service/${serviceShape.id.name}/operation/${operationShape.id.name}"))
             .build()
 
-        override fun determineRequestContentType(operationShape: OperationShape): String = when {
-            operationShape.isInputEventStream(model) -> "application/vnd.amazon.eventstream"
-            else -> "application/cbor"
-        }
+        override fun determineRequestContentType(operationShape: OperationShape): String = "application/cbor"
     }
 }

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/eventstream/EventStreamParserGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/eventstream/EventStreamParserGenerator.kt
@@ -28,6 +28,7 @@ val RPC_BOUND_PROTOCOLS = setOf(
     "awsJson1_1",
     "awsQuery",
     "ec2Query",
+    "rpcv2Cbor",
 )
 
 /**

--- a/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/RpcV2CborTest.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/RpcV2CborTest.kt
@@ -20,7 +20,7 @@ class RpcV2CborTest {
         @service(sdkId: "CborExample")
         service CborExample {
             version: "1.0.0",
-            operations: [GetFoo, GetFooStreaming]
+            operations: [GetFoo, GetFooStreaming, PutFooStreaming]
         }
 
         @http(method: "POST", uri: "/foo")
@@ -34,7 +34,29 @@ class RpcV2CborTest {
             }
         }
         
+        @http(method: "POST", uri: "/put-foo-streaming")
+        operation PutFooStreaming {
+            input: PutFooStreamingInput
+        }
+        
+        structure PutFooStreamingInput {
+            room: String
+            messages: PublishEvents
+        }
+        
         // Model taken from https://smithy.io/2.0/spec/streaming.html#event-streams
+        @streaming
+        union PublishEvents {
+            message: Message
+            leave: LeaveEvent
+        }
+        
+        structure Message {
+            message: String
+        }
+        
+        structure LeaveEvent {}
+        
         @streaming
         union FooEvents {
             up: Movement
@@ -97,5 +119,28 @@ class RpcV2CborTest {
         )
         """.replaceIndent("        ")
         getFooMethod.shouldContainOnlyOnceWithDiff(expectedHeaderMutation)
+    }
+
+    @Test
+    fun testEventStreamContentTypeHeaders() {
+        val ctx = model.newTestContext("CborExample")
+
+        val generator = RpcV2Cbor()
+        generator.generateProtocolClient(ctx.generationCtx)
+
+        ctx.generationCtx.delegator.finalize()
+        ctx.generationCtx.delegator.flushWriters()
+
+        val serializer = ctx.manifest.expectFileString("/src/main/kotlin/com/test/serde/PutFooStreamingOperationSerializer.kt")
+
+        // Event stream messages should have `:content-type: application/cbor`
+        val encodeMessage = serializer.lines("private fun encodePutFooStreamingPublishEventsEventMessage(input: PublishEvents): Message = buildMessage {", "}")
+        encodeMessage.shouldContainOnlyOnceWithDiff("""
+            addHeader(":content-type", HeaderValue.String("application/cbor"))
+        """.trimIndent())
+
+        // Event stream requests should have Content-Type=application/vnd.amazon.eventstream
+        val serializeBody = serializer.lines("    override suspend fun serialize(context: ExecutionContext, input: PutFooStreamingRequest): HttpRequestBuilder {", "}")
+        serializeBody.shouldContainOnlyOnceWithDiff("""builder.headers.setMissing("Content-Type", "application/vnd.amazon.eventstream")""")
     }
 }

--- a/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/RpcV2CborTest.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/RpcV2CborTest.kt
@@ -135,9 +135,11 @@ class RpcV2CborTest {
 
         // Event stream messages should have `:content-type: application/cbor`
         val encodeMessage = serializer.lines("private fun encodePutFooStreamingPublishEventsEventMessage(input: PublishEvents): Message = buildMessage {", "}")
-        encodeMessage.shouldContainOnlyOnceWithDiff("""
+        encodeMessage.shouldContainOnlyOnceWithDiff(
+            """
             addHeader(":content-type", HeaderValue.String("application/cbor"))
-        """.trimIndent())
+            """.trimIndent(),
+        )
 
         // Event stream requests should have Content-Type=application/vnd.amazon.eventstream
         val serializeBody = serializer.lines("    override suspend fun serialize(context: ExecutionContext, input: PutFooStreamingRequest): HttpRequestBuilder {", "}")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -249,6 +249,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 if (op.isInputEventStream(ctx.model)) {
                     val eventStreamSerializeFn = eventStreamRequestHandler(ctx, op)
                     writer.write("builder.body = #T(context, input)", eventStreamSerializeFn)
+                    renderContentTypeHeader(ctx, op, writer, resolver)
                 } else {
                     renderSerializeHttpBody(ctx, op, writer)
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
