### PR TITLE
misc: Remove Elastic Inference SDK ID test

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/test/resources/sdk-ids-test-output.csv
+++ b/codegen/smithy-kotlin-codegen/src/test/resources/sdk-ids-test-output.csv
@@ -113,7 +113,6 @@ ECS,Ecs
 EFS,Efs
 EKS,Eks
 Elastic Beanstalk,ElasticBeanstalk
-Elastic Inference,ElasticInference
 Elastic Load Balancing v2,ElasticLoadBalancingV2
 Elastic Load Balancing,ElasticLoadBalancing
 Elastic Transcoder,ElasticTranscoder

--- a/codegen/smithy-kotlin-codegen/src/test/resources/sdk-ids.csv
+++ b/codegen/smithy-kotlin-codegen/src/test/resources/sdk-ids.csv
@@ -113,7 +113,6 @@ ECS
 EFS
 EKS
 Elastic Beanstalk
-Elastic Inference
 Elastic Load Balancing v2
 Elastic Load Balancing
 Elastic Transcoder


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Removes Elastic Inference from SDK ID tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
