### PR TITLE
feat: provide client config property for region provider

### DIFF
--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -488,6 +488,10 @@ public final class aws/smithy/kotlin/runtime/content/Document$List : aws/smithy/
 	public synthetic fun add (Ljava/lang/Object;)Z
 	public fun addAll (ILjava/util/Collection;)Z
 	public fun addAll (Ljava/util/Collection;)Z
+	public fun addFirst (Laws/smithy/kotlin/runtime/content/Document;)V
+	public synthetic fun addFirst (Ljava/lang/Object;)V
+	public fun addLast (Laws/smithy/kotlin/runtime/content/Document;)V
+	public synthetic fun addLast (Ljava/lang/Object;)V
 	public fun clear ()V
 	public final fun component1 ()Ljava/util/List;
 	public fun contains (Laws/smithy/kotlin/runtime/content/Document;)Z
@@ -513,6 +517,10 @@ public final class aws/smithy/kotlin/runtime/content/Document$List : aws/smithy/
 	public synthetic fun remove (I)Ljava/lang/Object;
 	public fun remove (Ljava/lang/Object;)Z
 	public fun removeAll (Ljava/util/Collection;)Z
+	public fun removeFirst ()Laws/smithy/kotlin/runtime/content/Document;
+	public synthetic fun removeFirst ()Ljava/lang/Object;
+	public fun removeLast ()Laws/smithy/kotlin/runtime/content/Document;
+	public synthetic fun removeLast ()Ljava/lang/Object;
 	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
 	public fun retainAll (Ljava/util/Collection;)Z
 	public fun set (ILaws/smithy/kotlin/runtime/content/Document;)Laws/smithy/kotlin/runtime/content/Document;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
api dump

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
[#1478](https://github.com/awslabs/aws-sdk-kotlin/issues/1478)

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This PR introduces `regionProvider` property to client config in the AWS SDK for Kotlin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
