### PR TITLE
chore: reintegrate E2E smoke tests into the top-level Gradle build; modularize smoke test runners to improve testability

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -115,6 +115,7 @@ object RuntimeTypes {
         }
 
         object SmokeTests : RuntimeTypePackage(KotlinDependency.CORE, "smoketests") {
+            val DefaultPrinter = symbol("DefaultPrinter")
             val exitProcess = symbol("exitProcess")
             val printExceptionStackTrace = symbol("printExceptionStackTrace")
             val SmokeTestsException = symbol("SmokeTestsException")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
@@ -109,6 +109,7 @@ object KotlinTypes {
     }
 
     object Text : RuntimeTypePackage(KotlinDependency.KOTLIN_STDLIB, "text") {
+        val Appendable = stdlibSymbol("Appendable")
         val encodeToByteArray = stdlibSymbol("encodeToByteArray")
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGenerator.kt
@@ -93,7 +93,7 @@ class SmokeTestsRunnerGenerator(
                 }
                 indent()
                 write(".map { it() }")
-                write(".none { !it }")
+                write(".all { it }")
                 dedent()
             }
             renderFunctions()
@@ -234,7 +234,7 @@ class SmokeTestsRunnerGenerator(
         )
 
         writer.withBlock("if (!success) {", "}") {
-            write("printer.appendLine(exception.stackTraceToString().prependIndent(#S))", "#")
+            write("printer.appendLine(exception.stackTraceToString().prependIndent(#S))", "# ")
         }
 
         writer.write("")

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
@@ -112,7 +112,7 @@ class SmokeTestsRunnerGeneratorTest {
                         ::failureTest,
                     )
                         .map { it() }
-                        .none { !it }
+                        .all { it }
             """.formatForTest(),
         )
     }
@@ -148,7 +148,7 @@ class SmokeTestsRunnerGeneratorTest {
                         val status: String = if (success) "ok" else "not ok"
                         printer.appendLine("${'$'}status Test SuccessTest - no error expected from service ")
                         if (!success) {
-                            printer.appendLine(exception.stackTraceToString().prependIndent("#"))
+                            printer.appendLine(exception.stackTraceToString().prependIndent("# "))
                         }
                 
                         success
@@ -186,7 +186,7 @@ class SmokeTestsRunnerGeneratorTest {
                         val status: String = if (success) "ok" else "not ok"
                         printer.appendLine("${'$'}status Test InvalidMessageErrorTest - error expected from service ")
                         if (!success) {
-                            printer.appendLine(exception.stackTraceToString().prependIndent("#"))
+                            printer.appendLine(exception.stackTraceToString().prependIndent("# "))
                         }
                 
                         success
@@ -225,7 +225,7 @@ class SmokeTestsRunnerGeneratorTest {
                         val status: String = if (success) "ok" else "not ok"
                         printer.appendLine("${'$'}status Test FailureTest - error expected from service ")
                         if (!success) {
-                            printer.appendLine(exception.stackTraceToString().prependIndent("#"))
+                            printer.appendLine(exception.stackTraceToString().prependIndent("# "))
                         }
                 
                         success

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
@@ -113,7 +113,7 @@ class SmokeTestsRunnerGeneratorTest {
                     )
                         .map { it() }
                         .none { !it }
-            """.formatForTest()
+            """.formatForTest(),
         )
     }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
@@ -74,10 +74,9 @@ class SmokeTestsRunnerGeneratorTest {
     fun variablesTest() {
         generatedCode.shouldContainOnlyOnceWithDiff(
             """
-                private var exitCode = 0
-                private val skipTags = PlatformProvider.System.getenv("SMOKE_TEST_SKIP_TAGS")?.let { it.split(",").map { it.trim() }.toSet() } ?: emptySet()
-                private val serviceFilter = PlatformProvider.System.getenv("SMOKE_TEST_SERVICE_IDS")?.let { it.split(",").map { it.trim() }.toSet() }
-            """.trimIndent(),
+                private val skipTags = platform.getenv("SMOKE_TEST_SKIP_TAGS")?.let { it.split(",").map { it.trim() }.toSet() } ?: emptySet()
+                private val serviceFilter = platform.getenv("SMOKE_TEST_SERVICE_IDS")?.let { it.split(",").map { it.trim() }.toSet() }
+            """.formatForTest(),
         )
     }
 
