### PR TITLE
fix: correctly codegen paginators for types which require fully-qualified names

### DIFF
--- a/.changes/13a47747-197a-4b88-bc3b-393af5f5127a.json
+++ b/.changes/13a47747-197a-4b88-bc3b-393af5f5127a.json
@@ -1,0 +1,5 @@
+{
+    "id": "13a47747-197a-4b88-bc3b-393af5f5127a",
+    "type": "bugfix",
+    "description": "Correctly generate paginators for item type names which collide with other used types (e.g., an item type `com.foo.Flow` which conflicts with `kotlinx.coroutines.flow.Flow`)"
+}

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -264,7 +264,7 @@ class PaginatorGeneratorTest {
     }
 
     @Test
-    fun testRenderPaginatorWithItemRequiringFqName() {
+    fun testRenderPaginatorWithItemRequiringFullName() {
         val testModelWithItems = """
             namespace com.test
             

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -264,6 +264,130 @@ class PaginatorGeneratorTest {
     }
 
     @Test
+    fun testRenderPaginatorWithItemRequiringFqName() {
+        val testModelWithItems = """
+            namespace com.test
+            
+            use aws.protocols#restJson1
+            
+            service FlowService {
+                operations: [ListFlows]
+            }
+            
+            @paginated(
+                inputToken: "Marker",
+                outputToken: "NextMarker",
+                pageSize: "MaxItems",
+                items: "Flows"
+            )
+            @readonly
+            @http(method: "GET", uri: "/flows", code: 200)
+            operation ListFlows {
+                input: ListFlowsRequest,
+                output: ListFlowsResponse
+            }
+            
+            structure ListFlowsRequest {
+                @httpQuery("FlowVersion")
+                FlowVersion: String,
+                @httpQuery("Marker")
+                Marker: String,
+                @httpQuery("MasterRegion")
+                MasterRegion: String,
+                @httpQuery("MaxItems")
+                MaxItems: Integer
+            }
+            
+            structure ListFlowsResponse {
+                Flows: FlowList,
+                NextMarker: String
+            }
+            
+            list FlowList {
+                member: Flow
+            }
+            
+            structure Flow {
+                Name: String
+            }
+        """.toSmithyModel()
+        val testContextWithItems = testModelWithItems.newTestContext("FlowService", "com.test")
+
+        val codegenContextWithItems = object : CodegenContext {
+            override val model: Model = testContextWithItems.generationCtx.model
+            override val symbolProvider: SymbolProvider = testContextWithItems.generationCtx.symbolProvider
+            override val settings: KotlinSettings = testContextWithItems.generationCtx.settings
+            override val protocolGenerator: ProtocolGenerator = testContextWithItems.generator
+            override val integrations: List<KotlinIntegration> = testContextWithItems.generationCtx.integrations
+        }
+
+        val unit = PaginatorGenerator()
+        unit.writeAdditionalFiles(codegenContextWithItems, testContextWithItems.generationCtx.delegator)
+
+        testContextWithItems.generationCtx.delegator.flushWriters()
+        val testManifest = testContextWithItems.generationCtx.delegator.fileManifest as MockManifest
+        val actual = testManifest.expectFileString("src/main/kotlin/com/test/paginators/Paginators.kt")
+
+        val expectedCode = """
+            /**
+             * Paginate over [ListFlowsResponse] results.
+             *
+             * When this operation is called, a [kotlinx.coroutines.Flow] is created. Flows are lazy (cold) so no service
+             * calls are made until the flow is collected. This also means there is no guarantee that the request is valid
+             * until then. Once you start collecting the flow, the SDK will lazily load response pages by making service
+             * calls until there are no pages left or the flow is cancelled. If there are errors in your request, you will
+             * see the failures only after you start collection.
+             * @param initialRequest A [ListFlowsRequest] to start pagination
+             * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFlowsResponse]
+             */
+            public fun TestClient.listFlowsPaginated(initialRequest: ListFlowsRequest = ListFlowsRequest { }): kotlinx.coroutines.flow.Flow<ListFlowsResponse> =
+                flow {
+                    var cursor: kotlin.String? = initialRequest.marker
+                    var hasNextPage: Boolean = true
+            
+                    while (hasNextPage) {
+                        val req = initialRequest.copy {
+                            this.marker = cursor
+                        }
+                        val result = this@listFlowsPaginated.listFlows(req)
+                        cursor = result.nextMarker
+                        hasNextPage = cursor?.isNotEmpty() == true
+                        emit(result)
+                    }
+                }
+            
+            /**
+             * Paginate over [ListFlowsResponse] results.
+             *
+             * When this operation is called, a [kotlinx.coroutines.Flow] is created. Flows are lazy (cold) so no service
+             * calls are made until the flow is collected. This also means there is no guarantee that the request is valid
+             * until then. Once you start collecting the flow, the SDK will lazily load response pages by making service
+             * calls until there are no pages left or the flow is cancelled. If there are errors in your request, you will
+             * see the failures only after you start collection.
+             * @param block A builder block used for DSL-style invocation of the operation
+             * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFlowsResponse]
+             */
+            public fun TestClient.listFlowsPaginated(block: ListFlowsRequest.Builder.() -> Unit): kotlinx.coroutines.flow.Flow<ListFlowsResponse> =
+                listFlowsPaginated(ListFlowsRequest.Builder().apply(block).build())
+            
+            /**
+             * This paginator transforms the flow returned by [listFlowsPaginated]
+             * to access the nested member [Flow]
+             * @return A [kotlinx.coroutines.flow.Flow] that can collect [Flow]
+             */
+            @JvmName("listFlowsResponseFlow")
+            public fun kotlinx.coroutines.flow.Flow<ListFlowsResponse>.flows(): kotlinx.coroutines.flow.Flow<Flow> =
+                transform() { response ->
+                    response.flows?.forEach {
+                        emit(it)
+                    }
+                }
+        """.trimIndent()
+
+        actual.shouldContainOnlyOnceWithDiff(expectedCode)
+    }
+
+    @Test
     fun testRenderPaginatorWithSparseItem() {
         val testModelWithItems = """
             namespace com.test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ kotlin-compile-testing-version = "0.7.0"
 kotlinx-benchmark-version = "0.4.12"
 kotlinx-serialization-version = "1.7.3"
 docker-java-version = "3.4.0"
-ktor-version = "3.1.1"
+ktor-version = "3.0.0"
 kaml-version = "0.55.0"
 jsoup-version = "1.18.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ kotlin-compile-testing-version = "0.7.0"
 kotlinx-benchmark-version = "0.4.12"
 kotlinx-serialization-version = "1.7.3"
 docker-java-version = "3.4.0"
-ktor-version = "3.0.0"
+ktor-version = "3.1.1"
 kaml-version = "0.55.0"
 jsoup-version = "1.18.1"
 


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

The codegen for paginators does not correctly handle the case of item types whose names collide with other types. Specifically, the function signature for the items paginator is formed without taking into account existing imports. This was discovered in a test model in which the pagination items were of type `Flow` which caused a paginator like this:

```kotlin
public fun Flow<FooResponse>.flows(): Flow<Flow> = ...
```

This PR improves the logic which forms item descriptors in paginator generators and will fully qualify type names which collide with existing imports, leading to this:

```kotlin
public fun Flow<FooResponse>.flows(): Flow<com.foo.Flow> = ...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
