### PR TITLE
fix: unions with member names matching auto-imported Kotlin symbols

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -154,7 +154,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         val fullyQualifiedValueType = "${reference.fullName}$valueSuffix"
         return createSymbolBuilder(shape, "List<$valueType>")
             .addReferences(reference)
-            .putProperty(SymbolProperty.FULLY_QUALIFIED_NAME_HINT, "List<$fullyQualifiedValueType>")
+            .putProperty(SymbolProperty.FULLY_QUALIFIED_NAME_HINT, "kotlin.collections.List<$fullyQualifiedValueType>")
             .putProperty(SymbolProperty.MUTABLE_COLLECTION_FUNCTION, "mutableListOf<$valueType>")
             .putProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION, "listOf<$valueType>")
             .build()
@@ -173,7 +173,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         return createSymbolBuilder(shape, "Map<$keyType, $valueType>")
             .addReferences(keyReference)
             .addReferences(valueReference)
-            .putProperty(SymbolProperty.FULLY_QUALIFIED_NAME_HINT, "Map<$fullyQualifiedKeyType, $fullyQualifiedValueType>")
+            .putProperty(SymbolProperty.FULLY_QUALIFIED_NAME_HINT, "kotlin.collections.Map<$fullyQualifiedKeyType, $fullyQualifiedValueType>")
             .putProperty(SymbolProperty.MUTABLE_COLLECTION_FUNCTION, "mutableMapOf<$keyType, $valueType>")
             .putProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION, "mapOf<$keyType, $valueType>")
             .putProperty(SymbolProperty.ENTRY_EXPRESSION, "Map.Entry<$keyType, $valueType>")

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -481,8 +481,8 @@ class SymbolProviderTest {
         assertEquals("Record", sparseListSymbol.references[0].symbol.name)
 
         // check the fully qualified name hint is set
-        assertEquals("List<foo.bar.model.Record>", listSymbol.fullNameHint)
-        assertEquals("List<foo.bar.model.Record?>", sparseListSymbol.fullNameHint)
+        assertEquals("kotlin.collections.List<foo.bar.model.Record>", listSymbol.fullNameHint)
+        assertEquals("kotlin.collections.List<foo.bar.model.Record?>", sparseListSymbol.fullNameHint)
     }
 
     @Test
@@ -544,8 +544,8 @@ class SymbolProviderTest {
         assertTrue("com.test.model.Record" in sparseRefNames)
 
         // check the fully qualified name hint is set
-        assertEquals("Map<kotlin.String, com.test.model.Record>", mapSymbol.fullNameHint)
-        assertEquals("Map<kotlin.String, com.test.model.Record?>", sparseMapSymbol.fullNameHint)
+        assertEquals("kotlin.collections.Map<kotlin.String, com.test.model.Record>", mapSymbol.fullNameHint)
+        assertEquals("kotlin.collections.Map<kotlin.String, com.test.model.Record?>", sparseMapSymbol.fullNameHint)
     }
 
     @Test

--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
@@ -263,6 +263,68 @@ class SmithySdkTest {
 
         assertEquals(KotlinCompilation.ExitCode.OK, compilationResult.exitCode, compileOutputStream.toString())
     }
+
+    // https://github.com/smithy-lang/smithy-kotlin/issues/1127
+    @Test
+    fun `it compiles models with union member names that match their types`() {
+        val model = """
+            namespace aws.sdk.kotlin.test
+
+            use aws.protocols#awsJson1_0
+            use smithy.rules#operationContextParams
+            use smithy.rules#endpointRuleSet
+            use aws.api#service
+            
+            @awsJson1_0
+            @service(sdkId: "UnionOperationTest")
+            service TestService {
+                operations: [DeleteObjects],
+                version: "1"
+            }
+            
+            operation DeleteObjects {
+                input: DeleteObjectsRequest
+            }
+            
+            structure DeleteObjectsRequest {
+                Delete: Foo
+            }
+            
+            union Foo {
+                list: BarList
+                map: IntegerMap
+                instant: Timestamp
+                byteArray: Blob
+                boolean: Boolean
+                string: String
+                bigInteger: BigInteger
+                bigDecimal: BigDecimal
+                double: Double
+                float: Float
+                long: Long
+                short: Short
+                int: Integer
+                byte: Byte
+            }
+            
+            list BarList {
+                member: Bar
+            }
+            
+            map IntegerMap {
+                key: String
+                value: Integer
+            }
+            
+            string Bar
+        """.asSmithy()
+
+        val compileOutputStream = ByteArrayOutputStream()
+        val compilationResult = compileSdkAndTest(model = model, outputSink = compileOutputStream, emitSourcesToTmp = Debug.emitSourcesToTemp)
+        compileOutputStream.flush()
+
+        assertEquals(KotlinCompilation.ExitCode.OK, compilationResult.exitCode, compileOutputStream.toString())
+    }
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
https://github.com/smithy-lang/smithy-kotlin/issues/1127

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Lists and Maps were the only offenders of this type of bug. Adding a fully qualified name to the symbol fixes the naming conflicts like the ones shown in https://github.com/smithy-lang/smithy-kotlin/issues/1127

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
