### PR TITLE
docs: rename `awslabs/smithy-kotlin` to `smithy-lang/smithy-kotlin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 ## [1.3.8] - 08/29/2024
 
 ### Fixes
-* [#1126](https://github.com/awslabs/smithy-kotlin/issues/1126) Correct deserialization of nested map/list types in unions
+* [#1126](https://github.com/smithy-lang/smithy-kotlin/issues/1126) Correct deserialization of nested map/list types in unions
 
 ## [1.3.7] - 08/26/2024
 
@@ -78,7 +78,7 @@
 ## [1.3.4] - 08/12/2024
 
 ### Features
-* [#1087](https://github.com/awslabs/smithy-kotlin/issues/1087) Introduce new Micrometer telemetry provider. **Note**: This new provider (like the rest of the telemetry system) is marked `@ExperimentalApi` and could see backwards-incompatible API changes in future releases.
+* [#1087](https://github.com/smithy-lang/smithy-kotlin/issues/1087) Introduce new Micrometer telemetry provider. **Note**: This new provider (like the rest of the telemetry system) is marked `@ExperimentalApi` and could see backwards-incompatible API changes in future releases.
 * Add new `ISO_8601_FULL` timestamp format for untruncated precision
 
 ### Fixes
@@ -197,12 +197,12 @@
 ## [1.1.4] - 04/17/2024
 
 ### Features
-* [#428](https://github.com/awslabs/smithy-kotlin/issues/428) ⚠️ **IMPORTANT**: Add new @SdkDsl DSL marker to all generated structure builders, clarifying DSL scopes when building complex types. See the [**Scope control applied to DSL builders** breaking change announcement](https://github.com/awslabs/aws-sdk-kotlin/discussions/1280) for more details.
+* [#428](https://github.com/smithy-lang/smithy-kotlin/issues/428) ⚠️ **IMPORTANT**: Add new @SdkDsl DSL marker to all generated structure builders, clarifying DSL scopes when building complex types. See the [**Scope control applied to DSL builders** breaking change announcement](https://github.com/awslabs/aws-sdk-kotlin/discussions/1280) for more details.
 
 ### Fixes
 * [#900](https://github.com/awslabs/aws-sdk-kotlin/issues/900) Correctly generate waiters and paginators for resource operations
 * [#1281](https://github.com/awslabs/aws-sdk-kotlin/issues/1281) Lazily resolve proxy environment variables
-* [#1061](https://github.com/awslabs/smithy-kotlin/issues/1061) Correctly handle async cancellation of call context in OkHttp engine
+* [#1061](https://github.com/smithy-lang/smithy-kotlin/issues/1061) Correctly handle async cancellation of call context in OkHttp engine
 
 ## [1.1.3] - 04/02/2024
 
@@ -217,8 +217,8 @@
 ## [1.1.0] - 03/18/2024
 
 ### Fixes
-* [#1045](https://github.com/awslabs/smithy-kotlin/issues/1045) ⚠️ **IMPORTANT**: Fix codegen for map shapes which use string enums as map keys. See the [**Map key changes** breaking change announcement](https://github.com/awslabs/aws-sdk-kotlin/discussions/1258) for more details
-* [#1041](https://github.com/awslabs/smithy-kotlin/issues/1041) ⚠️ **IMPORTANT**: Disable [OkHttp's transparent response decompression](https://square.github.io/okhttp/features/calls/#rewriting-requests) by manually specifying `Accept-Encoding: identity` in requests. See the [**Disabling automatic response decompression** breaking change announcement](https://github.com/awslabs/aws-sdk-kotlin/discussions/1259) for more details.
+* [#1045](https://github.com/smithy-lang/smithy-kotlin/issues/1045) ⚠️ **IMPORTANT**: Fix codegen for map shapes which use string enums as map keys. See the [**Map key changes** breaking change announcement](https://github.com/awslabs/aws-sdk-kotlin/discussions/1258) for more details
+* [#1041](https://github.com/smithy-lang/smithy-kotlin/issues/1041) ⚠️ **IMPORTANT**: Disable [OkHttp's transparent response decompression](https://square.github.io/okhttp/features/calls/#rewriting-requests) by manually specifying `Accept-Encoding: identity` in requests. See the [**Disabling automatic response decompression** breaking change announcement](https://github.com/awslabs/aws-sdk-kotlin/discussions/1259) for more details.
 
 ## [1.0.20] - 03/15/2024
 
@@ -269,7 +269,7 @@
 ## [1.0.13] - 02/07/2024
 
 ### Fixes
-* [#1031](https://github.com/awslabs/smithy-kotlin/issues/1031) Correctly parse URLs which contain the `@` symbol in the path and/or fragment (but not in the userinfo)
+* [#1031](https://github.com/smithy-lang/smithy-kotlin/issues/1031) Correctly parse URLs which contain the `@` symbol in the path and/or fragment (but not in the userinfo)
 
 ## [1.0.12] - 01/31/2024
 
@@ -305,7 +305,7 @@
 
 ### Features
 * Generate KDoc samples from modeled examples
-* [#955](https://github.com/awslabs/smithy-kotlin/issues/955) Added support for [request compression](https://smithy.io/2.0/spec/behavior-traits.html#requestcompression-trait)
+* [#955](https://github.com/smithy-lang/smithy-kotlin/issues/955) Added support for [request compression](https://smithy.io/2.0/spec/behavior-traits.html#requestcompression-trait)
 
 ## [1.0.5] - 12/19/2023
 
@@ -460,7 +460,7 @@
 * [#745](https://github.com/awslabs/aws-sdk-kotlin/issues/745) Add a response length validation interceptor
 
 ### Fixes
-* [#880](https://github.com/awslabs/smithy-kotlin/issues/880) Enforce `maxConnections` for CRT HTTP engine
+* [#880](https://github.com/smithy-lang/smithy-kotlin/issues/880) Enforce `maxConnections` for CRT HTTP engine
 
 ### Miscellaneous
 * **BREAKING**: Remove `maxConnections` from generic HTTP engine config since it can't be enforced for OkHttp.
@@ -469,12 +469,12 @@
 
 ### Features
 * Add experimental support for OpenTelemetry based telemetry provider
-* [#146](https://github.com/awslabs/smithy-kotlin/issues/146) Enable endpoint discovery
-* [#898](https://github.com/awslabs/smithy-kotlin/issues/898) BREAKING: introduce `maxConcurrency` HTTP engine setting and rename OkHttp specific `maxConnectionsPerHost` to `maxConcurrencyPerHost`.
+* [#146](https://github.com/smithy-lang/smithy-kotlin/issues/146) Enable endpoint discovery
+* [#898](https://github.com/smithy-lang/smithy-kotlin/issues/898) BREAKING: introduce `maxConcurrency` HTTP engine setting and rename OkHttp specific `maxConnectionsPerHost` to `maxConcurrencyPerHost`.
 
 ### Fixes
 * [#905](https://github.com/awslabs/aws-sdk-kotlin/issues/905) Retry connection reset errors in OkHttp engine
-* [#888](https://github.com/awslabs/smithy-kotlin/issues/888) Correct URL encoding in endpoint resolution
+* [#888](https://github.com/smithy-lang/smithy-kotlin/issues/888) Correct URL encoding in endpoint resolution
 
 ### Miscellaneous
 * **BREAKING**: Refactor observability API and configuration. See the [discussion](https://github.com/awslabs/aws-sdk-kotlin/discussions/981) post from the AWS SDK for Kotlin for more information.
@@ -488,7 +488,7 @@
 ## [0.22.0] - 06/29/2023
 
 ### Features
-* [#213](https://github.com/awslabs/smithy-kotlin/issues/213) Add support for `BigInteger` and `BigDecimal` in Smithy models
+* [#213](https://github.com/smithy-lang/smithy-kotlin/issues/213) Add support for `BigInteger` and `BigDecimal` in Smithy models
 * [#701](https://github.com/awslabs/aws-sdk-kotlin/issues/701) **Breaking**: Simplify mechanisms for setting/updating retry strategies in client config. See [this discussion post](https://github.com/awslabs/aws-sdk-kotlin/discussions/964) for more details.
 * [#701](https://github.com/awslabs/aws-sdk-kotlin/issues/701) Add adaptive retry mode
 
@@ -498,11 +498,11 @@
 ## [0.21.3] - 06/19/2023
 
 ### Features
-* [#718](https://github.com/awslabs/smithy-kotlin/issues/718) Support Smithy default trait
+* [#718](https://github.com/smithy-lang/smithy-kotlin/issues/718) Support Smithy default trait
 
 ### Fixes
-* [#867](https://github.com/awslabs/smithy-kotlin/issues/867) Add fully qualified name hint for collection types
-* [#828](https://github.com/awslabs/smithy-kotlin/issues/828) Use correct precedence order for determining restJson error codes
+* [#867](https://github.com/smithy-lang/smithy-kotlin/issues/867) Add fully qualified name hint for collection types
+* [#828](https://github.com/smithy-lang/smithy-kotlin/issues/828) Use correct precedence order for determining restJson error codes
 
 ## [0.21.2] - 06/08/2023
 
@@ -520,7 +520,7 @@
 ## [0.21.0] - 05/25/2023
 
 ### Features
-* [#755](https://github.com/awslabs/smithy-kotlin/issues/755) **Breaking**: Refresh presigning APIs to simplify usage and add new capabilities. See [this discussion post](https://github.com/awslabs/aws-sdk-kotlin/discussions/925) for more information.
+* [#755](https://github.com/smithy-lang/smithy-kotlin/issues/755) **Breaking**: Refresh presigning APIs to simplify usage and add new capabilities. See [this discussion post](https://github.com/awslabs/aws-sdk-kotlin/discussions/925) for more information.
 
 ## [0.20.0] - 05/18/2023
 
@@ -542,7 +542,7 @@
 ## [0.18.0] - 05/04/2023
 
 ### Features
-* [#661](https://github.com/awslabs/smithy-kotlin/issues/661) **Breaking**: Add HTTP engine configuration for minimum TLS version. See the [BREAKING: Streamlined TLS configuration](https://github.com/awslabs/aws-sdk-kotlin/discussions/909) discussion post for more details.
+* [#661](https://github.com/smithy-lang/smithy-kotlin/issues/661) **Breaking**: Add HTTP engine configuration for minimum TLS version. See the [BREAKING: Streamlined TLS configuration](https://github.com/awslabs/aws-sdk-kotlin/discussions/909) discussion post for more details.
 * BREAKING: rename SdkLogMode to LogMode
 * [#432](https://github.com/awslabs/aws-sdk-kotlin/issues/432) Enable resolving LogMode from environment
 
@@ -561,7 +561,7 @@
 
 ## [0.17.3] - 04/20/2023
 This release is identical to 
-[0.17.2](https://github.com/awslabs/smithy-kotlin/blob/main/CHANGELOG.md#0172---04202023).
+[0.17.2](https://github.com/smithy-lang/smithy-kotlin/blob/main/CHANGELOG.md#0172---04202023).
 
 ## [0.17.2] - 04/20/2023
 
@@ -581,7 +581,7 @@ This release is identical to
 ## [0.17.0] - 04/13/2023
 
 ### Fixes
-* [#818](https://github.com/awslabs/smithy-kotlin/issues/818) Allow requests with zero content length in the CRT HTTP engine
+* [#818](https://github.com/smithy-lang/smithy-kotlin/issues/818) Allow requests with zero content length in the CRT HTTP engine
 
 ### Miscellaneous
 * **BREAKING**: Refactor identity and authentication APIs
@@ -589,7 +589,7 @@ This release is identical to
 ## [0.16.6] - 04/06/2023
 
 ### Features
-* [#752](https://github.com/awslabs/smithy-kotlin/issues/752) Add intEnum support.
+* [#752](https://github.com/smithy-lang/smithy-kotlin/issues/752) Add intEnum support.
 
 ## [0.16.5] - 03/30/2023
 
@@ -617,7 +617,7 @@ This release is identical to
 ## [0.16.0] - 02/23/2023
 
 ### Fixes
-* [#805](https://github.com/awslabs/smithy-kotlin/issues/805) Fix a bug where system time jumps could cause unexpected retry behavior
+* [#805](https://github.com/smithy-lang/smithy-kotlin/issues/805) Fix a bug where system time jumps could cause unexpected retry behavior
 
 ### Miscellaneous
 * Refactor: move `EndpointProvider` out of http package into `aws.smithy.kotlin.runtime.client.endpoints`
@@ -651,7 +651,7 @@ This release is identical to
 ## [0.15.1] - 02/02/2023
 
 ### Features
-* [#446](https://github.com/awslabs/smithy-kotlin/issues/446) Implement flexible checksums customization
+* [#446](https://github.com/smithy-lang/smithy-kotlin/issues/446) Implement flexible checksums customization
 * Add support for unsigned `aws-chunked` requests
 
 ### Miscellaneous
@@ -663,8 +663,8 @@ This release is identical to
 * Allow config override for one or more operations with an existing service client.
 
 ### Fixes
-* [#781](https://github.com/awslabs/smithy-kotlin/issues/781) Lazily open random access files to prevent exhausting file handles in highly concurrent scenarios
-* [#784](https://github.com/awslabs/smithy-kotlin/issues/784) Include exceptions in logging from trace probes
+* [#781](https://github.com/smithy-lang/smithy-kotlin/issues/781) Lazily open random access files to prevent exhausting file handles in highly concurrent scenarios
+* [#784](https://github.com/smithy-lang/smithy-kotlin/issues/784) Include exceptions in logging from trace probes
 
 ### Miscellaneous
 * Upgrade dependencies
@@ -675,8 +675,8 @@ This release is identical to
 ## [0.14.3] - 01/12/2023
 
 ### Features
-* [#122](https://github.com/awslabs/smithy-kotlin/issues/122) Add capability to intercept SDK operations
-* [#745](https://github.com/awslabs/smithy-kotlin/issues/745) Add KMP DNS resolver
+* [#122](https://github.com/smithy-lang/smithy-kotlin/issues/122) Add capability to intercept SDK operations
+* [#745](https://github.com/smithy-lang/smithy-kotlin/issues/745) Add KMP DNS resolver
 
 ### Miscellaneous
 * Add design document for per-op config.
@@ -697,8 +697,8 @@ This release is identical to
 
 ### Fixes
 * [#759](https://github.com/awslabs/aws-sdk-kotlin/issues/759) Allow root trace spans to inherit their parent from current context
-* [#763](https://github.com/awslabs/smithy-kotlin/issues/763) Respect @sensitive trait when applied to container shape
-* [#759](https://github.com/awslabs/smithy-kotlin/issues/759) Fix `aws-chunked` requests in the CRT HTTP engine
+* [#763](https://github.com/smithy-lang/smithy-kotlin/issues/763) Respect @sensitive trait when applied to container shape
+* [#759](https://github.com/smithy-lang/smithy-kotlin/issues/759) Fix `aws-chunked` requests in the CRT HTTP engine
 
 ## [0.14.0] - 12/01/2022
 
@@ -714,7 +714,7 @@ This release is identical to
 
 ### Features
 * **BREAKING** Implement codegen and update runtime for smithy-modeled endpoint resolution.
-* [#677](https://github.com/awslabs/smithy-kotlin/issues/677) Add a new tracing framework for centralized handling of log messages and metric events and providing easy integration points for connecting to downstream tracing systems (e.g., kotlin-logging)
+* [#677](https://github.com/smithy-lang/smithy-kotlin/issues/677) Add a new tracing framework for centralized handling of log messages and metric events and providing easy integration points for connecting to downstream tracing systems (e.g., kotlin-logging)
 * [#747](https://github.com/awslabs/aws-sdk-kotlin/issues/747) Add aws-chunked content encoding
 * Implement common-Kotlin URL parsing and IPv4/v6 address validation.
 
@@ -756,7 +756,7 @@ This release is identical to
 
 ### Fixes
 * [#715](https://github.com/awslabs/aws-sdk-kotlin/issues/715) Enable intra-repo links in API ref docs
-* [#714](https://github.com/awslabs/smithy-kotlin/issues/714) Properly parse timestamps when format override is applied to target shapes
+* [#714](https://github.com/smithy-lang/smithy-kotlin/issues/714) Properly parse timestamps when format override is applied to target shapes
 
 ## [0.12.8] - 10/03/2022
 
@@ -782,7 +782,7 @@ This release is identical to
 
 ### Fixes
 * Fix occasional stream leak due to race condition in CRT engine
-* [#678](https://github.com/awslabs/smithy-kotlin/issues/678) Fix the calculation of file lengths on `ByteStream`s from `Path`s
+* [#678](https://github.com/smithy-lang/smithy-kotlin/issues/678) Fix the calculation of file lengths on `ByteStream`s from `Path`s
 * Properly check if a member can be nullable
 
 ### Miscellaneous
@@ -828,10 +828,10 @@ This release is identical to
 
 ### Features
 * Add support for NOT, OR, and AND JMESPath expressions in waiters
-* [#123](https://github.com/awslabs/smithy-kotlin/issues/123) Add support for smithy Document type.
+* [#123](https://github.com/smithy-lang/smithy-kotlin/issues/123) Add support for smithy Document type.
 
 ### Miscellaneous
-* [#599](https://github.com/awslabs/smithy-kotlin/issues/599) Upgrade Smithy version to 1.22
+* [#599](https://github.com/smithy-lang/smithy-kotlin/issues/599) Upgrade Smithy version to 1.22
 
 ## [0.11.1] - 07/01/2022
 
@@ -845,25 +845,25 @@ This release is identical to
 
 ### Features
 * (breaking) Use kotlin nullability to represent null Documents instead of an explicit subclass.
-* [#494](https://github.com/awslabs/smithy-kotlin/issues/494) Add support for HTTP proxies
+* [#494](https://github.com/smithy-lang/smithy-kotlin/issues/494) Add support for HTTP proxies
 
 ### Fixes
 * [#638](https://github.com/awslabs/aws-sdk-kotlin/issues/638) Fix ktor engine representation of empty payload
-* [#139](https://github.com/awslabs/smithy-kotlin/issues/139) Validate that members bound to URI paths are non-null at object construction
+* [#139](https://github.com/smithy-lang/smithy-kotlin/issues/139) Validate that members bound to URI paths are non-null at object construction
 
 ### Miscellaneous
-* [#629](https://github.com/awslabs/smithy-kotlin/issues/629) Refactor to bind directly to okhttp and remove ktor as a middleman
+* [#629](https://github.com/smithy-lang/smithy-kotlin/issues/629) Refactor to bind directly to okhttp and remove ktor as a middleman
 
 ## [0.10.2] - 06/09/2022
 
 ### Fixes
 * [#619](https://github.com/awslabs/aws-sdk-kotlin/issues/619) Fix bugs with signing for query parameters containing '+' and '%'
-* [#657](https://github.com/awslabs/smithy-kotlin/issues/657) Fix bug in URI encoding during signing when dealing with special characters like '<', '>', and '/'
+* [#657](https://github.com/smithy-lang/smithy-kotlin/issues/657) Fix bug in URI encoding during signing when dealing with special characters like '<', '>', and '/'
 
 ## [0.10.1] - 06/02/2022
 
 ### Features
-* [#617](https://github.com/awslabs/smithy-kotlin/issues/617) Add a new non-CRT SigV4 signer and use it as the default. This removes the CRT as a hard dependency for using the SDK (although the CRT signer can still be used via explicit configuration on client creation).
+* [#617](https://github.com/smithy-lang/smithy-kotlin/issues/617) Add a new non-CRT SigV4 signer and use it as the default. This removes the CRT as a hard dependency for using the SDK (although the CRT signer can still be used via explicit configuration on client creation).
 
 ### Fixes
 * [#473](https://github.com/awslabs/aws-sdk-kotlin/issues/473) Upgrade aws-crt-kotlin to latest
@@ -883,7 +883,7 @@ This release is identical to
 ## [0.9.2] - 05/19/2022
 
 ### Features
-* [#129](https://github.com/awslabs/smithy-kotlin/issues/129) Allow omission of input in service method calls where no parameters are required.
+* [#129](https://github.com/smithy-lang/smithy-kotlin/issues/129) Allow omission of input in service method calls where no parameters are required.
 
 ### Fixes
 * Handle invalid (empty) description term headers when generating documentation.
@@ -896,7 +896,7 @@ This release is identical to
 * [#530](https://github.com/awslabs/aws-sdk-kotlin/issues/530) Add partial-file ByteStream support.
 
 ### Fixes
-* [#136](https://github.com/awslabs/smithy-kotlin/issues/136) Convert HTML to Markdown for improved Dokka compatibility.
+* [#136](https://github.com/smithy-lang/smithy-kotlin/issues/136) Convert HTML to Markdown for improved Dokka compatibility.
 
 ### Miscellaneous
 * [#575](https://github.com/awslabs/aws-sdk-kotlin/issues/575) Add support for getting all env vars and system properties (i.e., not just by a single key)
@@ -910,8 +910,8 @@ This release is identical to
 ## [0.8.5] - 04/21/2022
 
 ### Fixes
-* set Content-Type header on empty bodies with Ktor if canonical request includes it [#630](https://github.com/awslabs/smithy-kotlin/pull/630)
-* coroutine leak in ktor engine [#628](https://github.com/awslabs/smithy-kotlin/pull/628)
+* set Content-Type header on empty bodies with Ktor if canonical request includes it [#630](https://github.com/smithy-lang/smithy-kotlin/pull/630)
+* coroutine leak in ktor engine [#628](https://github.com/smithy-lang/smithy-kotlin/pull/628)
 
 ## [0.8.4] - 04/21/2022
 
@@ -920,87 +920,87 @@ NOTE: Do not use. No difference from 0.8.3
 ## [0.8.3] - 04/14/2022
 
 ### Fixes
-* only set Content-Type when body is non-empty [#619](https://github.com/awslabs/smithy-kotlin/pull/619)
+* only set Content-Type when body is non-empty [#619](https://github.com/smithy-lang/smithy-kotlin/pull/619)
 
 ## [0.8.2] - 04/07/2022
 
 ### Fixes
-* remove maxTime from StandardRetryStrategy [#624](https://github.com/awslabs/smithy-kotlin/pull/624)
-* readAvailable fallback behavior [#620](https://github.com/awslabs/smithy-kotlin/pull/620)
+* remove maxTime from StandardRetryStrategy [#624](https://github.com/smithy-lang/smithy-kotlin/pull/624)
+* readAvailable fallback behavior [#620](https://github.com/smithy-lang/smithy-kotlin/pull/620)
 
 ## [0.8.1] - 03/31/2022
 
 ### New features
-* implement KMP XML serde and remove XmlPull dependency [#615](https://github.com/awslabs/smithy-kotlin/pull/615)
+* implement KMP XML serde and remove XmlPull dependency [#615](https://github.com/smithy-lang/smithy-kotlin/pull/615)
 
 ### Fixes
-* respect hostname immutability in endpoints to disable host prefixing [#612](https://github.com/awslabs/smithy-kotlin/pull/612)
+* respect hostname immutability in endpoints to disable host prefixing [#612](https://github.com/smithy-lang/smithy-kotlin/pull/612)
 
 ## [0.8.0] - 03/24/2022
 
 ### Breaking changes
-* introduce opaque KMP default HTTP client engine [#606](https://github.com/awslabs/smithy-kotlin/pull/606)
+* introduce opaque KMP default HTTP client engine [#606](https://github.com/smithy-lang/smithy-kotlin/pull/606)
 
 ### New features
-* bootstrap event streams [#597](https://github.com/awslabs/smithy-kotlin/pull/597)
+* bootstrap event streams [#597](https://github.com/smithy-lang/smithy-kotlin/pull/597)
 
 ### Fixes
-* temporarily handle httpchecksum trait the same as httpchecksumrequired [#608](https://github.com/awslabs/smithy-kotlin/pull/608)
+* temporarily handle httpchecksum trait the same as httpchecksumrequired [#608](https://github.com/smithy-lang/smithy-kotlin/pull/608)
 
 ### Miscellaneous
-* add convenience function for decoding URL components [#607](https://github.com/awslabs/smithy-kotlin/pull/607)
-* fix pagination design docs [#600](https://github.com/awslabs/smithy-kotlin/pull/600)
+* add convenience function for decoding URL components [#607](https://github.com/smithy-lang/smithy-kotlin/pull/607)
+* fix pagination design docs [#600](https://github.com/smithy-lang/smithy-kotlin/pull/600)
 
 ## [0.7.8] - 02/17/2022
 
 ### New features
-* add DSL overloads to paginator methods [#591](https://github.com/awslabs/smithy-kotlin/pull/591)
+* add DSL overloads to paginator methods [#591](https://github.com/smithy-lang/smithy-kotlin/pull/591)
 
 ### Fixes
-* ignore redirect statuses in Ktor engine [#590](https://github.com/awslabs/smithy-kotlin/pull/590)
-* handle stream response exceptions properly in Ktor engine [#589](https://github.com/awslabs/smithy-kotlin/pull/589)
+* ignore redirect statuses in Ktor engine [#590](https://github.com/smithy-lang/smithy-kotlin/pull/590)
+* handle stream response exceptions properly in Ktor engine [#589](https://github.com/smithy-lang/smithy-kotlin/pull/589)
 
 ### Miscellaneous
-* coroutine version bump to 1.6.0 and Duration stabilization [#580](https://github.com/awslabs/smithy-kotlin/pull/580)
-* dokka upgrade [#588](https://github.com/awslabs/smithy-kotlin/pull/588)
-* upgrade smithy to 1.17.0 [#587](https://github.com/awslabs/smithy-kotlin/pull/587)
+* coroutine version bump to 1.6.0 and Duration stabilization [#580](https://github.com/smithy-lang/smithy-kotlin/pull/580)
+* dokka upgrade [#588](https://github.com/smithy-lang/smithy-kotlin/pull/588)
+* upgrade smithy to 1.17.0 [#587](https://github.com/smithy-lang/smithy-kotlin/pull/587)
 
 ## [0.7.7] - 02/04/2022
 
 ### New features
-* implement waiters codegen [#584](https://github.com/awslabs/smithy-kotlin/pull/584)
-* Kotlin MP gradle file generation [#577](https://github.com/awslabs/smithy-kotlin/pull/577)
-* allow custom rendering of config properties [#568](https://github.com/awslabs/smithy-kotlin/pull/568)
+* implement waiters codegen [#584](https://github.com/smithy-lang/smithy-kotlin/pull/584)
+* Kotlin MP gradle file generation [#577](https://github.com/smithy-lang/smithy-kotlin/pull/577)
+* allow custom rendering of config properties [#568](https://github.com/smithy-lang/smithy-kotlin/pull/568)
 
 ### Miscellaneous
-* event stream design [#576](https://github.com/awslabs/smithy-kotlin/pull/576)
+* event stream design [#576](https://github.com/smithy-lang/smithy-kotlin/pull/576)
 
 ## [0.7.6] - 01/13/2022
 
 ### New features
-* Paginator codegen using Kotlin Flow [#557](https://github.com/awslabs/smithy-kotlin/pull/557)
-* allow nullable LazyAsyncValue; add test utils for constructing http traffic from JSON [#561](https://github.com/awslabs/smithy-kotlin/pull/561)
+* Paginator codegen using Kotlin Flow [#557](https://github.com/smithy-lang/smithy-kotlin/pull/557)
+* allow nullable LazyAsyncValue; add test utils for constructing http traffic from JSON [#561](https://github.com/smithy-lang/smithy-kotlin/pull/561)
 
 ### Fixes
-* paginator generation for models that specify non-string cursor [#566](https://github.com/awslabs/smithy-kotlin/pull/566)
-* Fix smithy sdk no default client [#564](https://github.com/awslabs/smithy-kotlin/pull/564)
+* paginator generation for models that specify non-string cursor [#566](https://github.com/smithy-lang/smithy-kotlin/pull/566)
+* Fix smithy sdk no default client [#564](https://github.com/smithy-lang/smithy-kotlin/pull/564)
 
 ## [0.7.5] - 01/06/2022
 
 ### New features
-* upgrade to Kotlin 1.6.10 [#551](https://github.com/awslabs/smithy-kotlin/pull/551)
-* allow query params to be set from resolved endpoints [#554](https://github.com/awslabs/smithy-kotlin/pull/554)
-* sha1 hash; expose json utils [#548](https://github.com/awslabs/smithy-kotlin/pull/548)
+* upgrade to Kotlin 1.6.10 [#551](https://github.com/smithy-lang/smithy-kotlin/pull/551)
+* allow query params to be set from resolved endpoints [#554](https://github.com/smithy-lang/smithy-kotlin/pull/554)
+* sha1 hash; expose json utils [#548](https://github.com/smithy-lang/smithy-kotlin/pull/548)
 
 ### Fixes
-* only retry client errors if metadata allows [#560](https://github.com/awslabs/smithy-kotlin/pull/560)
+* only retry client errors if metadata allows [#560](https://github.com/smithy-lang/smithy-kotlin/pull/560)
 
 ## [0.7.4-beta] - 12/09/2021
 
 **WARNING: Beta releases may contain bugs and no guarantee is made about API stability. They are not recommended for production use!**
 
 ### New features
-* add call logging at DEBUG level [#547](https://github.com/awslabs/smithy-kotlin/pull/547)
+* add call logging at DEBUG level [#547](https://github.com/smithy-lang/smithy-kotlin/pull/547)
 
 ## [0.7.3-beta] - 12/01/2021
 
@@ -1012,20 +1012,20 @@ NOTE: Do not use. No difference from 0.8.3
 **WARNING: Alpha releases may contain bugs and no guarantee is made about API stability. They are not recommended for production use!**
 
 ### Fixes
-* Fix nested struct dsl builder function codegen [#538](https://github.com/awslabs/smithy-kotlin/pull/538)
-* remove leaky trace logging from XML serde [#537](https://github.com/awslabs/smithy-kotlin/pull/537)
-* fix rendering of middleware without configure [#535](https://github.com/awslabs/smithy-kotlin/pull/535)
+* Fix nested struct dsl builder function codegen [#538](https://github.com/smithy-lang/smithy-kotlin/pull/538)
+* remove leaky trace logging from XML serde [#537](https://github.com/smithy-lang/smithy-kotlin/pull/537)
+* fix rendering of middleware without configure [#535](https://github.com/smithy-lang/smithy-kotlin/pull/535)
 
 ## [0.7.1-alpha] - 11/04/2021
 
 **WARNING: Alpha releases may contain bugs and no guarantee is made about API stability. They are not recommended for production use!**
 
 ### New features
-* add convenience extension method for detecting if a Shape has the Streaming trait [#512](https://github.com/awslabs/smithy-kotlin/pull/512)
+* add convenience extension method for detecting if a Shape has the Streaming trait [#512](https://github.com/smithy-lang/smithy-kotlin/pull/512)
 
 ### Fixes
-* delegate when to set content-type to binding resolver; fix content-length for empty bodies [#525](https://github.com/awslabs/smithy-kotlin/pull/525)
-* Update regex to handle version segments greater than 9 [#521](https://github.com/awslabs/smithy-kotlin/pull/521)
+* delegate when to set content-type to binding resolver; fix content-length for empty bodies [#525](https://github.com/smithy-lang/smithy-kotlin/pull/525)
+* Update regex to handle version segments greater than 9 [#521](https://github.com/smithy-lang/smithy-kotlin/pull/521)
 
 ## [0.7.0-alpha] - 10/28/2021
 
@@ -1033,18 +1033,18 @@ NOTE: Do not use. No difference from 0.8.3
 
 ### New Features
 
-* add endpoint configuration and middleware by default [#507](https://github.com/awslabs/smithy-kotlin/pull/507)
+* add endpoint configuration and middleware by default [#507](https://github.com/smithy-lang/smithy-kotlin/pull/507)
 
 ## [0.6.0-alpha] - 10/21/2021
 
 **WARNING: Alpha releases may contain bugs and no guarantee is made about API stability. They are not recommended for production use!**
 
 ### Fixes
-* emulate a real response body more closely to help catch subtle codegen bugs [#505](https://github.com/awslabs/smithy-kotlin/pull/505)
-* **BREAKING**: overhaul client config property generation [#504](https://github.com/awslabs/smithy-kotlin/pull/504)
+* emulate a real response body more closely to help catch subtle codegen bugs [#505](https://github.com/smithy-lang/smithy-kotlin/pull/505)
+* **BREAKING**: overhaul client config property generation [#504](https://github.com/smithy-lang/smithy-kotlin/pull/504)
 
 ### Misc
-* Bump Kotlin and Dokka versions to latest release [#506](https://github.com/awslabs/smithy-kotlin/pull/506)
+* Bump Kotlin and Dokka versions to latest release [#506](https://github.com/smithy-lang/smithy-kotlin/pull/506)
 
 ## [0.5.1-alpha] - 10/14/2021
 
@@ -1052,10 +1052,10 @@ NOTE: Do not use. No difference from 0.8.3
 
 ### New features
 
-* http client engine config [#493](https://github.com/awslabs/smithy-kotlin/pull/493)
-* add codegen wrappers for retries [#490](https://github.com/awslabs/smithy-kotlin/pull/490)
+* http client engine config [#493](https://github.com/smithy-lang/smithy-kotlin/pull/493)
+* add codegen wrappers for retries [#490](https://github.com/smithy-lang/smithy-kotlin/pull/490)
 
 ### Fixes
 
-* remove gson from dependencies [#496](https://github.com/awslabs/smithy-kotlin/pull/496)
+* remove gson from dependencies [#496](https://github.com/smithy-lang/smithy-kotlin/pull/496)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ of your request may disagree and ask that you add one anyway.
   "type": "feature",
   "description": "Add multiplatform support for URL parsing",
   "issues": [
-    "awslabs/smithy-kotlin#12345"
+    "smithy-lang/smithy-kotlin#12345"
   ]
 }
 ```

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/RestJson1.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/RestJson1.kt
@@ -46,7 +46,7 @@ class RestJson1 : JsonHttpBindingProtocolGenerator() {
 
         // restjson1 has some different semantics and expectations around empty structures bound via @httpPayload trait
         //   * empty structures get serialized to `{}`
-        // see: https://github.com/awslabs/smithy/pull/924
+        // see: https://github.com/smithy-lang/smithy/pull/924
         val requestBindings = resolver.requestBindings(op)
         val httpPayload = requestBindings.firstOrNull { it.location == HttpBinding.Location.PAYLOAD }
         if (httpPayload != null) {
@@ -58,7 +58,7 @@ class RestJson1 : JsonHttpBindingProtocolGenerator() {
                     write("builder.body = #T.fromBytes(#S.encodeToByteArray())", RuntimeTypes.Http.HttpBody, "{}")
                 }
                 // Content-Type still needs to be set for non-structured payloads
-                // https://github.com/awslabs/smithy/blob/main/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy#L174
+                // https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy#L174
                 write("builder.headers.setMissing(\"Content-Type\", #S)", resolver.determineRequestContentType(op))
             }
         }

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/xml/RestXmlSerdeDescriptorGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/xml/RestXmlSerdeDescriptorGenerator.kt
@@ -34,7 +34,7 @@ class RestXmlSerdeDescriptorGenerator(
             val serialName = getSerialName(member, nameSuffix)
             if (serialName.equals("message", ignoreCase = true)) {
                 // Need to be able to read error messages from "Message" or "message"
-                // https://github.com/awslabs/smithy-kotlin/issues/352
+                // https://github.com/smithy-lang/smithy-kotlin/issues/352
                 traitList.add(RuntimeTypes.Serde.SerdeXml.XmlAliasName, serialName.toggleFirstCharacterCase().dq())
             }
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/CodegenVisitor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/CodegenVisitor.kt
@@ -61,7 +61,7 @@ class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Unit>() {
         // Model pre-processing:
         // 1. Start with the model from the plugin context
         // 2. Apply integrations
-        // 3. Flatten error shapes (see: https://github.com/awslabs/smithy/pull/919)
+        // 3. Flatten error shapes (see: https://github.com/smithy-lang/smithy/pull/919)
         // 4. Normalize the operations
         for (integration in integrations) {
             if (integration.enabledForService(resolvedModel, settings)) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/SectionWriter.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/SectionWriter.kt
@@ -28,7 +28,7 @@ fun interface SectionWriter {
      *  evaluated [SectionWriter] associated with the same [SectionId]. For writers that wish to
      *  append to any pre-existing codegen strings in the section, they must explicitly write
      *  the contents of previousValue to the writer.  See the
-     *  [CodeWriter](https://github.com/awslabs/smithy/blob/main/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java)
+     *  [CodeWriter](https://github.com/smithy-lang/smithy/blob/main/smithy-utils/src/main/java/software/amazon/smithy/utils/CodeWriter.java)
      *  documentation for more details
      */
     fun write(writer: KotlinWriter, previousValue: String?)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerdeDescriptorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerdeDescriptorGenerator.kt
@@ -35,7 +35,7 @@ open class XmlSerdeDescriptorGenerator(
         val objTraits = mutableListOf<SdkFieldDescriptorTrait>()
         val serialName = when {
             // FIXME - we should be able to remove special casing of errors here which is protocol specific
-            // see https://github.com/awslabs/smithy-kotlin/issues/350
+            // see https://github.com/smithy-lang/smithy-kotlin/issues/350
             objectShape.hasTrait<ErrorTrait>() -> "Error"
             objectShape.hasTrait<XmlNameTrait>() -> objectShape.expectTrait<XmlNameTrait>().value
             objectShape.hasTrait<SyntheticClone>() -> objectShape.expectTrait<SyntheticClone>().archetype.name

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/utils/CaseUtils.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/utils/CaseUtils.kt
@@ -11,7 +11,7 @@ private val completeWords = listOf("ipv4", "ipv6", "sigv4", "mib", "gib", "kib",
  * Split a string on word boundaries
  */
 fun String.splitOnWordBoundaries(): List<String> {
-    // This is taken from Rust: https://github.com/awslabs/smithy-rs/pull/3037/files#diff-4175c66ee81a450fcf1cd3e256f36ae2c8e0b30b910be8ca505135fbe215144d
+    // This is taken from Rust: https://github.com/smithy-lang/smithy-rs/pull/3037/files#diff-4175c66ee81a450fcf1cd3e256f36ae2c8e0b30b910be8ca505135fbe215144d
     // with minor changes (s3 and iot as whole words). Previously we used the Java v2 implementation
     // https://github.com/aws/aws-sdk-java-v2/blob/2.20.162/utils/src/main/java/software/amazon/awssdk/utils/internal/CodegenNamingUtils.java#L36
     // but this has some edge cases it doesn't handle well

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -488,8 +488,8 @@ internal class SmokeTestOperationDeserializer: HttpDeserializer.NonStreaming<Smo
 
     @Test
     fun itEscapesUriLiterals() {
-        // https://github.com/awslabs/smithy-kotlin/issues/65
-        // https://github.com/awslabs/smithy-kotlin/issues/395
+        // https://github.com/smithy-lang/smithy-kotlin/issues/65
+        // https://github.com/smithy-lang/smithy-kotlin/issues/395
         val uri = "/test/\$LATEST"
         val model = """
             @http(method: "PUT", uri: "$uri", code: 200)

--- a/docs/design/binary-streaming.md
+++ b/docs/design/binary-streaming.md
@@ -628,7 +628,7 @@ The issue with going that route is two fold:
 
 # Revision history
 
-* 11/29/2022 - SDK I/O refactor (see [#751](https://github.com/awslabs/smithy-kotlin/pull/751))
+* 11/29/2022 - SDK I/O refactor (see [#751](https://github.com/smithy-lang/smithy-kotlin/pull/751))
 * 11/15/2021 - Update code snippets from builder refactoring
 * 6/03/2021 - Initial upload
 * 6/11/2020 - Created

--- a/docs/design/flexible-checksums.md
+++ b/docs/design/flexible-checksums.md
@@ -33,9 +33,9 @@ of injecting the `Content-MD5` header.
 
 ## Checksum Algorithms
 
-The SDK needs to support the following checksum algorithms: CRC32C, CRC32, SHA-1, SHA-256. All of them are [already implemented for JVM](https://github.com/awslabs/smithy-kotlin/tree/5773afb348c779b9e4aa9689836844f21a571908/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing).
+The SDK needs to support the following checksum algorithms: CRC32C, CRC32, SHA-1, SHA-256. All of them are [already implemented for JVM](https://github.com/smithy-lang/smithy-kotlin/tree/5773afb348c779b9e4aa9689836844f21a571908/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing).
 
-As part of this feature, CRC32C was implemented in **smithy-kotlin** [PR#724](https://github.com/awslabs/smithy-kotlin/pull/724). 
+As part of this feature, CRC32C was implemented in **smithy-kotlin** [PR#724](https://github.com/smithy-lang/smithy-kotlin/pull/724). 
 This algorithm is essentially the same as CRC32, but uses a different polynomial under the hood. 
 The SDK uses [`java.util.zip`'s implementation of CRC32](https://docs.oracle.com/javase/8/docs/api/java/util/zip/CRC32.html), 
 but this package only began shipping CRC32C in Java 9. The SDK requires Java 8, so this was implemented rather than importing it as a dependency.
@@ -47,7 +47,7 @@ using SHA-256, the header containing the checksum will be `x-amz-checksum-sha256
 
 # Implementation
 
-This feature can be implemented by adding two new [interceptors](https://github.com/awslabs/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/docs/design/interceptors.md):
+This feature can be implemented by adding two new [interceptors](https://github.com/smithy-lang/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/docs/design/interceptors.md):
 one for calculating checksums for requests, and one for validating checksums present in responses.
 
 ## Requests
@@ -104,7 +104,7 @@ and the checksum will be calculated internally using the selected checksum algor
 When a user sets the member represented by the `requestAlgorithmMember` property, they are opting-in to sending request checksums. 
 
 This property is modeled as an enum value, so validation needs to be done prior to using it. The enum is generated from the service model,
-but the set of possible enum values is constrained by the [`httpChecksum` trait specification](#checksum-algorithms). The following code will match a `String` to a [`HashFunction`](https://github.com/awslabs/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/HashFunction.kt).
+but the set of possible enum values is constrained by the [`httpChecksum` trait specification](#checksum-algorithms). The following code will match a `String` to a [`HashFunction`](https://github.com/smithy-lang/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/HashFunction.kt).
 ```kotlin
 public fun String.toHashFunction(): HashFunction? {
     return when (this.lowercase()) {
@@ -131,7 +131,7 @@ An exception will be thrown if the algorithm can't be parsed or if it's not supp
 Note that because users select an algorithm from a code-generated enum, accidentally selecting an unsupported algorithm is unlikely.
 
 ### Computing and Injecting Checksums
-Next the SDK will compute and inject the checksum. If the body is smaller than the `aws-chunked` threshold ([1MB today](https://github.com/awslabs/smithy-kotlin/blob/9b9297c690d9a01777447f437f0e91562e146bf9/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/middleware/AwsSigningMiddleware.kt#L38)), 
+Next the SDK will compute and inject the checksum. If the body is smaller than the `aws-chunked` threshold ([1MB today](https://github.com/smithy-lang/smithy-kotlin/blob/9b9297c690d9a01777447f437f0e91562e146bf9/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/middleware/AwsSigningMiddleware.kt#L38)), 
 the checksum will be immediately computed and injected under the appropriate header name.
 
 Otherwise, if the request body is large enough to be uploaded with `aws-chunked`, the SDK will append the checksum header name to the `x-amz-trailer` header.
@@ -152,10 +152,10 @@ x-amz-trailer-signature:<trailer-signature> + \r\n
 \r\n
 ```
 
-To calculate the checksum while the payload is being written, the body will be wrapped in either a [`HashingSource`](https://github.com/awslabs/smithy-kotlin/blob/354c6cf011190bb4dff349d0c4a812c1de609d18/runtime/io/common/src/aws/smithy/kotlin/runtime/io/HashingSource.kt)
-or a [`HashingByteReadChannel`](https://github.com/awslabs/smithy-kotlin/blob/354c6cf011190bb4dff349d0c4a812c1de609d18/runtime/io/common/src/aws/smithy/kotlin/runtime/io/HashingByteReadChannel.kt), 
-depending on its type. These are new types which are constructed with an [`SdkSource`](https://github.com/awslabs/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt) or 
-[`SdkByteReadChannel`](https://github.com/awslabs/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannel.kt),
+To calculate the checksum while the payload is being written, the body will be wrapped in either a [`HashingSource`](https://github.com/smithy-lang/smithy-kotlin/blob/354c6cf011190bb4dff349d0c4a812c1de609d18/runtime/io/common/src/aws/smithy/kotlin/runtime/io/HashingSource.kt)
+or a [`HashingByteReadChannel`](https://github.com/smithy-lang/smithy-kotlin/blob/354c6cf011190bb4dff349d0c4a812c1de609d18/runtime/io/common/src/aws/smithy/kotlin/runtime/io/HashingByteReadChannel.kt), 
+depending on its type. These are new types which are constructed with an [`SdkSource`](https://github.com/smithy-lang/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt) or 
+[`SdkByteReadChannel`](https://github.com/smithy-lang/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannel.kt),
 respectively, along with a `HashFunction`. These constructs will use the provided hash function to compute the checksum as the data is being read.
 
 Later in the request's lifecycle, this hashing body will be wrapped once more in an `aws-chunked` body. This body is used to format the 
@@ -211,7 +211,7 @@ The same is done for `HashingByteReadChannel` using a `CompletingByteReadChannel
 
 There are many places during the request's lifecycle where trailing headers could be mutated.
 
-The trailing headers will be added as a member in the [`HttpRequestBuilder`](https://github.com/awslabs/smithy-kotlin/blob/a250c3e3e3e54ef35990a1609fb380a91b70cf4b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt) 
+The trailing headers will be added as a member in the [`HttpRequestBuilder`](https://github.com/smithy-lang/smithy-kotlin/blob/a250c3e3e3e54ef35990a1609fb380a91b70cf4b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt) 
 , which is where `Headers` are already stored. This will enable the trailing headers to be modified wherever the `HttpRequest` is accessible.
 
 The `HttpRequestBuilder` signature is updated to the following:
@@ -252,8 +252,8 @@ This allows users to add custom interceptors which modify the validation opt-in 
 The `modifyBeforeDeserialization` hook's purpose is to validate the checksum before the response is deserialized into its output type. 
 
 First, the body will be wrapped in a `HashingSource`/`HashingByteReadChannel`. This will calculate the checksum as the body is being consumed.
-The response body will also be wrapped in a [`ChecksumValidatingSource`](https://github.com/awslabs/smithy-kotlin/blob/354c6cf011190bb4dff349d0c4a812c1de609d18/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptor.kt#L88-L100)
-/[`ChecksumValidatingByteReadChannel`](https://github.com/awslabs/smithy-kotlin/blob/354c6cf011190bb4dff349d0c4a812c1de609d18/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptor.kt#L102-L114). 
+The response body will also be wrapped in a [`ChecksumValidatingSource`](https://github.com/smithy-lang/smithy-kotlin/blob/354c6cf011190bb4dff349d0c4a812c1de609d18/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptor.kt#L88-L100)
+/[`ChecksumValidatingByteReadChannel`](https://github.com/smithy-lang/smithy-kotlin/blob/354c6cf011190bb4dff349d0c4a812c1de609d18/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptor.kt#L102-L114). 
 This is a new type which takes an expected checksum and an underlying hashing data source. After the underlying data is fully consumed, the checksum is digested and validated.
 
 Below is the implementation of the `ChecksumValidatingSource`, which performs checksum validation after the underlying `HashingSource` is fully consumed:
@@ -370,7 +370,7 @@ The accepted design choice is to store trailing headers in the `HttpRequest`.
 Alternatively, the trailing headers could have been stored in the `ExecutionContext` or `HttpBody`.
 
 ### ExecutionContext
-The SDK uses [`ExecutionContext`](https://github.com/awslabs/smithy-kotlin/blob/a250c3e3e3e54ef35990a1609fb380a91b70cf4b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ExecutionContext.kt) 
+The SDK uses [`ExecutionContext`](https://github.com/smithy-lang/smithy-kotlin/blob/a250c3e3e3e54ef35990a1609fb380a91b70cf4b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ExecutionContext.kt) 
 as a property bag, storing a variety of properties related to the execution of a request.
 
 To add the trailing headers to this property bag, a new `AttributeKey` would be added. This can then be used to lookup 
@@ -386,7 +386,7 @@ Cons:
 
 ### HttpBody
 
-By adding the trailing headers to [HttpBody](https://github.com/awslabs/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpBody.kt), 
+By adding the trailing headers to [HttpBody](https://github.com/smithy-lang/smithy-kotlin/blob/5773afb348c779b9e4aa9689836844f21a571908/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpBody.kt), 
 users can modify the trailing headers anywhere they have access to the request body.
 
 Pros:
@@ -397,7 +397,7 @@ Cons:
 and headers don't really fit in here
 
 Ultimately, it was decided to store trailing headers in the `HttpRequest` (specifically, 
-[`HttpRequestBuilder`](https://github.com/awslabs/smithy-kotlin/blob/a250c3e3e3e54ef35990a1609fb380a91b70cf4b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt)
+[`HttpRequestBuilder`](https://github.com/smithy-lang/smithy-kotlin/blob/a250c3e3e3e54ef35990a1609fb380a91b70cf4b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt)
 ) because that is where regular headers are already stored.
 
 ## Synchronous Checksum Validation

--- a/docs/design/interceptors.md
+++ b/docs/design/interceptors.md
@@ -599,9 +599,9 @@ require an explicit `copy` to mutate. The assumption of immutability of these ty
 ### Retry and Signing Middleware
 
 Every hook defined in the `Interceptor` interface can be implemented as part of 
-[SdkOperationExecution](https://github.com/awslabs/smithy-kotlin/blob/v0.14.0/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt#L36)
+[SdkOperationExecution](https://github.com/smithy-lang/smithy-kotlin/blob/v0.14.0/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt#L36)
 with the exception of the retry (attempt) and signing related hooks. These two capabilities are currently implemented in
-terms of [Middleware](https://github.com/awslabs/smithy-kotlin/blob/v0.14.0/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/Middleware.kt#L13). 
+terms of [Middleware](https://github.com/smithy-lang/smithy-kotlin/blob/v0.14.0/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/Middleware.kt#L13). 
 The anticipation is that these middleware components will be pulled into `SdkOperationExecution` as explicit phases 
 (similar to serialization and deserialization). The middleware as it exists today will be removed and relocated to these
 new explicit phases. This should be safe to do as every operation typically has a retry and signing middleware and those

--- a/docs/design/kotlin-smithy-sdk.md
+++ b/docs/design/kotlin-smithy-sdk.md
@@ -543,7 +543,7 @@ use the provided enum name.
 
 The value will be stored as an abstract property on the sealed class and each variant will have to override it. This
 allows enums to be applied to other types in the future if Smithy
-[evolves to allow it](https://github.com/awslabs/smithy/issues/98).
+[evolves to allow it](https://github.com/smithy-lang/smithy/issues/98).
 
 ```
 @enum("YES": {}, "NO": {})

--- a/docs/design/modeled-errors.md
+++ b/docs/design/modeled-errors.md
@@ -179,11 +179,11 @@ public open class AwsServiceException : ServiceException {
 These two fields `requestId` and `errorCode` both result in conflicts in a handful of models (and subsequently fails to compile) because the errors themselves have fields with matching names.
 
 
-See: https://github.com/awslabs/smithy-kotlin/issues/110
+See: https://github.com/smithy-lang/smithy-kotlin/issues/110
 
 As you can see this inherits from another type `ServiceException` which defines several other (un-modeled) fields further increasing the chance of a conflict. This also means that future modifications to the hierarchy could be difficult due to possible conflicts.
 
-The exception hierarchy is defined [here](https://github.com/awslabs/smithy-kotlin/blob/v0.1.0-M0/client-runtime/client-rt-core/common/src/software/aws/clientrt/Exceptions.kt) and further extended [here](https://github.com/awslabs/aws-sdk-kotlin/blob/v0.1.0-M0/client-runtime/aws-client-rt/common/src/aws/sdk/kotlin/runtime/Exceptions.kt).
+The exception hierarchy is defined [here](https://github.com/smithy-lang/smithy-kotlin/blob/v0.1.0-M0/client-runtime/client-rt-core/common/src/software/aws/clientrt/Exceptions.kt) and further extended [here](https://github.com/awslabs/aws-sdk-kotlin/blob/v0.1.0-M0/client-runtime/aws-client-rt/common/src/aws/sdk/kotlin/runtime/Exceptions.kt).
 
 
 #### 2. A desire to remove mutability

--- a/docs/design/structured-concurrency.md
+++ b/docs/design/structured-concurrency.md
@@ -18,9 +18,9 @@ used by the SDK. It is meant to be a living document and provide additional cont
 
 The SDK has three implementations of `CoroutineScope`:
 
-1. [ExecutionContext](https://github.com/awslabs/smithy-kotlin/blob/main/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/operation/ExecutionContext.kt)
-2. [HttpClientEngine](https://github.com/awslabs/smithy-kotlin/blob/main/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngine.kt)
-3. [HttpCall](https://github.com/awslabs/smithy-kotlin/blob/main/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpCall.kt)
+1. [ExecutionContext](https://github.com/smithy-lang/smithy-kotlin/blob/main/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/operation/ExecutionContext.kt)
+2. [HttpClientEngine](https://github.com/smithy-lang/smithy-kotlin/blob/main/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngine.kt)
+3. [HttpCall](https://github.com/smithy-lang/smithy-kotlin/blob/main/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpCall.kt)
     
 
 `ExecutionContext` implements `CoroutineScope` to provide a place for any background work to be done as part of implementing an operation. 

--- a/docs/design/waiters.md
+++ b/docs/design/waiters.md
@@ -376,7 +376,7 @@ val matcher: (DescribeBatchPredictionsOutput) -> Boolean = {
 ```
 
 Smithy provides
-[a JMESPath parser](https://github.com/awslabs/smithy/tree/main/smithy-jmespath/src/main/java/software/amazon/smithy/jmespath)
+[a JMESPath parser](https://github.com/smithy-lang/smithy/tree/main/smithy-jmespath/src/main/java/software/amazon/smithy/jmespath)
 with visitor pattern that can be used for codegenning path-based matchers.
 
 #### Rejected alternatives

--- a/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultCanonicalizerTest.kt
+++ b/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultCanonicalizerTest.kt
@@ -77,7 +77,7 @@ class DefaultCanonicalizerTest {
         assertEquals(expectedHeaders, actual.request.headers.entries())
     }
 
-    // Targeted test for proper URI path escaping. See https://github.com/awslabs/smithy-kotlin/issues/657
+    // Targeted test for proper URI path escaping. See https://github.com/smithy-lang/smithy-kotlin/issues/657
     @Test
     fun testEscapablePath() {
         val uri = Url.Builder()

--- a/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSignatureCalculatorTest.kt
+++ b/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSignatureCalculatorTest.kt
@@ -84,7 +84,7 @@ class DefaultSignatureCalculatorTest {
     fun testChunkStringToSign() {
         // Test event stream signing
         // https://docs.aws.amazon.com/transcribe/latest/dg/streaming-http2.html
-        // Adapted from: https://github.com/awslabs/smithy-rs/blob/v0.38.0/aws/rust-runtime/aws-sigv4/src/event_stream.rs#L166
+        // Adapted from: https://github.com/smithy-lang/smithy-rs/blob/v0.38.0/aws/rust-runtime/aws-sigv4/src/event_stream.rs#L166
         val tests = listOf(
             ChunkStringToSignTest(AwsSignatureType.HTTP_REQUEST_CHUNK, HashSpecification.EmptyBody.hash),
             ChunkStringToSignTest(

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -103,7 +103,7 @@ public actual abstract class SigningSuiteTestBase : HasSigner {
     }
 
     protected open val disabledTests: Set<String> = setOf(
-        // TODO https://github.com/awslabs/smithy-kotlin/issues/653
+        // TODO https://github.com/smithy-lang/smithy-kotlin/issues/653
         // ktor-http-cio parser doesn't support parsing multiline headers since they are deprecated in RFC7230
         "get-header-value-multiline",
         // ktor fails to parse with space in it (expects it to be a valid request already encoded)

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
@@ -36,7 +36,7 @@ class AwsJsonProtocolTest {
 
         assertEquals("application/x-amz-json-1.1", request.headers["Content-Type"])
         // ensure we use the original shape id name, NOT the one from the context
-        // see: https://github.com/awslabs/smithy-kotlin/issues/316
+        // see: https://github.com/smithy-lang/smithy-kotlin/issues/316
         assertEquals("FooService_blah.Bar", request.headers["X-Amz-Target"])
     }
 

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
@@ -93,7 +93,7 @@ public fun Headers.toOkHttpHeaders(): OkHttpHeaders = OkHttpHeaders.Builder().al
     }
 
     if ("Accept-Encoding" !in this) {
-        // Disable OkHttp transparent response decompression. See https://github.com/awslabs/smithy-kotlin/issues/1041
+        // Disable OkHttp transparent response decompression. See https://github.com/smithy-lang/smithy-kotlin/issues/1041
         okHeaders.addUnsafeNonAscii("Accept-Encoding", "identity")
     }
 }.build()

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
@@ -86,7 +86,7 @@ class OkHttpRequestTest {
         assertEquals(listOf("\uD83E\uDD7D"), actual.headers("foo"))
     }
 
-    // https://github.com/awslabs/smithy-kotlin/issues/1041
+    // https://github.com/smithy-lang/smithy-kotlin/issues/1041
     @Test
     fun itAddsAcceptEncodingHeader() {
         val url = Url.parse("https://aws.amazon.com")
@@ -103,7 +103,7 @@ class OkHttpRequestTest {
         assertEquals(listOf("identity"), actual.headers("Accept-Encoding"))
     }
 
-    // https://github.com/awslabs/smithy-kotlin/issues/1041
+    // https://github.com/smithy-lang/smithy-kotlin/issues/1041
     @Test
     fun itDoesNotModifyAcceptEncodingHeaderIfAlreadySet() {
         val url = Url.parse("https://aws.amazon.com")

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/StreamingRequestBodyTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/StreamingRequestBodyTest.kt
@@ -114,7 +114,7 @@ class StreamingRequestBodyTest {
 
         job.cancel()
         withTimeout(2.seconds) {
-            // See https://github.com/awslabs/smithy-kotlin/issues/739
+            // See https://github.com/smithy-lang/smithy-kotlin/issues/739
             // writeTo() should end up blocked waiting for data that will never come.
             // If the job used in the implementation isn't tied to the parent coroutine correctly
             // it will block forever

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
@@ -137,7 +137,7 @@ class UploadTest : AbstractEngineTest() {
     @Test
     fun testUploadWithWrappedStream() = testEngines {
         // test custom ByteStream behavior
-        // see https://github.com/awslabs/smithy-kotlin/issues/613
+        // see https://github.com/smithy-lang/smithy-kotlin/issues/613
         test { _, client ->
             val data = ByteArray(1024 * 1024) { it.toByte() }
             val sha = data.sha256().encodeToHex()

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/FileUploadDownloadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/FileUploadDownloadTest.kt
@@ -80,7 +80,7 @@ class FileUploadDownloadTest : AbstractEngineTest() {
         }
     }
 
-    // https://github.com/awslabs/smithy-kotlin/issues/1041
+    // https://github.com/smithy-lang/smithy-kotlin/issues/1041
     @Test
     fun testDownloadCompressedPayload() = testEngines {
         test { _, client ->

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/time/ParseRfc5322Test.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/time/ParseRfc5322Test.kt
@@ -34,7 +34,7 @@ class ParseRfc5322Test {
         ParseTest("Sun, 06 Nov 1994 08:49:37 UTC", 1994, 11, 6, 8, 49, 37, 0, 0),
         ParseTest("Sun, 06 Nov 1994 08:49:37 UT", 1994, 11, 6, 8, 49, 37, 0, 0),
         ParseTest("Sun, 06 Nov 1994 08:49:37 Z", 1994, 11, 6, 8, 49, 37, 0, 0),
-        // fractional seconds (required by awsJson1.1 apparently). See: https://github.com/awslabs/smithy/blob/master/smithy-aws-protocol-tests/model/awsJson1_1/kitchen-sink.smithy#L682
+        // fractional seconds (required by awsJson1.1 apparently). See: https://github.com/smithy-lang/smithy/blob/master/smithy-aws-protocol-tests/model/awsJson1_1/kitchen-sink.smithy#L682
         ParseTest("Sun, 06 Nov 1994 08:49:37.001 GMT", 1994, 11, 6, 8, 49, 37, 1_000_000, 0),
     )
 

--- a/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
+++ b/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
@@ -169,7 +169,7 @@ private class FormUrlStructSerializer(
 
     override fun structField(descriptor: SdkFieldDescriptor, block: StructSerializer.() -> Unit) {
         // FIXME - do we even use this function in any of the formats? It seems like we go through `field(.., SdkSerializable)` ??
-        // https://github.com/awslabs/smithy-kotlin/issues/314
+        // https://github.com/smithy-lang/smithy-kotlin/issues/314
         TODO("Not yet implemented")
     }
 

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriterTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriterTest.kt
@@ -73,7 +73,7 @@ class XmlStreamWriterTest {
     }
 
     // The following escape tests were adapted from
-    // https://github.com/awslabs/smithy-rs/blob/c15289a7163cb6344b088a0ee39244df2967070a/rust-runtime/smithy-xml/src/unescape.rs
+    // https://github.com/smithy-lang/smithy-rs/blob/c15289a7163cb6344b088a0ee39244df2967070a/rust-runtime/smithy-xml/src/unescape.rs
     @Test
     fun itHandlesEscaping() {
         val testCases = mapOf(

--- a/tests/codegen/serde-tests/src/test/kotlin/aws/smithy/kotlin/tests/serde/XmlMapTest.kt
+++ b/tests/codegen/serde-tests/src/test/kotlin/aws/smithy/kotlin/tests/serde/XmlMapTest.kt
@@ -246,7 +246,7 @@ class XmlMapTest : AbstractXmlTest() {
 
     @Test
     fun testEnumKeyMap() {
-        // see also https://github.com/awslabs/smithy-kotlin/issues/1045
+        // see also https://github.com/smithy-lang/smithy-kotlin/issues/1045
         val expected = StructType {
             enumKeyMap = mapOf(
                 FooEnum.Foo to 1,

--- a/tests/codegen/serde-tests/src/test/kotlin/aws/smithy/kotlin/tests/serde/XmlUnionTest.kt
+++ b/tests/codegen/serde-tests/src/test/kotlin/aws/smithy/kotlin/tests/serde/XmlUnionTest.kt
@@ -266,7 +266,7 @@ class XmlUnionTest : AbstractXmlTest() {
         testRoundTrip(expected, payload, ::serializeStructTypeDocument, ::deserializeStructTypeDocument)
     }
 
-    // FIXME - https://github.com/awslabs/smithy-kotlin/issues/1040
+    // FIXME - https://github.com/smithy-lang/smithy-kotlin/issues/1040
     // @Test
     // fun testUnitField() { }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
