### PR TITLE
misc: include `aws-crt-kotlin` as a composite build

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,7 +59,6 @@ compositeProjectList.forEach {
     }
 }
 
-
 rootProject.name = "smithy-kotlin"
 
 include(":dokka-smithy")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ dependencyResolutionManagement {
     }
 }
 
+// TODO This is largely shared with aws-sdk-kotlin, consider commonizing
 // Set up a sibling directory aws-crt-kotlin as a composite build, if it exists.
 // Allows overrides via local.properties:
 // compositeProjects=~/repos/aws-crt-kotlin,/tmp/some/other/thing,../../another/project

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,40 @@ dependencyResolutionManagement {
     }
 }
 
+// Set up a sibling directory aws-crt-kotlin as a composite build, if it exists.
+// Allows overrides via local.properties:
+// compositeProjects=~/repos/aws-crt-kotlin,/tmp/some/other/thing,../../another/project
+val compositeProjectList = try {
+    val localProperties = java.util.Properties().also {
+        it.load(File(rootProject.projectDir, "local.properties").inputStream())
+    }
+    val compositeProjects = localProperties.getProperty("compositeProjects") ?: "../aws-crt-kotlin"
+
+    val compositeProjectPaths = compositeProjects.split(",")
+        .map { it.replaceFirst("^~".toRegex(), System.getProperty("user.home")) } // expand ~ to user's home directory
+        .filter { it.isNotBlank() }
+        .map { file(it) }
+
+    compositeProjectPaths.also {
+        if (it.isNotEmpty()) {
+            println("Adding composite build projects from local.properties: ${compositeProjectPaths.joinToString { it.name }}")
+        }
+    }
+} catch (_: Throwable) {
+    logger.error("Could not load composite project paths from local.properties")
+    listOf(file("../aws-crt-kotlin"))
+}
+
+compositeProjectList.forEach {
+    if (it.exists()) {
+        println("Including build '$it'")
+        includeBuild(it)
+    } else {
+        println("Ignoring invalid build directory '$it'")
+    }
+}
+
+
 rootProject.name = "smithy-kotlin"
 
 include(":dokka-smithy")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Pulling this in from kn-main: https://github.com/smithy-lang/smithy-kotlin/blob/kn-main/settings.gradle.kts#L29

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
