### PR TITLE
fix: favor endpointUrl over endpoint discovery when provided

### DIFF
--- a/.changes/e7d8178c-4211-443d-b4d9-44d7019aefd1.json
+++ b/.changes/e7d8178c-4211-443d-b4d9-44d7019aefd1.json
@@ -1,0 +1,8 @@
+{
+    "id": "e7d8178c-4211-443d-b4d9-44d7019aefd1",
+    "type": "bugfix",
+    "description": "Favor `endpointUrl` over endpoint discovery when provided",
+    "issues": [
+        "https://github.com/awslabs/aws-sdk-kotlin/issues/1413"
+    ]
+}


### PR DESCRIPTION
## Issue \#

Partially addresses https://github.com/awslabs/aws-sdk-kotlin/issues/1413

## Description of changes

This change updates endpoint resolution to favor `endpointUrl` over endpoint discovery when both are provided/enabled. This allows callers to bypass endpoint discovery when using a custom endpoint.

This change is backported from https://github.com/smithy-lang/smithy-kotlin/pull/1221 (slated for **v1.5**) but only includes non-breaking changes in codegen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
