### PR TITLE
fix: improve handling of expected socket exceptions when using connection poller

### DIFF
--- a/.changes/6795f037-bb98-434b-8b87-1bbe59b2edb2.json
+++ b/.changes/6795f037-bb98-434b-8b87-1bbe59b2edb2.json
@@ -1,0 +1,8 @@
+{
+    "id": "6795f037-bb98-434b-8b87-1bbe59b2edb2",
+    "type": "bugfix",
+    "description": "Improve handling of excepted socket exceptions when using connection polling",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1214"
+    ]
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ConnectionIdleMonitor.kt
@@ -11,7 +11,7 @@ import okhttp3.Connection
 import okhttp3.ConnectionListener
 import okhttp3.ExperimentalOkHttpApi
 import okhttp3.internal.closeQuietly
-import okio.EOFException
+import okio.IOException
 import okio.buffer
 import okio.source
 import java.net.SocketException
@@ -96,7 +96,7 @@ internal class ConnectionIdleMonitor(val pollInterval: Duration) : ConnectionLis
                     source.readByte() // Blocking read; will take up to `pollInterval` time to complete
                 } catch (_: SocketTimeoutException) {
                     logger.trace { "Socket still alive for $conn" }
-                } catch (_: EOFException) {
+                } catch (_: IOException) {
                     logger.trace { "Socket closed remotely for $conn" }
                     socket.closeQuietly()
                     resetTimeout = false


### PR DESCRIPTION
## Issue \#

https://github.com/awslabs/aws-sdk-kotlin/issues/1214

## Description of changes

This change widens the socket exceptions caught by `ConnectionIdleMonitor` when a connection has been closed remotely to account for new behavior reported in https://github.com/awslabs/aws-sdk-kotlin/issues/1214.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
