### PR TITLE
feat: Kotlin/Native implementation of BigDecimal and BigInteger

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ kotlin.code.style=official
 kotlin.incremental.js=true
 kotlin.incremental.multiplatform=true
 kotlin.mpp.stability.nowarn=true
+kotlin.native.binary.sourceInfoType=libbacktrace
 kotlin.native.ignoreDisabledTargets=true
 
 # atomicfu

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.incremental.js=true
 kotlin.incremental.multiplatform=true
 kotlin.mpp.stability.nowarn=true
-kotlin.native.binary.sourceInfoType=libbacktrace
+# kotlin.native.binary.sourceInfoType=libbacktrace
 kotlin.native.ignoreDisabledTargets=true
 
 # atomicfu

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ slf4j-version = "2.0.16"
 slf4j-v1x-version = "1.7.36"
 crt-kotlin-version = "0.8.10"
 micrometer-version = "1.13.6"
+kotlin-multiplatform-bignum-version = "0.3.10"
 
 # codegen
 smithy-version = "1.51.0"
@@ -100,6 +101,8 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor-ve
 
 kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml-version" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup-version" }
+
+kotlin-multiplatform-bignum = { module = "com.ionspin.kotlin:bignum", version.ref = "kotlin-multiplatform-bignum-version" }
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka-version"}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -343,6 +343,7 @@ public final class aws/smithy/kotlin/runtime/config/EnvironmentSettingKt {
 public final class aws/smithy/kotlin/runtime/content/BigDecimal : java/lang/Number, java/lang/Comparable {
 	public fun <init> (Laws/smithy/kotlin/runtime/content/BigInteger;I)V
 	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/math/BigDecimal;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun byteValue ()B
 	public fun compareTo (Laws/smithy/kotlin/runtime/content/BigDecimal;)I
 	public synthetic fun compareTo (Ljava/lang/Object;)I
@@ -351,9 +352,11 @@ public final class aws/smithy/kotlin/runtime/content/BigDecimal : java/lang/Numb
 	public final fun floatValue ()F
 	public final fun getExponent ()I
 	public final fun getMantissa ()Laws/smithy/kotlin/runtime/content/BigInteger;
-	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
 	public final fun intValue ()I
 	public final fun longValue ()J
+	public final fun minus (Laws/smithy/kotlin/runtime/content/BigDecimal;)Laws/smithy/kotlin/runtime/content/BigDecimal;
+	public final fun plus (Laws/smithy/kotlin/runtime/content/BigDecimal;)Laws/smithy/kotlin/runtime/content/BigDecimal;
 	public final fun shortValue ()S
 	public fun toByte ()B
 	public fun toDouble ()D
@@ -362,6 +365,7 @@ public final class aws/smithy/kotlin/runtime/content/BigDecimal : java/lang/Numb
 	public fun toLong ()J
 	public final fun toPlainString ()Ljava/lang/String;
 	public fun toShort ()S
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class aws/smithy/kotlin/runtime/content/BigInteger : java/lang/Number, java/lang/Comparable {
@@ -373,7 +377,6 @@ public final class aws/smithy/kotlin/runtime/content/BigInteger : java/lang/Numb
 	public final fun doubleValue ()D
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun floatValue ()F
-	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun intValue ()I
 	public final fun longValue ()J
@@ -388,6 +391,8 @@ public final class aws/smithy/kotlin/runtime/content/BigInteger : java/lang/Numb
 	public fun toLong ()J
 	public fun toShort ()S
 	public fun toString ()Ljava/lang/String;
+	public final fun toString (I)Ljava/lang/String;
+	public static synthetic fun toString$default (Laws/smithy/kotlin/runtime/content/BigInteger;IILjava/lang/Object;)Ljava/lang/String;
 }
 
 public abstract class aws/smithy/kotlin/runtime/content/ByteStream {

--- a/runtime/runtime-core/build.gradle.kts
+++ b/runtime/runtime-core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -40,6 +42,12 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(libs.kaml)
+            }
+        }
+
+        nativeMain {
+            dependencies {
+                implementation(libs.kotlin.multiplatform.bignum)
             }
         }
 

