### PR TITLE
feat: add `retryStrategy` configuration option for waiters

### DIFF
--- a/.changes/0857b6f0-0444-479f-be6b-06ef71d482a0.json
+++ b/.changes/0857b6f0-0444-479f-be6b-06ef71d482a0.json
@@ -1,7 +1,7 @@
 {
-    "id": "1c6d0436-16c3-46d6-9fb5-d9af6c119ba5",
+    "id": "0857b6f0-0444-479f-be6b-06ef71d482a0",
     "type": "feature",
-    "description": "⚠\uFE0F **IMPORTANT**: Add `retryStrategy` configuration option for waiters",
+    "description": "⚠️ **IMPORTANT**: Add `retryStrategy` configuration option for waiters",
     "issues": [
         "https://github.com/awslabs/aws-sdk-kotlin/issues/1431"
     ],

--- a/.changes/1c6d0436-16c3-46d6-9fb5-d9af6c119ba5.json
+++ b/.changes/1c6d0436-16c3-46d6-9fb5-d9af6c119ba5.json
@@ -1,0 +1,8 @@
+{
+    "id": "1c6d0436-16c3-46d6-9fb5-d9af6c119ba5",
+    "type": "feature",
+    "description": "Add `retryStrategy` configuration option for waiters",
+    "issues": [
+        "https://github.com/awslabs/aws-sdk-kotlin/issues/1431"
+    ]
+}

--- a/.changes/1c6d0436-16c3-46d6-9fb5-d9af6c119ba5.json
+++ b/.changes/1c6d0436-16c3-46d6-9fb5-d9af6c119ba5.json
@@ -1,8 +1,9 @@
 {
     "id": "1c6d0436-16c3-46d6-9fb5-d9af6c119ba5",
     "type": "feature",
-    "description": "Add `retryStrategy` configuration option for waiters",
+    "description": "⚠\uFE0F **IMPORTANT**: Add `retryStrategy` configuration option for waiters",
     "issues": [
         "https://github.com/awslabs/aws-sdk-kotlin/issues/1431"
-    ]
+    ],
+    "requiresMinorVersionBump": true
 }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
@@ -43,7 +43,7 @@ class ServiceWaitersGeneratorTest {
             /**
              * Wait until a foo exists with optional input
              */
-            public suspend fun TestClient.waitUntilFooOptionalExists(request: DescribeFooOptionalRequest = DescribeFooOptionalRequest { }): Outcome<DescribeFooOptionalResponse> {
+            public suspend fun TestClient.waitUntilFooOptionalExists(request: DescribeFooOptionalRequest = DescribeFooOptionalRequest { }, retryStrategy: RetryStrategy? = null): Outcome<DescribeFooOptionalResponse> {
         """.trimIndent()
         val methodFooter = """
                 val policy = AcceptorRetryPolicy(request, acceptors)
@@ -59,7 +59,7 @@ class ServiceWaitersGeneratorTest {
             /**
              * Wait until a foo exists with required input
              */
-            public suspend fun TestClient.waitUntilFooRequiredExists(request: DescribeFooRequiredRequest): Outcome<DescribeFooRequiredResponse> {
+            public suspend fun TestClient.waitUntilFooRequiredExists(request: DescribeFooRequiredRequest, retryStrategy: RetryStrategy? = null): Outcome<DescribeFooRequiredResponse> {
         """.trimIndent()
         listOf(
             generateService("simple-service-with-operation-waiter.smithy"),
@@ -105,7 +105,7 @@ class ServiceWaitersGeneratorTest {
     @Test
     fun testRetryStrategy() {
         val expected = """
-            val strategy = StandardRetryStrategy {
+            val strategy = retryStrategy ?: StandardRetryStrategy {
                 maxAttempts = 20
                 tokenBucket = InfiniteTokenBucket
                 delayProvider {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGeneratorTest.kt
@@ -28,7 +28,7 @@ class WaiterGeneratorTest {
     @Test
     fun testDefaultDelays() {
         val expected = """
-            val strategy = StandardRetryStrategy {
+            val strategy = retryStrategy ?: StandardRetryStrategy {
                 maxAttempts = 20
                 tokenBucket = InfiniteTokenBucket
                 delayProvider {
@@ -45,7 +45,7 @@ class WaiterGeneratorTest {
     @Test
     fun testCustomDelays() {
         val expected = """
-            val strategy = StandardRetryStrategy {
+            val strategy = retryStrategy ?: StandardRetryStrategy {
                 maxAttempts = 20
                 tokenBucket = InfiniteTokenBucket
                 delayProvider {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add optional configuration for waiters' `RetryStrategy`

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Closes https://github.com/awslabs/aws-sdk-kotlin/issues/1431 and closes https://github.com/smithy-lang/smithy-kotlin/issues/839

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
