### PR TITLE
chore: upgrade aws-kotlin-repo-tools

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin-version = "2.1.0"
 dokka-version = "1.9.10"
 
-aws-kotlin-repo-tools-version = "0.4.20"
+aws-kotlin-repo-tools-version = "0.4.22"
 
 # libs
 coroutines-version = "1.9.0"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Upgrade **aws-kotlin-repo-tools** to **0.4.22** to pick up [fix for compiler warning](https://github.com/awslabs/aws-kotlin-repo-tools/pull/82).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.