### PR TITLE
fix: correctly deserialize/render input values for smoke tests

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -78,7 +78,7 @@ class ShapeValueGenerator(
     private fun classDeclaration(writer: KotlinWriter, shape: StructureShape, block: () -> Unit) {
         val symbol = symbolProvider.toSymbol(shape)
         // invoke the generated DSL builder for the class
-        writer.writeInline("#L {", symbol.name)
+        writer.writeInline("#T {", symbol)
             .ensureNewline()
             .indent()
             .call { block() }
@@ -129,7 +129,7 @@ class ShapeValueGenerator(
         val suffix = when {
             shape.isEnum -> {
                 val symbol = symbolProvider.toSymbol(shape)
-                writer.writeInline("#L.fromValue(", symbol.name)
+                writer.writeInline("#T.fromValue(", symbol)
                 ")"
             }
 
@@ -243,14 +243,14 @@ class ShapeValueGenerator(
                 ShapeType.DOUBLE,
                 ShapeType.FLOAT,
                 -> {
-                    val symbolName = generator.symbolProvider.toSymbol(currShape).name
+                    val symbol = generator.symbolProvider.toSymbol(currShape)
                     val symbolMember = when (node.value) {
                         "Infinity" -> "POSITIVE_INFINITY"
                         "-Infinity" -> "NEGATIVE_INFINITY"
                         "NaN" -> "NaN"
-                        else -> throw CodegenException("""Cannot interpret $symbolName value "${node.value}".""")
+                        else -> throw CodegenException("""Cannot interpret $symbol value "${node.value}".""")
                     }
-                    writer.writeInline("#L", "$symbolName.$symbolMember")
+                    writer.writeInline("#T.#L", symbol, symbolMember)
                 }
 
                 ShapeType.BIG_INTEGER -> writer.writeInline("#T(#S)", RuntimeTypes.Core.Content.BigInteger, node.value)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -222,7 +222,7 @@ class ShapeValueGenerator(
                         val currSymbol = generator.symbolProvider.toSymbol(currShape)
                         val memberName = generator.symbolProvider.toMemberName(member)
                         val variantName = memberName.replaceFirstChar { c -> c.uppercaseChar() }
-                        writer.writeInline("${currSymbol.name}.$variantName(")
+                        writer.writeInline("#T.#L(", currSymbol, variantName)
                         generator.instantiateShapeInline(writer, memberShape, valueNode)
                         writer.writeInline(")")
                     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGenerator.kt
@@ -6,10 +6,9 @@ import software.amazon.smithy.kotlin.codegen.integration.SectionId
 import software.amazon.smithy.kotlin.codegen.integration.SectionKey
 import software.amazon.smithy.kotlin.codegen.model.getTrait
 import software.amazon.smithy.kotlin.codegen.model.hasTrait
-import software.amazon.smithy.kotlin.codegen.model.isStringEnumShape
+import software.amazon.smithy.kotlin.codegen.rendering.ShapeValueGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.endpoints.EndpointParametersGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.endpoints.EndpointProviderGenerator
-import software.amazon.smithy.kotlin.codegen.rendering.protocol.stringToNumber
 import software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestSectionIds.ClientConfig.EndpointParams
 import software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestSectionIds.ClientConfig.EndpointProvider
 import software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestSectionIds.ClientConfig.Name
@@ -17,7 +16,6 @@ import software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestSecti
 import software.amazon.smithy.kotlin.codegen.rendering.util.format
 import software.amazon.smithy.kotlin.codegen.utils.dq
 import software.amazon.smithy.kotlin.codegen.utils.toCamelCase
-import software.amazon.smithy.kotlin.codegen.utils.toPascalCase
 import software.amazon.smithy.kotlin.codegen.utils.topDownOperations
 import software.amazon.smithy.model.node.*
 import software.amazon.smithy.model.shapes.*
@@ -144,7 +142,7 @@ class SmokeTestsRunnerGenerator(
     }
 
     private fun renderClient(testCase: SmokeTestCase) {
-        writer.withInlineBlock("#L {", "}", service) {
+        writer.withInlineBlock("#T {", "}", service) {
             renderClientConfig(testCase)
         }
     }
@@ -180,27 +178,19 @@ class SmokeTestsRunnerGenerator(
     }
 
     private fun renderOperation(operation: OperationShape, testCase: SmokeTestCase) {
-        val operationSymbol = symbolProvider.toSymbol(model.getShape(operation.input.get()).get())
-
         writer.withBlock(".#T { client ->", "}", RuntimeTypes.Core.IO.use) {
-            withBlock("client.#L(", ")", operation.defaultName()) {
-                withBlock("#L {", "}", operationSymbol) {
-                    renderOperationParameters(operation, testCase)
+            val inputParams = testCase.params.getOrNull()
+
+            writeInline("client.#L", operation.defaultName())
+
+            if (inputParams == null) {
+                write("()")
+            } else {
+                withBlock("(", ")") {
+                    val inputShape = model.expectShape(operation.input.get())
+                    ShapeValueGenerator(model, symbolProvider).instantiateShapeInline(writer, inputShape, inputParams)
                 }
             }
-        }
-    }
-
-    private fun renderOperationParameters(operation: OperationShape, testCase: SmokeTestCase) {
-        if (!testCase.hasOperationParameters) return
-
-        val paramsToShapes = mapOperationParametersToModeledShapes(operation)
-
-        testCase.operationParameters.forEach { param ->
-            val paramName = param.key.value.toCamelCase()
-            writer.writeInline("#L = ", paramName)
-            val paramShape = paramsToShapes[paramName] ?: throw IllegalArgumentException("Unable to find shape for operation parameter '$paramName' in smoke test '${testCase.functionName}'.")
-            renderOperationParameter(paramName, param.value, paramShape, testCase)
         }
     }
 
@@ -229,56 +219,6 @@ class SmokeTestsRunnerGenerator(
 
     // Helpers
     /**
-     * Renders a [SmokeTestCase] operation parameter
-     */
-    private fun renderOperationParameter(
-        paramName: String,
-        node: Node,
-        shape: Shape,
-        testCase: SmokeTestCase,
-    ) {
-        when {
-            // String enum
-            node is StringNode && shape.isStringEnumShape -> {
-                val enumSymbol = symbolProvider.toSymbol(shape)
-                val enumValue = node.value.toPascalCase()
-                writer.write("#T.#L", enumSymbol, enumValue)
-            }
-            // Int enum
-            node is NumberNode && shape is IntEnumShape -> {
-                val enumSymbol = symbolProvider.toSymbol(shape)
-                val enumValue = node.format()
-                writer.write("#T.fromValue(#L.toInt())", enumSymbol, enumValue)
-            }
-            // Number
-            node is NumberNode && shape is NumberShape -> writer.write("#L.#L", node.format(), stringToNumber(shape))
-            // Object
-            node is ObjectNode -> {
-                val shapeSymbol = symbolProvider.toSymbol(shape)
-                writer.withBlock("#T {", "}", shapeSymbol) {
-                    node.members.forEach { member ->
-                        val memberName = member.key.value.toCamelCase()
-                        val memberShape = shape.allMembers[member.key.value] ?: throw IllegalArgumentException("Unable to find shape for operation parameter '$paramName' in smoke test '${testCase.functionName}'.")
-                        writer.writeInline("#L = ", memberName)
-                        renderOperationParameter(memberName, member.value, memberShape, testCase)
-                    }
-                }
-            }
-            // List
-            node is ArrayNode && shape is CollectionShape -> {
-                writer.withBlock("listOf(", ")") {
-                    node.elements.forEach { element ->
-                        renderOperationParameter(paramName, element, model.expectShape(shape.member.target), testCase)
-                        writer.write(",")
-                    }
-                }
-            }
-            // Everything else
-            else -> writer.write("#L", node.format())
-        }
-    }
-
-    /**
      * Tries to get the specific exception required in the failure criterion of a test.
      * If no specific exception is required we default to the generic smoke tests failure exception.
      */
@@ -303,14 +243,6 @@ class SmokeTestsRunnerGenerator(
         val testResult = "$status $service $testCase - $expectation $directive"
         writer.write("println(#S)", testResult)
     }
-
-    /**
-     * Maps an operations parameters to their shapes
-     */
-    private fun mapOperationParametersToModeledShapes(operation: OperationShape): Map<String, Shape> =
-        model.getShape(operation.inputShape).get().allMembers.map { (key, value) ->
-            key.toCamelCase() to model.getShape(value.target).get()
-        }.toMap()
 
     /**
      * Derives a function name for a [SmokeTestCase]

--- a/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -12,4 +12,4 @@ software.amazon.smithy.kotlin.codegen.rendering.endpoints.discovery.EndpointDisc
 software.amazon.smithy.kotlin.codegen.rendering.endpoints.SdkEndpointBuiltinIntegration
 software.amazon.smithy.kotlin.codegen.rendering.compression.RequestCompressionIntegration
 software.amazon.smithy.kotlin.codegen.rendering.auth.SigV4AsymmetricAuthSchemeIntegration
-# software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestsIntegration
+software.amazon.smithy.kotlin.codegen.rendering.smoketests.SmokeTestsIntegration

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
@@ -30,7 +30,8 @@ class SmokeTestsRunnerGeneratorTest {
                         }
                         vendorParamsShape: AwsVendorParams,
                         vendorParams: {
-                            region: "eu-central-1"
+                            region: "eu-central-1",
+                            uri: "https://foo.amazon.com"
                         }
                     }
                     {
@@ -109,6 +110,7 @@ class SmokeTestsRunnerGeneratorTest {
                         TestClient {
                             interceptors.add(SmokeTestsInterceptor())
                             region = "eu-central-1"
+                            uri = "https://foo.amazon.com"
                         }.use { client ->
                             client.testOperation(
                                 TestOperationRequest {
@@ -144,7 +146,6 @@ class SmokeTestsRunnerGeneratorTest {
                 
                     try {
                         TestClient {
-                
                         }.use { client ->
                             client.testOperation(
                                 TestOperationRequest {
@@ -181,7 +182,6 @@ class SmokeTestsRunnerGeneratorTest {
                     try {
                         TestClient {
                             interceptors.add(SmokeTestsInterceptor())
-                
                         }.use { client ->
                             client.testOperation(
                                 TestOperationRequest {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
@@ -106,12 +106,12 @@ class SmokeTestsRunnerGeneratorTest {
                     }
 
                     try {
-                        com.test.TestClient {
+                        TestClient {
                             interceptors.add(SmokeTestsInterceptor())
                             region = "eu-central-1"
                         }.use { client ->
                             client.testOperation(
-                                com.test.model.TestOperationRequest {
+                                TestOperationRequest {
                                     bar = "2"
                                 }
                             )
@@ -143,11 +143,11 @@ class SmokeTestsRunnerGeneratorTest {
                     }
                 
                     try {
-                        com.test.TestClient {
+                        TestClient {
                 
                         }.use { client ->
                             client.testOperation(
-                                com.test.model.TestOperationRequest {
+                                TestOperationRequest {
                                     bar = "föö"
                                 }
                             )
@@ -179,12 +179,12 @@ class SmokeTestsRunnerGeneratorTest {
                     }
                 
                     try {
-                        com.test.TestClient {
+                        TestClient {
                             interceptors.add(SmokeTestsInterceptor())
                 
                         }.use { client ->
                             client.testOperation(
-                                com.test.model.TestOperationRequest {
+                                TestOperationRequest {
                                     bar = "föö"
                                 }
                             )


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change replaces the codegen for smoke test input params with the `ShapeValueGenerator` and also makes small changes to use imported symbols rather than fully qualified ones.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
