### PR TITLE
fix: include more info for retry token bucket capacity errors

### DIFF
--- a/.changes/3456d00f-1b29-4d88-ab02-045db1b1ebce.json
+++ b/.changes/3456d00f-1b29-4d88-ab02-045db1b1ebce.json
@@ -1,0 +1,8 @@
+{
+    "id": "3456d00f-1b29-4d88-ab02-045db1b1ebce",
+    "type": "bugfix",
+    "description": "Include more information when retry strategy halts early due to capacity errors",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1321"
+    ]
+}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1,3 +1,13 @@
+public final class aws/smithy/kotlin/runtime/ClientErrorContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFormatted ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public class aws/smithy/kotlin/runtime/ClientException : aws/smithy/kotlin/runtime/SdkBaseException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -8,12 +18,14 @@ public class aws/smithy/kotlin/runtime/ClientException : aws/smithy/kotlin/runti
 public class aws/smithy/kotlin/runtime/ErrorMetadata {
 	public static final field Companion Laws/smithy/kotlin/runtime/ErrorMetadata$Companion;
 	public fun <init> ()V
+	public final fun getAdditionalClientContext ()Ljava/util/List;
 	public final fun getAttributes ()Laws/smithy/kotlin/runtime/collections/MutableAttributes;
 	public final fun isRetryable ()Z
 	public final fun isThrottling ()Z
 }
 
 public final class aws/smithy/kotlin/runtime/ErrorMetadata$Companion {
+	public final fun getAdditionalClientContext ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getRetryable ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getThrottlingError ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 }
@@ -62,7 +74,6 @@ public class aws/smithy/kotlin/runtime/ServiceException : aws/smithy/kotlin/runt
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun <init> (Ljava/lang/Throwable;)V
-	protected fun getDisplayMetadata ()Ljava/util/List;
 	public fun getMessage ()Ljava/lang/String;
 	public synthetic fun getSdkErrorMetadata ()Laws/smithy/kotlin/runtime/ErrorMetadata;
 	public fun getSdkErrorMetadata ()Laws/smithy/kotlin/runtime/ServiceErrorMetadata;
