### PR TITLE
misc: test union member name same as union

### DIFF
--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
@@ -227,7 +227,34 @@ class SmithySdkTest {
 
     @Test
     fun `it compiles models with unions with members that have the same name as the union`() {
-        val model = javaClass.getResource("/kitchen-sink-model.smithy")!!.asSmithy()
+        val model = """
+            namespace aws.sdk.kotlin.test
+
+            use aws.protocols#awsJson1_0
+            use smithy.rules#operationContextParams
+            use smithy.rules#endpointRuleSet
+            use aws.api#service
+            
+            @awsJson1_0
+            @service(sdkId: "UnionOperationTest")
+            service TestService {
+                operations: [UnionOperation],
+                version: "1"
+            }
+            
+            operation UnionOperation {
+                input: UnionOperationRequest
+            }
+            
+            structure UnionOperationRequest {
+                Union: Foo
+            }
+            
+            union Foo {
+                foo: Boolean
+            }
+
+        """.asSmithy()
 
         val compileOutputStream = ByteArrayOutputStream()
         val compilationResult = compileSdkAndTest(model = model, outputSink = compileOutputStream, emitSourcesToTmp = Debug.emitSourcesToTemp)

--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
@@ -224,6 +224,17 @@ class SmithySdkTest {
 
         assertEquals(KotlinCompilation.ExitCode.OK, compilationResult.exitCode, compileOutputStream.toString())
     }
+
+    @Test
+    fun `it compiles models with unions with members that have the same name as the union`() {
+        val model = javaClass.getResource("/kitchen-sink-model.smithy")!!.asSmithy()
+
+        val compileOutputStream = ByteArrayOutputStream()
+        val compilationResult = compileSdkAndTest(model = model, outputSink = compileOutputStream, emitSourcesToTmp = Debug.emitSourcesToTemp)
+        compileOutputStream.flush()
+
+        assertEquals(KotlinCompilation.ExitCode.OK, compilationResult.exitCode, compileOutputStream.toString())
+    }
 }
 
 /**

--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
@@ -225,6 +225,7 @@ class SmithySdkTest {
         assertEquals(KotlinCompilation.ExitCode.OK, compilationResult.exitCode, compileOutputStream.toString())
     }
 
+    // https://github.com/smithy-lang/smithy-kotlin/issues/1129
     @Test
     fun `it compiles models with unions with members that have the same name as the union`() {
         val model = """

--- a/tests/compile/src/test/resources/kitchen-sink-model.smithy
+++ b/tests/compile/src/test/resources/kitchen-sink-model.smithy
@@ -59,13 +59,7 @@ structure SmokeTestRequest {
 
     payload1: String,
     payload2: Integer,
-    payload3: Nested,
-
-    nestedUnion: NestedUnion
-}
-
-union NestedUnion {
-    nestedUnion: Boolean
+    payload3: Nested
 }
 
 structure Nested {

--- a/tests/compile/src/test/resources/kitchen-sink-model.smithy
+++ b/tests/compile/src/test/resources/kitchen-sink-model.smithy
@@ -59,7 +59,13 @@ structure SmokeTestRequest {
 
     payload1: String,
     payload2: Integer,
-    payload3: Nested
+    payload3: Nested,
+
+    nestedUnion: NestedUnion
+}
+
+union NestedUnion {
+    nestedUnion: Boolean
 }
 
 structure Nested {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes https://github.com/smithy-lang/smithy-kotlin/issues/1129

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Adds a test to make sure we don't regress.
See: https://github.com/awslabs/aws-sdk-kotlin/pull/1526


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
