### PR TITLE
chore: add .kotlin/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ out/
 # Compiled class file
 *.class
 *.klib
+.kotlin/
 
 # Log file
 *.log


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Adds the Kotlin/Native **.kotlin/** directory to the Git ignore list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
