### PR TITLE
Fix caseinsensitivemap entry hashcode

### DIFF
--- a/.changes/c0040355-ffdc-4813-80e9-baf859ef02b9.json
+++ b/.changes/c0040355-ffdc-4813-80e9-baf859ef02b9.json
@@ -1,0 +1,5 @@
+{
+    "id": "c0040355-ffdc-4813-80e9-baf859ef02b9",
+    "type": "bugfix",
+    "description": "fix: correct hash code calculation for case-insensitive map entries"
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/CaseInsensitiveMap.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/CaseInsensitiveMap.kt
@@ -63,7 +63,8 @@ internal class CaseInsensitiveMap<Value> : MutableMap<String, Value> {
             return value
         }
 
-        override fun hashCode(): Int = 17 * 31 + key!!.hashCode() + value!!.hashCode()
+        // override fun hashCode(): Int = 17 * 31 + key!!.hashCode() + value!!.hashCode()
+        override fun hashCode(): Int = key.hashCode() xor value.hashCode()
 
         override fun equals(other: Any?): Boolean {
             if (other == null || other !is Map.Entry<*, *>) return false

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/CaseInsensitiveMap.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/CaseInsensitiveMap.kt
@@ -63,8 +63,7 @@ internal class CaseInsensitiveMap<Value> : MutableMap<String, Value> {
             return value
         }
 
-        // override fun hashCode(): Int = 17 * 31 + key!!.hashCode() + value!!.hashCode()
-        override fun hashCode(): Int = key.hashCode() xor value.hashCode()
+        override fun hashCode(): Int = key.hashCode() xor value.hashCode() // Match JVM & K/N stdlib implementations
 
         override fun equals(other: Any?): Boolean {
             if (other == null || other !is Map.Entry<*, *>) return false

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/collections/CaseInsensitiveMapTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/collections/CaseInsensitiveMapTest.kt
@@ -77,6 +77,22 @@ class CaseInsensitiveMapTest {
     }
 
     @Test
+    fun testEntriesEqualityWithNormalMap() {
+        val left = CaseInsensitiveMap<String>()
+        left["A"] = "apple"
+        left["B"] = "banana"
+        left["C"] = "cherry"
+
+        val right = mutableMapOf(
+            "c" to "cherry",
+            "b" to "banana",
+            "a" to "apple",
+        )
+
+        assertEquals(left.entries, right.entries)
+    }
+
+    @Test
     fun testToString() {
         val map = CaseInsensitiveMap<String>()
         map["A"] = "apple"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change fixes a small bug in hashcode calculation for `CaseInsensitiveMap` entries, namely that the hashcode calculation does not match the one used by JVM and Kotlin/Native's standard implementations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
