### PR TITLE
fix: remove usage of `java.time.Duration` from `OkHttpEngineConfig.buildClientFromConfig`

### DIFF
--- a/.changes/dbca7fdf-0135-4492-9b23-6c00f8b92bea.json
+++ b/.changes/dbca7fdf-0135-4492-9b23-6c00f8b92bea.json
@@ -1,0 +1,5 @@
+{
+    "id": "dbca7fdf-0135-4492-9b23-6c00f8b92bea",
+    "type": "bugfix",
+    "description": "Remove usage of `java.time.Duration` from `OkHttpEngineConfig.buildClientFromConfig`"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -20,7 +20,6 @@ import okhttp3.*
 import okhttp3.ConnectionPool
 import okhttp3.coroutines.executeAsync
 import java.util.concurrent.TimeUnit
-import kotlin.time.toJavaDuration
 import aws.smithy.kotlin.runtime.net.TlsVersion as SdkTlsVersion
 import okhttp3.TlsVersion as OkHttpTlsVersion
 
@@ -95,9 +94,9 @@ private fun OkHttpEngineConfig.buildClientFromConfig(
         // appropriately internally). We don't want inner retry logic that inflates the number of retries.
         retryOnConnectionFailure(false)
 
-        connectTimeout(config.connectTimeout.toJavaDuration())
-        readTimeout(config.socketReadTimeout.toJavaDuration())
-        writeTimeout(config.socketWriteTimeout.toJavaDuration())
+        connectTimeout(config.connectTimeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
+        readTimeout(config.socketReadTimeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
+        writeTimeout(config.socketWriteTimeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
 
         // use our own pool configured with the timeout settings taken from config
         val pool = poolOverride ?: ConnectionPool(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
