### PR TITLE
fix: address various failing protocol tests

### DIFF
--- a/codegen/protocol-tests/model/error-correction-tests.smithy
+++ b/codegen/protocol-tests/model/error-correction-tests.smithy
@@ -39,8 +39,7 @@ operation SayHelloXml { output: TestOutput, errors: [Error] }
 
 structure TestOutputDocument with [TestStruct] {
     innerField: Nested,
-    // FIXME: This trait fails smithy validator
-    // @required
+    @required
     document: Document
 }
 structure TestOutput with [TestStruct] { innerField: Nested }
@@ -65,8 +64,7 @@ structure TestStruct {
     @required
     nestedListValue: NestedList
 
-    // FIXME: This trait fails smithy validator
-    // @required
+    @required
     nested: Nested
 
     @required
@@ -97,8 +95,7 @@ union MyUnion {
 }
 
 structure Nested {
-    // FIXME: This trait fails smithy validator
-    // @required
+    @required
     a: String
 }
 

--- a/codegen/protocol-tests/model/error-correction-tests.smithy
+++ b/codegen/protocol-tests/model/error-correction-tests.smithy
@@ -39,8 +39,9 @@ operation SayHelloXml { output: TestOutput, errors: [Error] }
 
 structure TestOutputDocument with [TestStruct] {
     innerField: Nested,
-    // FIXME: This trait fails smithy validator
-    // @required
+
+    // Note: This shape _should_ be @required, but causes Smithy httpResponseTests validation to fail.
+    // We expect `nested` to be deserialized as `null` and enforce @required using a runtime check, but Smithy validator doesn't recognize / allow this.
     document: Document
 }
 structure TestOutput with [TestStruct] { innerField: Nested }
@@ -65,8 +66,8 @@ structure TestStruct {
     @required
     nestedListValue: NestedList
 
-    // FIXME: This trait fails smithy validator
-    // @required
+    // Note: This shape _should_ be @required, but causes Smithy httpResponseTests validation to fail.
+    // We expect `nested` to be deserialized as `null` and enforce @required using a runtime check, but Smithy validator doesn't recognize / allow this.
     nested: Nested
 
     @required
@@ -97,8 +98,7 @@ union MyUnion {
 }
 
 structure Nested {
-    // FIXME: This trait fails smithy validator
-    // @required
+    @required
     a: String
 }
 

--- a/codegen/protocol-tests/model/error-correction-tests.smithy
+++ b/codegen/protocol-tests/model/error-correction-tests.smithy
@@ -39,7 +39,9 @@ operation SayHelloXml { output: TestOutput, errors: [Error] }
 
 structure TestOutputDocument with [TestStruct] {
     innerField: Nested,
-    @required
+
+    // Note: This shape _should_ be @required, but causes Smithy httpResponseTests validation to fail.
+    // We expect `document` to be deserialized as `null` and enforce @required using a runtime check, but Smithy validator doesn't recognize / allow this.
     document: Document
 }
 structure TestOutput with [TestStruct] { innerField: Nested }
@@ -64,7 +66,8 @@ structure TestStruct {
     @required
     nestedListValue: NestedList
 
-    @required
+    // Note: This shape _should_ be @required, but causes Smithy httpResponseTests validation to fail.
+    // We expect `nested` to be deserialized as `null` and enforce @required using a runtime check, but Smithy validator doesn't recognize / allow this.
     nested: Nested
 
     @required

--- a/codegen/protocol-tests/model/error-correction-tests.smithy
+++ b/codegen/protocol-tests/model/error-correction-tests.smithy
@@ -128,8 +128,8 @@ apply SayHello @httpResponseTests([
             listValue: [],
             mapValue: {},
             nestedListValue: [],
-            document: null,
-            nested: null,
+            document: {},
+            nested: { a: "" },
             timestampValue: 0
         },
         code: 200,
@@ -151,7 +151,7 @@ apply SayHelloXml @httpResponseTests([
             listValue: [],
             mapValue: {},
             nestedListValue: [],
-            nested: null,
+            nested: { a: "" },
             timestampValue: 0
         },
         code: 200,

--- a/codegen/protocol-tests/model/error-correction-tests.smithy
+++ b/codegen/protocol-tests/model/error-correction-tests.smithy
@@ -128,8 +128,8 @@ apply SayHello @httpResponseTests([
             listValue: [],
             mapValue: {},
             nestedListValue: [],
-            document: {},
-            nested: { a: "" },
+            document: null,
+            nested: null,
             timestampValue: 0
         },
         code: 200,
@@ -151,7 +151,7 @@ apply SayHelloXml @httpResponseTests([
             listValue: [],
             mapValue: {},
             nestedListValue: [],
-            nested: { a: "" },
+            nested: null,
             timestampValue: 0
         },
         code: 200,

--- a/codegen/protocol-tests/model/error-correction-tests.smithy
+++ b/codegen/protocol-tests/model/error-correction-tests.smithy
@@ -39,7 +39,8 @@ operation SayHelloXml { output: TestOutput, errors: [Error] }
 
 structure TestOutputDocument with [TestStruct] {
     innerField: Nested,
-    @required
+    // FIXME: This trait fails smithy validator
+    // @required
     document: Document
 }
 structure TestOutput with [TestStruct] { innerField: Nested }
@@ -64,7 +65,8 @@ structure TestStruct {
     @required
     nestedListValue: NestedList
 
-    @required
+    // FIXME: This trait fails smithy validator
+    // @required
     nested: Nested
 
     @required
@@ -95,7 +97,8 @@ union MyUnion {
 }
 
 structure Nested {
-    @required
+    // FIXME: This trait fails smithy validator
+    // @required
     a: String
 }
 

--- a/codegen/protocol-tests/model/error-correction-tests.smithy
+++ b/codegen/protocol-tests/model/error-correction-tests.smithy
@@ -39,9 +39,7 @@ operation SayHelloXml { output: TestOutput, errors: [Error] }
 
 structure TestOutputDocument with [TestStruct] {
     innerField: Nested,
-
-    // Note: This shape _should_ be @required, but causes Smithy httpResponseTests validation to fail.
-    // We expect `nested` to be deserialized as `null` and enforce @required using a runtime check, but Smithy validator doesn't recognize / allow this.
+    @required
     document: Document
 }
 structure TestOutput with [TestStruct] { innerField: Nested }
@@ -66,8 +64,7 @@ structure TestStruct {
     @required
     nestedListValue: NestedList
 
-    // Note: This shape _should_ be @required, but causes Smithy httpResponseTests validation to fail.
-    // We expect `nested` to be deserialized as `null` and enforce @required using a runtime check, but Smithy validator doesn't recognize / allow this.
+    @required
     nested: Nested
 
     @required

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
@@ -40,9 +40,7 @@ abstract class AwsHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
         // val targetedTest = TestMemberDelta(setOf("RestJsonComplexErrorWithNoMessage"), TestContainmentMode.RUN_TESTS)
 
         val ignoredTests = TestMemberDelta(
-            setOf(
-                "RpcV2CborClientPopulatesDefaultValuesInInput", // FIXME Bug in protocol test, malformed Base64 body. Fix will be in the next Smithy release: https://github.com/smithy-lang/smithy/pull/2502
-            ),
+            setOf(),
         )
 
         val requestTestBuilder = HttpProtocolUnitTestRequestGenerator.Builder()

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
@@ -41,8 +41,6 @@ abstract class AwsHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
 
         val ignoredTests = TestMemberDelta(
             setOf(
-                "AwsJson10ClientErrorCorrectsWithDefaultValuesWhenServerFailsToSerializeRequiredValues", // FIXME Protocol test seems to be wrong. Default value of the member is "YmxvYg==" but they are expecting it to be decoded "blob".
-                "RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse", // FIXME Protocol test seems to be wrong. Default value of member is "YWJj" but they are expecting it to be decoded "abc".
                 "RpcV2CborClientPopulatesDefaultValuesInInput", // FIXME Bug in protocol test, malformed Base64 body. Fix will be in the next Smithy release: https://github.com/smithy-lang/smithy/pull/2502
             ),
         )

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
@@ -42,8 +42,6 @@ abstract class AwsHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
         val ignoredTests = TestMemberDelta(
             setOf(
                 "AwsJson10ClientErrorCorrectsWithDefaultValuesWhenServerFailsToSerializeRequiredValues",
-                "RestJsonNullAndEmptyHeaders",
-                "NullAndEmptyHeaders",
                 "RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse",
                 "RpcV2CborClientPopulatesDefaultValuesInInput",
             ),

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/aws/protocols/core/AwsHttpBindingProtocolGenerator.kt
@@ -41,9 +41,9 @@ abstract class AwsHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
 
         val ignoredTests = TestMemberDelta(
             setOf(
-                "AwsJson10ClientErrorCorrectsWithDefaultValuesWhenServerFailsToSerializeRequiredValues",
-                "RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse",
-                "RpcV2CborClientPopulatesDefaultValuesInInput",
+                "AwsJson10ClientErrorCorrectsWithDefaultValuesWhenServerFailsToSerializeRequiredValues", // FIXME Protocol test seems to be wrong. Default value of the member is "YmxvYg==" but they are expecting it to be decoded "blob".
+                "RpcV2CborClientPopulatesDefaultsValuesWhenMissingInResponse", // FIXME Protocol test seems to be wrong. Default value of member is "YWJj" but they are expecting it to be decoded "abc".
+                "RpcV2CborClientPopulatesDefaultValuesInInput", // FIXME Bug in protocol test, malformed Base64 body. Fix will be in the next Smithy release: https://github.com/smithy-lang/smithy/pull/2502
             ),
         )
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -193,7 +193,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
                 } else {
                     // only use @default if type is `T`
                     shape.getTrait<DefaultTrait>()?.let {
-                        defaultValue(it.getDefaultValue(targetShape))
+                        setDefaultValue(it, targetShape)
                     }
                 }
             }
@@ -219,9 +219,10 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         }
     }
 
-    private fun DefaultTrait.getDefaultValue(targetShape: Shape): String? {
-        val node = toNode()
-        return when {
+    private fun Symbol.Builder.setDefaultValue(defaultTrait: DefaultTrait, targetShape: Shape) {
+        val node = defaultTrait.toNode()
+
+        val defaultValue = when {
             node.toString() == "null" -> null
 
             // Check if target is an enum before treating the default like a regular number/string
@@ -235,13 +236,20 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
                 "${enumSymbol.fullName}.fromValue($arg)"
             }
 
-            targetShape.isBlobShape && targetShape.isStreaming ->
-                node
-                    .toString()
-                    .takeUnless { it.isEmpty() }
-                    ?.let { "ByteStream.fromString(${it.dq()})" }
+            targetShape.isBlobShape -> {
+                addReferences(RuntimeTypes.Core.Text.Encoding.decodeBase64)
 
-            targetShape.isBlobShape -> "${node.toString().dq()}.decodeBase64().encodeToByteArray()"
+                if (targetShape.isStreaming) {
+                    node.toString()
+                        .takeUnless { it.isEmpty() }
+                        ?.let {
+                            addReferences(RuntimeTypes.Core.Content.ByteStream)
+                            "ByteStream.fromString(${it.dq()}.decodeBase64())"
+                        }
+                } else {
+                    "${node.toString().dq()}.decodeBase64().encodeToByteArray()"
+                }
+            }
 
             targetShape.isDocumentShape -> getDefaultValueForDocument(node)
             targetShape.isTimestampShape -> getDefaultValueForTimestamp(node.asNumberNode().get())
@@ -252,6 +260,8 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
             node.isStringNode -> node.toString().dq()
             else -> node.toString()
         }
+
+        defaultValue(defaultValue)
     }
 
     private fun getDefaultValueForTimestamp(node: NumberNode): String {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -241,7 +241,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
                     .takeUnless { it.isEmpty() }
                     ?.let { "ByteStream.fromString(${it.dq()})" }
 
-            targetShape.isBlobShape -> "${node.toString().dq()}.encodeToByteArray()"
+            targetShape.isBlobShape -> "${node.toString().dq()}.decodeBase64().encodeToByteArray()"
 
             targetShape.isDocumentShape -> getDefaultValueForDocument(node)
             targetShape.isTimestampShape -> getDefaultValueForTimestamp(node.asNumberNode().get())

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -248,6 +248,11 @@ class StructureGenerator(
                     } else {
                         memberSymbol
                     }
+
+                    if (builderMemberSymbol.shape is BlobShape && builderMemberSymbol.isNotNullable) {
+                        writer.addImport(RuntimeTypes.Core.Text.Encoding.decodeBase64)
+                    }
+
                     write("public var #L: #E", memberName, builderMemberSymbol)
                 }
                 write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -249,10 +249,6 @@ class StructureGenerator(
                         memberSymbol
                     }
 
-                    if (builderMemberSymbol.shape is BlobShape && builderMemberSymbol.isNotNullable) {
-                        writer.addImport(RuntimeTypes.Core.Text.Encoding.decodeBase64)
-                    }
-
                     write("public var #L: #E", memberName, builderMemberSymbol)
                 }
                 write("")

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -182,7 +182,7 @@ class SymbolProviderTest {
         "double,2.71828,2.71828",
         "byte,10,10.toByte()",
         "string,\"hello\",\"hello\"",
-        "blob,\"abcdefg\",\"abcdefg\".encodeToByteArray()",
+        "blob,\"abcdefg\",\"abcdefg\".decodeBase64().encodeToByteArray()",
         "boolean,true,true",
         "bigInteger,5,5",
         "bigDecimal,9.0123456789,9.0123456789",

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -57,8 +57,8 @@ internal class SmokeTestOperationSerializer: HttpSerializer.NonStreaming<SmokeTe
         }
 
         builder.headers {
-            if (input.header1?.isNotEmpty() == true) append("X-Header1", input.header1)
-            if (input.header2?.isNotEmpty() == true) append("X-Header2", input.header2)
+            if (input.header1 != null) append("X-Header1", input.header1)
+            if (input.header2 != null) append("X-Header2", input.header2)
         }
 
         val payload = serializeSmokeTestOperationBody(context, input)
@@ -264,7 +264,7 @@ internal class TimestampInputOperationSerializer: HttpSerializer.NonStreaming<Ti
             }
             parameters.decodedParameters(PercentEncoding.SmithyLabel) {
                 if (input.queryTimestamp != null) add("qtime", input.queryTimestamp.format(TimestampFormat.ISO_8601))
-                if (input.queryTimestampList?.isNotEmpty() == true) addAll("qtimeList", input.queryTimestampList.map { it.format(TimestampFormat.ISO_8601) })
+                if (input.queryTimestampList != null) addAll("qtimeList", input.queryTimestampList.map { it.format(TimestampFormat.ISO_8601) })
             }
         }
 
@@ -304,7 +304,7 @@ internal class BlobInputOperationSerializer: HttpSerializer.NonStreaming<BlobInp
         }
 
         builder.headers {
-            if (input.headerMediaType?.isNotEmpty() == true) append("X-Blob", input.headerMediaType.encodeBase64())
+            if (input.headerMediaType != null) append("X-Blob", input.headerMediaType.encodeBase64())
         }
 
         val payload = serializeBlobInputOperationBody(context, input)

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
@@ -145,8 +145,8 @@ class HttpStringValuesMapSerializerTest {
         contents.assertBalancedBracesAndParens()
 
         val expectedContents = """
-            if (input.header1?.isNotEmpty() == true) append("X-Header1", input.header1)
-            if (input.header2?.isNotEmpty() == true) append("X-Header2", input.header2)
+            if (input.header1 != null) append("X-Header1", input.header1)
+            if (input.header2 != null) append("X-Header2", input.header2)
         """.trimIndent()
         contents.shouldContainOnlyOnceWithDiff(expectedContents)
     }
@@ -157,7 +157,7 @@ class HttpStringValuesMapSerializerTest {
         contents.assertBalancedBracesAndParens()
 
         val expectedContents = """
-            if (input.headerMediaType?.isNotEmpty() == true) append("X-Blob", input.headerMediaType.encodeBase64())
+            if (input.headerMediaType != null) append("X-Blob", input.headerMediaType.encodeBase64())
         """.trimIndent()
         contents.shouldContainOnlyOnceWithDiff(expectedContents)
     }
@@ -168,10 +168,10 @@ class HttpStringValuesMapSerializerTest {
         contents.assertBalancedBracesAndParens()
 
         val expectedContents = """
-            if (input.enumList?.isNotEmpty() == true) appendAll("x-enumList", input.enumList.map { quoteHeaderValue(it.value) })
-            if (input.intList?.isNotEmpty() == true) appendAll("x-intList", input.intList.map { it.toString() })
-            if (input.strList?.isNotEmpty() == true) appendAll("x-strList", input.strList.map { quoteHeaderValue(it) })
-            if (input.tsList?.isNotEmpty() == true) appendAll("x-tsList", input.tsList.map { it.format(TimestampFormat.RFC_5322) })
+            if (input.enumList != null) appendAll("x-enumList", input.enumList.map { quoteHeaderValue(it.value) })
+            if (input.intList != null) appendAll("x-intList", input.intList.map { it.toString() })
+            if (input.strList != null) appendAll("x-strList", input.strList.map { quoteHeaderValue(it) })
+            if (input.tsList != null) appendAll("x-tsList", input.tsList.map { it.format(TimestampFormat.RFC_5322) })
         """.trimIndent()
         contents.shouldContainOnlyOnceWithDiff(expectedContents)
     }
@@ -190,7 +190,7 @@ class HttpStringValuesMapSerializerTest {
         val queryContents = getTestContents(defaultModel, "com.test#TimestampInput", HttpBinding.Location.QUERY)
         val expectedQueryContents = """
             if (input.queryTimestamp != null) add("qtime", input.queryTimestamp.format(TimestampFormat.ISO_8601))
-            if (input.queryTimestampList?.isNotEmpty() == true) addAll("qtimeList", input.queryTimestampList.map { it.format(TimestampFormat.ISO_8601) })
+            if (input.queryTimestampList != null) addAll("qtimeList", input.queryTimestampList.map { it.format(TimestampFormat.ISO_8601) })
         """.trimIndent()
         queryContents.shouldContainOnlyOnceWithDiff(expectedQueryContents)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ micrometer-version = "1.14.2"
 binary-compatibility-validator-version = "0.16.3"
 
 # codegen
-smithy-version = "1.53.0"
+smithy-version = "1.54.0"
 smithy-gradle-version = "0.9.0"
 
 # testing

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/text/encoding/Base64.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/text/encoding/Base64.kt
@@ -99,10 +99,18 @@ public fun String.decodeBase64Bytes(): ByteArray = encodeToByteArray().decodeBas
  * Decode [ByteArray] from base64 format
  */
 public fun ByteArray.decodeBase64(): ByteArray {
-    val encoded = this
+
+    // Calculate the padding needed to make the length a multiple of 4
+    val remainder = size % 4
+    val encoded: ByteArray = if (remainder == 0) {
+        this
+    } else {
+        this + ByteArray(4 - remainder) { BASE64_PAD.code.toByte() }
+    }
+
     val decodedLen = base64DecodedLen(encoded)
     val decoded = ByteArray(decodedLen)
-    val blockCnt = size / 4
+    val blockCnt = encoded.size / 4
     var readIdx = 0
     var writeIdx = 0
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/text/encoding/Base64.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/text/encoding/Base64.kt
@@ -99,7 +99,6 @@ public fun String.decodeBase64Bytes(): ByteArray = encodeToByteArray().decodeBas
  * Decode [ByteArray] from base64 format
  */
 public fun ByteArray.decodeBase64(): ByteArray {
-
     // Calculate the padding needed to make the length a multiple of 4
     val remainder = size % 4
     val encoded: ByteArray = if (remainder == 0) {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/text/encoding/Base64Test.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/text/encoding/Base64Test.kt
@@ -77,14 +77,6 @@ class Base64Test {
     }
 
     @Test
-    fun decodeNonMultipleOf4() {
-        val ex = assertFails {
-            "Zm9vY=".decodeBase64()
-        }
-        ex.message!!.shouldContain("invalid base64 string of length 6; not a multiple of 4")
-    }
-
-    @Test
     fun decodeInvalidPadding() {
         val ex = assertFails {
             "Zm9vY===".decodeBase64()
@@ -115,5 +107,25 @@ class Base64Test {
         val encoded = "aGVsbG8Jd29ybGQK"
         assertEquals(encoded, decoded.encodeBase64())
         assertEquals(decoded, encoded.decodeBase64())
+    }
+
+    @Test
+    fun testUnpaddedInputs() {
+        // from https://github.com/smithy-lang/smithy/pull/2502
+        val input = "v2hkZWZhdWx0c79tZGVmYXVsdFN0cmluZ2JoaW5kZWZhdWx0Qm9vbGVhbvVrZGVmYXVsdExpc3Sf/3BkZWZhdWx0VGltZXN0YW1wwQBrZGVmYXVsdEJsb2JDYWJja2RlZmF1bHRCeXRlAWxkZWZhdWx0U2hvcnQBbmRlZmF1bHRJbnRlZ2VyCmtkZWZhdWx0TG9uZxhkbGRlZmF1bHRGbG9hdPo/gAAAbWRlZmF1bHREb3VibGX6P4AAAGpkZWZhdWx0TWFwv/9rZGVmYXVsdEVudW1jRk9PbmRlZmF1bHRJbnRFbnVtAWtlbXB0eVN0cmluZ2BsZmFsc2VCb29sZWFu9GllbXB0eUJsb2JAaHplcm9CeXRlAGl6ZXJvU2hvcnQAa3plcm9JbnRlZ2VyAGh6ZXJvTG9uZwBpemVyb0Zsb2F0+gAAAABqemVyb0RvdWJsZfoAAAAA//8"
+        input.decodeBase64()
+
+        val inputs = mapOf<String, String>(
+            "YQ" to "a",
+            "Yg" to "b",
+            "YWI" to "ab",
+            "YWJj" to "abc",
+            "SGVsbG8gd29ybGQ" to "Hello world",
+        )
+
+        inputs.forEach { (encoded, expected) ->
+            val actual = encoded.decodeBase64()
+            assertEquals(expected, actual)
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Fixes a failing protocol test by allowing serialization of empty headers. Related to https://github.com/smithy-lang/smithy/pull/2433 and https://github.com/smithy-lang/smithy/pull/2403.
- Fixes a few failing protocol tests by updating our handling of default blob values to decode the Base64 string
- Address another failing protocol test by ~~merging an upstream fix to make Base64 string length a multiple of 4 (aka padded)~~ adding support for unpadded Base64 inputs

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This change is required to comply with Smithy protocol tests which assert that empty header values are sent.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
