### PR TITLE
fix: correctly handle sequential calls to `SingleFlightGroup`

### DIFF
--- a/.changes/065e6349-8e2a-403b-b588-067161f260fd.json
+++ b/.changes/065e6349-8e2a-403b-b588-067161f260fd.json
@@ -1,0 +1,5 @@
+{
+    "id": "065e6349-8e2a-403b-b588-067161f260fd",
+    "type": "bugfix",
+    "description": "Correctly handle sequential calls to `SingleFlightGroup`"
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/SingleFlightGroup.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/SingleFlightGroup.kt
@@ -52,6 +52,6 @@ public class SingleFlightGroup<T> {
         inFlight = deferred
         mu.unlock()
         runCatching { block() }.let { deferred.complete(it) }
-        return deferred.await().getOrThrow()
+        return deferred.await().also { inFlight = null }.getOrThrow()
     }
 }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/SingleFlightGroupTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/SingleFlightGroupTest.kt
@@ -109,4 +109,14 @@ class SingleFlightGroupTest {
             }
         }
     }
+
+    @Test
+    fun testSequential() = runTest {
+        val group = SingleFlightGroup<String>()
+        val first = group.singleFlight { "Foo" }
+        assertEquals("Foo", first)
+
+        val second = group.singleFlight { "Bar" }
+        assertEquals("Bar", second) // Fails; second == "Foo"
+    }
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Fixes a bug that caused subsequent invocations of `SingleFlightGroup.singleFlight` to reuse previously-completed jobs _even when_ they'd completed before the subsequent call began.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
