### PR TITLE
ci(lint): run commitlint on pull requests

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes

This change adds a check for commit message formatting via `commitlint`.
It uses [wagoid/commitlint-github-action](https://github.com/wagoid/commitlint-github-action)'s default example.

It runs checks only against PRs so that reviewers don't have to manually check the messages. Effectively automating this repo's CONTRIBUTING.md section, [Git Commit Guidelines](https://github.com/smithy-lang/smithy-kotlin/blob/main/CONTRIBUTING.md#git-commit-guidelines).

My internal alias on slack is `@frashen` if you need to ping me there :)

## Testing

- Failing check on bad commit message, `test change!`. [Link](https://github.com/RenFraser/smithy-kotlin/actions/runs/13410223110/job/37458514032?pr=1)
- Successful check on good commit message, `build: test commit should be ok`. [Link](https://github.com/RenFraser/smithy-kotlin/actions/runs/13410245649/job/37458586660)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