--- a/runtime/runtime-core/build.gradle.kts
+++ b/runtime/runtime-core/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigDecimal.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigDecimal.kt
@@ -11,32 +11,94 @@ package aws.smithy.kotlin.runtime.content
 public expect class BigDecimal(value: String) :
     Number,
     Comparable<BigDecimal> {
+
     /**
      * Create an instance of [BigDecimal] from a mantissa and exponent.
-     * @param mantissa a [BigInteger] representing the mantissa of this big decimal
-     * @param exponent an [Int] representing the exponent of this big decimal
+     * @param mantissa a [BigInteger] representing the [significant digits](https://en.wikipedia.org/wiki/Significand)
+     * of this decimal value
+     * @param exponent an [Int] representing the exponent of this decimal value
      */
     public constructor(mantissa: BigInteger, exponent: Int)
 
     /**
-     * The mantissa of this decimal number
+     * The [significant digits](https://en.wikipedia.org/wiki/Significand) of this decimal value
      */
     public val mantissa: BigInteger
 
     /**
-     * The exponent of this decimal number.
-     * If zero or positive, this represents the number of digits to the right of the decimal point.
-     * If negative, the mantissa is multiplied by ten to the power of the negation of the scale.
+     * The exponent of this decimal number. If zero or positive, this represents the number of digits to the right of
+     * the decimal point. If negative, the [mantissa] is multiplied by ten to the power of the negation of the scale.
      */
     public val exponent: Int
 
+    /**
+     * Converts this value to a [Byte], which may involve rounding or truncation
+     */
     override fun toByte(): Byte
+
+    /**
+     * Converts this value to a [Double], which may involve rounding or truncation
+     */
     override fun toDouble(): Double
+
+    /**
+     * Converts this value to a [Float], which may involve rounding or truncation
+     */
     override fun toFloat(): Float
+
+    /**
+     * Converts this value to a [Short], which may involve rounding or truncation
+     */
     override fun toShort(): Short
+
+    /**
+     * Converts this value to an [Int], which may involve rounding or truncation
+     */
     override fun toInt(): Int
+
+    /**
+     * Converts this value to a [Long], which may involve rounding or truncation
+     */
     override fun toLong(): Long
+
+    /**
+     * Returns the decimal (i.e., radix-10) string representation of this value in long-form (i.e., _not_ scientific)
+     * notation
+     */
     public fun toPlainString(): String
+
+    /**
+     * Returns the decimal (i.e., radix-10) string representation of this value using scientific notation if an exponent
+     * is needed
+     */
+    override fun toString(): String
+
+    /**
+     * Returns a hash code for this value
+     */
+    override fun hashCode(): Int
+
+    /**
+     * Checks if this value is equal to the given object
+     * @param other The other value to compare against
+     */
     override fun equals(other: Any?): Boolean
+
+    /**
+     * Returns the sum of this value and the given value
+     * @param other The other value to add (i.e., the addend)
+     */
+    public operator fun plus(other: BigDecimal): BigDecimal
+
+    /**
+     * Returns the difference of this value and the given value
+     * @param other The value to subtract (i.e., the subtrahend)
+     */
+    public operator fun minus(other: BigDecimal): BigDecimal
+
+    /**
+     * Compare this value to the given value for in/equality
+     * @param other The value to compare against
+     */
     public override operator fun compareTo(other: BigDecimal): Int
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigInteger.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigInteger.kt
@@ -11,23 +11,86 @@ package aws.smithy.kotlin.runtime.content
 public expect class BigInteger(value: String) :
     Number,
     Comparable<BigInteger> {
+
     /**
      * Create an instance of [BigInteger] from a [ByteArray]
      * @param bytes ByteArray representing the large integer
      */
     public constructor(bytes: ByteArray)
 
+    /**
+     * Converts this value to a [Byte], which may involve rounding or truncation
+     */
     override fun toByte(): Byte
+
+    /**
+     * Converts this value to a [Long], which may involve rounding or truncation
+     */
     override fun toLong(): Long
+
+    /**
+     * Converts this value to a [Short], which may involve rounding or truncation
+     */
     override fun toShort(): Short
+
+    /**
+     * Converts this value to an [Int], which may involve rounding or truncation
+     */
     override fun toInt(): Int
+
+    /**
+     * Converts this value to a [Float], which may involve rounding or truncation
+     */
     override fun toFloat(): Float
+
+    /**
+     * Converts this value to a [Double], which may involve rounding or truncation
+     */
     override fun toDouble(): Double
+
+    /**
+     * Returns the decimal (i.e., radix-10) string representation of this value
+     */
     override fun toString(): String
+
+    /**
+     * Returns a string representation of this value in the given radix
+     * @param radix The [numerical base](https://en.wikipedia.org/wiki/Radix) in which to represent the value
+     */
+    public fun toString(radix: Int = 10): String
+
+    /**
+     * Returns a hash code for this value
+     */
     override fun hashCode(): Int
+
+    /**
+     * Checks if this value is equal to the given object
+     * @param other The other value to compare against
+     */
     override fun equals(other: Any?): Boolean
+
+    /**
+     * Returns the sum of this value and the given value
+     * @param other The other value to add (i.e., the addend)
+     */
     public operator fun plus(other: BigInteger): BigInteger
+
+    /**
+     * Returns the difference of this value and the given value
+     * @param other The value to subtract (i.e., the subtrahend)
+     */
     public operator fun minus(other: BigInteger): BigInteger
+
+    /**
+     * Returns the [two's complement](https://en.wikipedia.org/wiki/Two%27s_complement) binary representation of this
+     * value
+     */
     public fun toByteArray(): ByteArray
+
+    /**
+     * Compare this value to the given value for in/equality
+     * @param other The value to compare against
+     */
     public override operator fun compareTo(other: BigInteger): Int
 }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/BigIntegerTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/BigIntegerTest.kt
@@ -77,7 +77,6 @@ class BigIntegerTest {
             "0x123456789abcdef0" to "1311768467463790320",
             "0x00ffffffffffffffffffffffffffffffec" to "340282366920938463463374607431768211436",
             "0x81445edf51ddc07216da5621c727bfd379d400f3da08018d45749a" to "-52134902384590238490284023839028330923830129830129301234239834982",
-
         )
 
         tests.forEach { (hex, expected) ->

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
@@ -4,33 +4,52 @@
  */
 package aws.smithy.kotlin.runtime.content
 
-public actual class BigDecimal actual constructor(public val value: String) :
+import java.math.BigDecimal as JvmBigDecimal
+
+public actual class BigDecimal private constructor(private val delegate: JvmBigDecimal) :
     Number(),
     Comparable<BigDecimal> {
-    private val delegate = java.math.BigDecimal(value)
 
-    public actual constructor(mantissa: BigInteger, exponent: Int) : this(
-        java.math.BigDecimal(
-            java.math.BigInteger(mantissa.toString()),
-            exponent,
-        ).toPlainString(),
-    )
+    private companion object {
+        /**
+         * Returns a new or existing [BigDecimal] wrapper for the given delegate [value]
+         * @param value The delegate value to wrap
+         * @param left A candidate wrapper which may already contain [value]
+         * @param right A candidate wrapper which may already contain [value]
+         */
+        fun coalesceOrCreate(value: JvmBigDecimal, left: BigDecimal, right: BigDecimal): BigDecimal = when (value) {
+            left.delegate -> left
+            right.delegate -> right
+            else -> BigDecimal(value)
+        }
+    }
+
+    public actual constructor(value: String) : this(JvmBigDecimal(value))
+    public actual constructor(mantissa: BigInteger, exponent: Int) : this(JvmBigDecimal(mantissa.delegate, exponent))
 
     public actual fun toPlainString(): String = delegate.toPlainString()
-    actual override fun toByte(): Byte = delegate.toByte()
-    actual override fun toDouble(): Double = delegate.toDouble()
-    actual override fun toFloat(): Float = delegate.toFloat()
-    actual override fun toInt(): Int = delegate.toInt()
-    actual override fun toLong(): Long = delegate.toLong()
-    actual override fun toShort(): Short = delegate.toShort()
+    public actual override fun toString(): String = delegate.toString()
+    public actual override fun toByte(): Byte = delegate.toByte()
+    public actual override fun toDouble(): Double = delegate.toDouble()
+    public actual override fun toFloat(): Float = delegate.toFloat()
+    public actual override fun toInt(): Int = delegate.toInt()
+    public actual override fun toLong(): Long = delegate.toLong()
+    public actual override fun toShort(): Short = delegate.toShort()
 
-    actual override fun equals(other: Any?): Boolean = other is BigDecimal && delegate == other.delegate
+    public actual override fun equals(other: Any?): Boolean = other is BigDecimal && delegate == other.delegate
+    public actual override fun hashCode(): Int = 31 + delegate.hashCode()
 
     public actual val mantissa: BigInteger
-        get() = BigInteger(delegate.unscaledValue().toString())
+        get() = BigInteger(delegate.unscaledValue())
 
     public actual val exponent: Int
         get() = delegate.scale()
+
+    public actual operator fun plus(other: BigDecimal): BigDecimal =
+        coalesceOrCreate(delegate + other.delegate, this, other)
+
+    public actual operator fun minus(other: BigDecimal): BigDecimal =
+        coalesceOrCreate(delegate - other.delegate, this, other)
 
     actual override fun compareTo(other: BigDecimal): Int = delegate.compareTo(other.delegate)
 }

--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigIntegerNative.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigIntegerNative.kt
@@ -4,37 +4,38 @@
  */
 package aws.smithy.kotlin.runtime.content
 
-public actual class BigInteger actual constructor(value: String) :
+import com.ionspin.kotlin.bignum.integer.util.fromTwosComplementByteArray
+import com.ionspin.kotlin.bignum.integer.util.toTwosComplementByteArray
+import com.ionspin.kotlin.bignum.integer.BigInteger as IonSpinBigInteger
+
+public actual class BigInteger private constructor(private val delegate: IonSpinBigInteger) :
     Number(),
     Comparable<BigInteger> {
-    public actual constructor(bytes: ByteArray) : this("Not yet implemented")
 
-    actual override fun toByte(): Byte {
-        TODO("Not yet implemented")
+    private companion object {
+        fun coalesceOrCreate(value: IonSpinBigInteger, left: BigInteger, right: BigInteger): BigInteger = when (value) {
+            left.delegate -> left
+            right.delegate -> right
+            else -> BigInteger(value)
+        }
     }
 
-    actual override fun toDouble(): Double {
-        TODO("Not yet implemented")
-    }
+    public actual constructor(value: String) : this(IonSpinBigInteger.parseString(value, 10))
+    public actual constructor(bytes: ByteArray) : this(IonSpinBigInteger.fromTwosComplementByteArray(bytes))
 
-    actual override fun toFloat(): Float {
-        TODO("Not yet implemented")
-    }
+    actual override fun toByte(): Byte = delegate.byteValue(exactRequired = false)
+    actual override fun toDouble(): Double = delegate.doubleValue(exactRequired = false)
+    actual override fun toFloat(): Float = delegate.floatValue(exactRequired = false)
+    actual override fun toInt(): Int = delegate.intValue(exactRequired = false)
+    actual override fun toLong(): Long = delegate.longValue(exactRequired = false)
+    actual override fun toShort(): Short = delegate.shortValue(exactRequired = false)
 
-    actual override fun toInt(): Int {
-        TODO("Not yet implemented")
-    }
+    public actual operator fun plus(other: BigInteger): BigInteger =
+        coalesceOrCreate(delegate + other.delegate, this, other)
 
-    actual override fun toLong(): Long {
-        TODO("Not yet implemented")
-    }
+    public actual operator fun minus(other: BigInteger): BigInteger =
+        coalesceOrCreate(delegate - other.delegate, this, other)
 
-    actual override fun toShort(): Short {
-        TODO("Not yet implemented")
-    }
-
-    public actual operator fun plus(other: BigInteger): BigInteger = TODO("Not yet implemented")
-    public actual operator fun minus(other: BigInteger): BigInteger = TODO("Not yet implemented")
-    public actual fun toByteArray(): ByteArray = TODO("Not yet implemented")
-    actual override fun compareTo(other: BigInteger): Int = TODO("Not yet implemented")
+    public actual fun toByteArray(): ByteArray = delegate.toTwosComplementByteArray()
+    actual override fun compareTo(other: BigInteger): Int = delegate.compare(other.delegate)
 }

--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigIntegerNative.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigIntegerNative.kt
@@ -8,11 +8,17 @@ import com.ionspin.kotlin.bignum.integer.util.fromTwosComplementByteArray
 import com.ionspin.kotlin.bignum.integer.util.toTwosComplementByteArray
 import com.ionspin.kotlin.bignum.integer.BigInteger as IonSpinBigInteger
 
-public actual class BigInteger private constructor(private val delegate: IonSpinBigInteger) :
+public actual class BigInteger internal constructor(internal val delegate: IonSpinBigInteger) :
     Number(),
     Comparable<BigInteger> {
 
     private companion object {
+        /**
+         * Returns a new or existing [BigInteger] wrapper for the given delegate [value]
+         * @param value The delegate value to wrap
+         * @param left A candidate wrapper which may already contain [value]
+         * @param right A candidate wrapper which may already contain [value]
+         */
         fun coalesceOrCreate(value: IonSpinBigInteger, left: BigInteger, right: BigInteger): BigInteger = when (value) {
             left.delegate -> left
             right.delegate -> right
@@ -23,12 +29,12 @@ public actual class BigInteger private constructor(private val delegate: IonSpin
     public actual constructor(value: String) : this(IonSpinBigInteger.parseString(value, 10))
     public actual constructor(bytes: ByteArray) : this(IonSpinBigInteger.fromTwosComplementByteArray(bytes))
 
-    actual override fun toByte(): Byte = delegate.byteValue(exactRequired = false)
-    actual override fun toDouble(): Double = delegate.doubleValue(exactRequired = false)
-    actual override fun toFloat(): Float = delegate.floatValue(exactRequired = false)
-    actual override fun toInt(): Int = delegate.intValue(exactRequired = false)
-    actual override fun toLong(): Long = delegate.longValue(exactRequired = false)
-    actual override fun toShort(): Short = delegate.shortValue(exactRequired = false)
+    public actual override fun toByte(): Byte = delegate.byteValue(exactRequired = false)
+    public actual override fun toDouble(): Double = delegate.doubleValue(exactRequired = false)
+    public actual override fun toFloat(): Float = delegate.floatValue(exactRequired = false)
+    public actual override fun toInt(): Int = delegate.intValue(exactRequired = false)
+    public actual override fun toLong(): Long = delegate.longValue(exactRequired = false)
+    public actual override fun toShort(): Short = delegate.shortValue(exactRequired = false)
 
     public actual operator fun plus(other: BigInteger): BigInteger =
         coalesceOrCreate(delegate + other.delegate, this, other)
@@ -37,5 +43,9 @@ public actual class BigInteger private constructor(private val delegate: IonSpin
         coalesceOrCreate(delegate - other.delegate, this, other)
 
     public actual fun toByteArray(): ByteArray = delegate.toTwosComplementByteArray()
-    actual override fun compareTo(other: BigInteger): Int = delegate.compare(other.delegate)
+    public actual override fun compareTo(other: BigInteger): Int = delegate.compare(other.delegate)
+    public actual override fun equals(other: Any?): Boolean = other is BigInteger && other.delegate == delegate
+    public actual override fun hashCode(): Int = 17 + delegate.hashCode()
+    public actual override fun toString(): String = toString(10)
+    public actual fun toString(radix: Int): String = delegate.toString(radix)
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change implements Kotlin/Native support for `BigInteger`/`BigDecimal` by way of the [IonSpin **kotlin-multiplatform-bignum**](https://github.com/ionspin/kotlin-multiplatform-bignum) library. This change adds a workaround for building **smithy-kotlin** on Amazon Linux 2 because of linking issues with zlib (see **[runtime/build.gradle.kts](https://github.com/smithy-lang/smithy-kotlin/compare/kn-main...kn-bignums?expand=1#diff-23f01691d6dba0dd32c4e07f9490975ea4bfe9c0a29a6a004fd8b51c7a952c1a)**).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
