### PR TITLE
fix: Check if an `InputStream` is replayable when setting `isOneShot`

### DIFF
--- a/.changes/68aac1d5-64f9-4569-bf95-db8d5712a2df.json
+++ b/.changes/68aac1d5-64f9-4569-bf95-db8d5712a2df.json
@@ -1,0 +1,5 @@
+{
+    "id": "68aac1d5-64f9-4569-bf95-db8d5712a2df",
+    "type": "bugfix",
+    "description": "Infer the replayability of `InputStream` using `markSupported()` when setting `isOneShot`"
+}

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
@@ -117,7 +117,7 @@ public fun InputStream.asByteStream(contentLength: Long? = null): ByteStream.Sou
     val source = source()
     return object : ByteStream.SourceStream() {
         override val contentLength: Long? = contentLength
-        override val isOneShot: Boolean = true
+        override val isOneShot: Boolean = !markSupported()
         override fun readFrom(): SdkSource = source
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
