### PR TITLE
misc: remove `@InternalApi` from `SdkClientOption` extension functions

### DIFF
--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
@@ -48,27 +48,23 @@ public object SdkClientOption {
 /**
  * Get the [IdempotencyTokenProvider] from the context. If one is not set the default will be returned.
  */
-@InternalApi
 public val ExecutionContext.idempotencyTokenProvider: IdempotencyTokenProvider
     get() = getOrNull(SdkClientOption.IdempotencyTokenProvider) ?: IdempotencyTokenProvider.Default
 
 /**
  * Get the [LogMode] from the context. If one is not set a default will be returned
  */
-@InternalApi
 public val ExecutionContext.logMode: LogMode
     get() = getOrNull(SdkClientOption.LogMode) ?: LogMode.Default
 
 /**
  * Get the name of the operation being invoked from the context.
  */
-@InternalApi
 public val ExecutionContext.operationName: String?
     get() = getOrNull(SdkClientOption.OperationName)
 
 /**
  * Get the name of the service being invoked from the context.
  */
-@InternalApi
 public val ExecutionContext.serviceName: String?
     get() = getOrNull(SdkClientOption.ServiceName)

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.client
 
-import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.collections.AttributeKey
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`ExecutionContext` and the keys of `SdkClientOption` are both fully public. Let's make these convenience extension functions public too.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