@@ -86,12 +85,35 @@ class SmokeTestsRunnerGeneratorTest {
         generatedCode.shouldContainOnlyOnceWithDiff(
             """
                 public suspend fun main() {
-                    successTest()
-                    invalidMessageErrorTest()
-                    failureTest()
-                    exitProcess(exitCode)
+                    val success = SmokeTestRunner().runAllTests()
+                    if (!success) {
+                        exitProcess(1)
+                    }
                 }
             """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun runnerClassTest() {
+        generatedCode.shouldContainOnlyOnceWithDiff(
+            "public class SmokeTestRunner(private val platform: PlatformProvider = PlatformProvider.System, private val printer: Appendable = DefaultPrinter) {",
+        )
+    }
+
+    @Test
+    fun runAllTestsTest() {
+        generatedCode.shouldContainOnlyOnceWithDiff(
+            """
+                public suspend fun runAllTests(): Boolean =
+                    listOf<suspend () -> Boolean>(
+                        ::successTest,
+                        ::invalidMessageErrorTest,
+                        ::failureTest,
+                    )
+                        .map { it() }
+                        .none { !it }
+            """.formatForTest()
         )
     }
 
@@ -99,14 +121,14 @@ class SmokeTestsRunnerGeneratorTest {
     fun successTest() {
         generatedCode.shouldContainOnlyOnceWithDiff(
             """
-                private suspend fun successTest() {
+                private suspend fun successTest(): Boolean {
                     val tags = setOf<String>("success")
                     if ((serviceFilter.isNotEmpty() && "Test" !in serviceFilter) || tags.any { it in skipTags }) {
-                        println("ok Test SuccessTest - no error expected from service # skip")
-                        return
+                        printer.appendLine("ok Test SuccessTest - no error expected from service # skip")
+                        return true
                     }
-
-                    try {
+                
+                    return try {
                         TestClient {
                             interceptors.add(SmokeTestsInterceptor())
                             region = "eu-central-1"
@@ -118,18 +140,21 @@ class SmokeTestsRunnerGeneratorTest {
                                 }
                             )
                         }
-
+                
+                        error("Unexpectedly completed smoke test operation without throwing exception")
+                
                     } catch (exception: Exception) {
                         val success: Boolean = exception is SmokeTestsSuccessException
                         val status: String = if (success) "ok" else "not ok"
-                        println("${'$'}status Test SuccessTest - no error expected from service ")
+                        printer.appendLine("${'$'}status Test SuccessTest - no error expected from service ")
                         if (!success) {
-                            printExceptionStackTrace(exception)
-                            exitCode = 1
+                            printer.appendLine(exception.stackTraceToString().prependIndent("#"))
                         }
+                
+                        success
                     }
                 }
-            """.trimIndent(),
+            """.formatForTest(),
         )
     }
 
@@ -137,14 +162,14 @@ class SmokeTestsRunnerGeneratorTest {
     fun invalidMessageErrorTest() {
         generatedCode.shouldContainOnlyOnceWithDiff(
             """
-                private suspend fun invalidMessageErrorTest() {
+                private suspend fun invalidMessageErrorTest(): Boolean {
                     val tags = setOf<String>()
                     if ((serviceFilter.isNotEmpty() && "Test" !in serviceFilter) || tags.any { it in skipTags }) {
-                        println("ok Test InvalidMessageErrorTest - error expected from service # skip")
-                        return
+                        printer.appendLine("ok Test InvalidMessageErrorTest - error expected from service # skip")
+                        return true
                     }
                 
-                    try {
+                    return try {
                         TestClient {
                         }.use { client ->
                             client.testOperation(
@@ -154,17 +179,20 @@ class SmokeTestsRunnerGeneratorTest {
                             )
                         }
                 
+                        error("Unexpectedly completed smoke test operation without throwing exception")
+                
                     } catch (exception: Exception) {
                         val success: Boolean = exception is InvalidMessageError
                         val status: String = if (success) "ok" else "not ok"
-                        println("${'$'}status Test InvalidMessageErrorTest - error expected from service ")
+                        printer.appendLine("${'$'}status Test InvalidMessageErrorTest - error expected from service ")
                         if (!success) {
-                            printExceptionStackTrace(exception)
-                            exitCode = 1
+                            printer.appendLine(exception.stackTraceToString().prependIndent("#"))
                         }
+                
+                        success
                     }
                 }
-            """.trimIndent(),
+            """.formatForTest(),
         )
     }
 
@@ -172,14 +200,14 @@ class SmokeTestsRunnerGeneratorTest {
     fun failureTest() {
         generatedCode.shouldContainOnlyOnceWithDiff(
             """
-                private suspend fun failureTest() {
+                private suspend fun failureTest(): Boolean {
                     val tags = setOf<String>()
                     if ((serviceFilter.isNotEmpty() && "Test" !in serviceFilter) || tags.any { it in skipTags }) {
-                        println("ok Test FailureTest - error expected from service # skip")
-                        return
+                        printer.appendLine("ok Test FailureTest - error expected from service # skip")
+                        return true
                     }
                 
-                    try {
+                    return try {
                         TestClient {
                             interceptors.add(SmokeTestsInterceptor())
                         }.use { client ->
@@ -190,17 +218,20 @@ class SmokeTestsRunnerGeneratorTest {
                             )
                         }
                 
+                        error("Unexpectedly completed smoke test operation without throwing exception")
+                
                     } catch (exception: Exception) {
                         val success: Boolean = exception is SmokeTestsFailureException
                         val status: String = if (success) "ok" else "not ok"
-                        println("${'$'}status Test FailureTest - error expected from service ")
+                        printer.appendLine("${'$'}status Test FailureTest - error expected from service ")
                         if (!success) {
-                            printExceptionStackTrace(exception)
-                            exitCode = 1
+                            printer.appendLine(exception.stackTraceToString().prependIndent("#"))
                         }
+                
+                        success
                     }
                 }
-            """.trimIndent(),
+            """.formatForTest(),
         )
     }
 

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -2093,6 +2093,7 @@ public final class aws/smithy/kotlin/runtime/smoketests/SmokeTestsFunctionsJVMKt
 }
 
 public final class aws/smithy/kotlin/runtime/smoketests/SmokeTestsFunctionsKt {
+	public static final fun getDefaultPrinter ()Ljava/lang/Appendable;
 	public static final fun printExceptionStackTrace (Ljava/lang/Exception;)V
 }
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/smoketests/SmokeTestsFunctions.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/smoketests/SmokeTestsFunctions.kt
@@ -15,7 +15,21 @@ public expect fun exitProcess(status: Int): Nothing
  * #	at executors.JavaRunnerExecutor$Companion.main(JavaRunnerExecutor.kt:27)
  * #	at executors.JavaRunnerExecutor.main(JavaRunnerExecutor.kt)
  */
+@Deprecated(
+    message = "No longer used, target for removal in 1.5",
+    replaceWith = ReplaceWith("println(exception.stackTraceToString().prependIndent(\"#\"))"),
+    level = DeprecationLevel.WARNING,
+)
 public fun printExceptionStackTrace(exception: Exception): Unit =
     println(exception.stackTraceToString().split("\n").joinToString("\n") { "#$it" })
 
 public class SmokeTestsException(message: String) : Exception(message)
+
+/**
+ * An [Appendable] which can be used for printing test results to the console
+ */
+public val DefaultPrinter: Appendable = object : Appendable {
+    override fun append(c: Char) = this.also { print(c) }
+    override fun append(csq: CharSequence?) = this.also { print(csq) }
+    override fun append(csq: CharSequence?, start: Int, end: Int) = this.also { print(csq?.subSequence(start, end)) }
+}


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change modularizes smoke test runners to improve their testability so that the E2E smoke tests can be refactored in **aws-sdk-kotlin** to run inside the top-level Gradle build.

**Companion PR**: https://github.com/awslabs/aws-sdk-kotlin/pull/1558

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
