### PR TITLE
fix: correctly serialize subset of shape's members when configured

### DIFF
--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/QueryHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/QueryHttpBindingProtocolGenerator.kt
@@ -145,7 +145,7 @@ abstract class AbstractQueryFormUrlSerializerGenerator(
         return shape.documentSerializer(ctx.settings, symbol, members) { writer ->
             writer.openBlock("internal fun #identifier.name:L(serializer: #T, input: #T) {", RuntimeTypes.Serde.Serializer, symbol)
                 .call {
-                    renderSerializerBody(ctx, shape, shape.members().toList(), writer)
+                    renderSerializerBody(ctx, shape, members.toList(), writer)
                 }
                 .closeBlock("}")
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/CborSerializerGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/CborSerializerGenerator.kt
@@ -108,7 +108,7 @@ class CborSerializerGenerator(
         val symbol = ctx.symbolProvider.toSymbol(shape)
         return shape.documentSerializer(ctx.settings, symbol, members) { writer ->
             writer.withBlock("internal fun #identifier.name:L(serializer: #T, input: #T) {", "}", RuntimeTypes.Serde.Serializer, symbol) {
-                call { renderSerializerBody(ctx, shape, shape.members().toList(), writer) }
+                call { renderSerializerBody(ctx, shape, members.toList(), writer) }
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
