### PR TITLE
fix: bump maximum event stream message length to 24MB

### DIFF
--- a/.changes/ba71e47f-d546-45f2-bf44-aedaab74a966.json
+++ b/.changes/ba71e47f-d546-45f2-bf44-aedaab74a966.json
@@ -1,0 +1,5 @@
+{
+    "id": "ba71e47f-d546-45f2-bf44-aedaab74a966",
+    "type": "misc",
+    "description": "Increase maximum event stream message length to 24MB"
+}

--- a/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/Message.kt
+++ b/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/Message.kt
@@ -12,15 +12,15 @@ import aws.smithy.kotlin.runtime.text.encoding.encodeToHex
 
 internal const val MESSAGE_CRC_BYTE_LEN = 4
 
-// max message size is 16 MB
-internal const val MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+// max message size is 24 MB
+internal const val MAX_MESSAGE_SIZE = 24 * 1024 * 1024
 
 // max header size is 128 KB
 internal const val MAX_HEADER_SIZE = 128 * 1024
 
 /*
     Message Wire Format
-    See also: https://docs.aws.amazon.com/transcribe/latest/dg/event-stream-med.html
+    See also: https://docs.aws.amazon.com/transcribe/latest/dg/streaming-setting-up.html
 
     +--------------------------------------------------------------------+   --
     |                            Total Len (32)                          |     |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Event streams spec was updated to say:
```
Additionally, services MUST validate, and clients MUST NOT validate, that:

The payload of a message may not exceed 25,165,824 bytes (24 MB).
The headers_length of a message may not exceed 131,072 bytes (128 kB). Note
that the in-memory representation of the headers, once decoded, may legally
exceed this value.
```

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Some services are returning messages >16kB, which would currently fail. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