@@ -134,6 +145,7 @@ public final class aws/smithy/kotlin/runtime/collections/AttributesBuilder {
 }
 
 public final class aws/smithy/kotlin/runtime/collections/AttributesKt {
+	public static final fun appendValue (Laws/smithy/kotlin/runtime/collections/MutableAttributes;Laws/smithy/kotlin/runtime/collections/AttributeKey;Ljava/lang/Object;)V
 	public static final fun attributesOf (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/collections/Attributes;
 	public static final fun emptyAttributes ()Laws/smithy/kotlin/runtime/collections/Attributes;
 	public static final fun get (Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/collections/AttributeKey;)Ljava/lang/Object;
@@ -1685,6 +1697,7 @@ public abstract class aws/smithy/kotlin/runtime/retries/RetryException : aws/smi
 	public final fun getAttempts ()I
 	public final fun getLastException ()Ljava/lang/Throwable;
 	public final fun getLastResponse ()Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/RetryFailureException : aws/smithy/kotlin/runtime/retries/RetryException {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/Attributes.kt
@@ -115,6 +115,17 @@ public fun MutableAttributes.merge(other: Attributes) {
     }
 }
 
+/**
+ * Appends a value to a list-typed attribute. If the attribute does not exist, it will be created.
+ * @param key The key for the attribute
+ * @param element The element to append to the existing (or new) list value of the attribute
+ */
+public fun <E> MutableAttributes.appendValue(key: AttributeKey<List<E>>, element: E) {
+    val existingList = getOrNull(key).orEmpty()
+    val newList = existingList + element
+    set(key, newList)
+}
+
 private class AttributesImpl constructor(seed: Attributes) : MutableAttributes {
     private val map: MutableMap<AttributeKey<*>, Any> = mutableMapOf()
     constructor() : this(emptyAttributes())

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/Exceptions.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/Exceptions.kt
@@ -22,7 +22,28 @@ public sealed class RetryException(
     public val attempts: Int,
     public val lastResponse: Any?,
     public val lastException: Throwable?,
-) : ClientException(message, cause)
+) : ClientException(message, cause) {
+    override fun toString(): String = buildString {
+        append(this@RetryException::class.simpleName)
+        append("(")
+
+        append("message=")
+        append(message)
+
+        append(",attempts=")
+        append(attempts)
+
+        if (lastException != null) {
+            append(",lastException=")
+            append(lastException)
+        } else if (lastResponse != null) {
+            append(",lastResponse=")
+            append(lastResponse)
+        }
+
+        append(")")
+    }
+}
 
 /**
  * Indicates that retrying has failed because too many attempts have completed unsuccessfully.

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
@@ -60,7 +60,7 @@ public class StandardRetryTokenBucket internal constructor(
             capacity -= size
         } else {
             if (config.useCircuitBreakerMode) {
-                throw RetryCapacityExceededException("Insufficient capacity to attempt another retry")
+                throw RetryCapacityExceededException("Insufficient capacity to attempt retry")
             }
 
             val extraRequiredCapacity = size - capacity

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/ExceptionsTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/ExceptionsTest.kt
@@ -5,9 +5,14 @@
 package aws.smithy.kotlin.runtime
 
 import aws.smithy.kotlin.runtime.collections.MutableAttributes
+import aws.smithy.kotlin.runtime.collections.appendValue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+private const val CTX_KEY_1 = "Color"
+private const val CTX_VALUE_1 = "blue"
+private const val CTX_KEY_2 = "Shape"
+private const val CTX_VALUE_2 = "square"
 private const val ERROR_CODE = "ErrorWithNoMessage"
 private const val METADATA_MESSAGE = "This is a message included in metadata but not the regular response"
 private const val PROTOCOL_RESPONSE_SUMMARY = "HTTP 418 I'm a teapot"
@@ -101,6 +106,35 @@ class ExceptionsTest {
         }
         assertEquals(
             "Error type: $ERROR_TYPE, Protocol response: $PROTOCOL_RESPONSE_SUMMARY, Request ID: $REQUEST_ID",
+            e.message,
+        )
+    }
+
+    @Test
+    fun testNoMessageWithClientContext() {
+        val e = FooServiceException {
+            appendValue(ErrorMetadata.AdditionalClientContext, ClientErrorContext(CTX_KEY_1, CTX_VALUE_1))
+            appendValue(ErrorMetadata.AdditionalClientContext, ClientErrorContext(CTX_KEY_2, CTX_VALUE_2))
+        }
+        assertEquals(
+            buildList {
+                add("Error type: Unknown")
+                add("Protocol response: (empty response)")
+                add("$CTX_KEY_1: $CTX_VALUE_1")
+                add("$CTX_KEY_2: $CTX_VALUE_2")
+            }.joinToString(),
+            e.message,
+        )
+    }
+
+    @Test
+    fun testMessageWithClientContext() {
+        val e = FooServiceException(SERVICE_MESSAGE) {
+            appendValue(ErrorMetadata.AdditionalClientContext, ClientErrorContext(CTX_KEY_1, CTX_VALUE_1))
+            appendValue(ErrorMetadata.AdditionalClientContext, ClientErrorContext(CTX_KEY_2, CTX_VALUE_2))
+        }
+        assertEquals(
+            "$SERVICE_MESSAGE, $CTX_KEY_1: $CTX_VALUE_1, $CTX_KEY_2: $CTX_VALUE_2",
             e.message,
         )
     }


### PR DESCRIPTION
## Issue \#

Resolves https://github.com/awslabs/aws-sdk-kotlin/issues/1321

## Description of changes

This change adds more information to exceptions thrown from the standard retry strategy when circuit breaker mode is enabled and the token bucket is exhausted. Exceptions will now include an additional element in the message such as:

`"<service exception message>, Early retry termination: Insufficient client capacity to attempt retry; halting on attempt 2 of 3"`

To accomplish this, this PR adds a new `AdditionalClientContext` attribute to `ServiceException` which holds a list of zero or more elements. These additional context (if present) are appended to service exception messages. `StandardRetryStrategy` now sets this additional context when throwing an exception due to insufficient bucket capacity while in circuit breaker mode. This decouples the exception from knowing about the various types of context.

**Companion PR**: (link coming soon)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
