### PR TITLE
misc: override toString in business metrics

### DIFF
--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -103,6 +103,7 @@ public final class aws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetri
 	public static final field WAITER Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public fun getIdentifier ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
 	public static fun values ()[Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/businessmetrics/BusinessMetricsUtils.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/businessmetrics/BusinessMetricsUtils.kt
@@ -90,4 +90,7 @@ public enum class SmithyBusinessMetric(public override val identifier: String) :
     SERVICE_ENDPOINT_OVERRIDE("N"),
     ACCOUNT_ID_BASED_ENDPOINT("O"),
     SIGV4A_SIGNING("S"),
+    ;
+
+    override fun toString(): String = identifier
 }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/businessmetrics/BusinessMetricsUtilsTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/businessmetrics/BusinessMetricsUtilsTest.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.businessmetrics
 import aws.smithy.kotlin.runtime.collections.get
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -54,5 +55,13 @@ class BusinessMetricsUtilsTest {
 
         executionContext.removeBusinessMetric(SmithyBusinessMetric.GZIP_REQUEST_COMPRESSION)
         assertFalse(executionContext.containsBusinessMetric(SmithyBusinessMetric.GZIP_REQUEST_COMPRESSION))
+    }
+
+    @Test
+    fun businessMetricToString() {
+        val businessMetricToString = SmithyBusinessMetric.GZIP_REQUEST_COMPRESSION.toString()
+        val businessMetricIdentifier = SmithyBusinessMetric.GZIP_REQUEST_COMPRESSION.identifier
+
+        assertEquals(businessMetricIdentifier, businessMetricToString)
     }
 }


### PR DESCRIPTION
These changes are related to malformed business metrics we are seeing in the `User-Agent` header.

Also see: https://github.com/awslabs/aws-sdk-kotlin/pull/1474

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
