### PR TITLE
style: properly indent the dependencies in the gradle file

### DIFF
--- a/.changes/14965afd-c9f4-48b0-a053-de860b81ecd2.json
+++ b/.changes/14965afd-c9f4-48b0-a053-de860b81ecd2.json
@@ -1,0 +1,5 @@
+{
+  "id": "14965afd-c9f4-48b0-a053-de860b81ecd2",
+  "type": "style",
+  "description": "Properly indent the dependencies in the gradle file and add some new lines to separate sections"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGenerator.kt
@@ -95,7 +95,7 @@ fun renderKmpGradleBuild(
             #W
         }  
         #W
-        
+
         kotlin {
             #W
             #W
@@ -165,14 +165,17 @@ fun renderJvmGradleBuild(
         plugins {
             #W
         }
+
         #W
 
         dependencies {
             #W
         }
+
         val optInAnnotations = listOf(
             #W
         )
+
         kotlin {
             #W
             sourceSets.all {
@@ -223,7 +226,7 @@ private fun renderDependencies(writer: GradleWriter, scope: Scope, isKmp: Boolea
         }
         .forEach { dependency ->
             writer.write(
-                "${dependency.config}(\"#L:#L:#L\")",
+                "${writer.indentText}${dependency.config}(\"#L:#L:#L\")",
                 dependency.group,
                 dependency.artifact,
                 dependency.version,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes

This changes add new lines between sections in the `gradle` file, and also properly indents the dependencies.

**Before**
```
plugins {
    kotlin("jvm") version "2.1.0"
}
repositories {
    mavenLocal()
    mavenCentral()
}

dependencies {
    implementation(kotlin("stdlib"))
implementation("aws.smithy.kotlin:aws-credentials:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:aws-json-protocols:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:aws-protocol-core:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:aws-signing-common:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:aws-signing-default:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:http:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:http-auth:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:http-auth-aws:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:http-client-engine-default:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:identity-api:1.4.17-SNAPSHOT")
implementation("org.jetbrains.kotlin:kotlin-stdlib:2.1.0")
implementation("aws.smithy.kotlin:serde:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:serde-json:1.4.17-SNAPSHOT")
implementation("aws.smithy.kotlin:telemetry-defaults:1.4.17-SNAPSHOT")
api("aws.smithy.kotlin:http-client:1.4.17-SNAPSHOT")
api("aws.smithy.kotlin:runtime-core:1.4.17-SNAPSHOT")
api("aws.smithy.kotlin:smithy-client:1.4.17-SNAPSHOT")
api("aws.smithy.kotlin:telemetry-api:1.4.17-SNAPSHOT")
testImplementation("org.jetbrains.kotlin:kotlin-test:2.1.0")
testImplementation("aws.smithy.kotlin:smithy-test:1.4.17-SNAPSHOT")
}
val optInAnnotations = listOf(
    "aws.smithy.kotlin.runtime.InternalApi"
)
kotlin {
    explicitApi()
    sourceSets.all {
        optInAnnotations.forEach { languageSettings.optIn(it) }
    }
}

tasks.test {
    useJUnitPlatform()
    testLogging {
        events("passed", "skipped", "failed")
        showStandardStreams = true
        showStackTraces = true
        showExceptions = true
        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
    }
}
```

**After**

```
plugins {
    kotlin("jvm") version "2.1.0"
}

repositories {
    mavenLocal()
    mavenCentral()
}

dependencies {
    implementation(kotlin("stdlib"))
    implementation("aws.smithy.kotlin:aws-credentials:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:aws-json-protocols:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:aws-protocol-core:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:aws-signing-common:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:aws-signing-default:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:http:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:http-auth:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:http-auth-aws:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:http-client-engine-default:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:identity-api:1.4.17-SNAPSHOT")
    implementation("org.jetbrains.kotlin:kotlin-stdlib:2.1.0")
    implementation("aws.smithy.kotlin:serde:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:serde-json:1.4.17-SNAPSHOT")
    implementation("aws.smithy.kotlin:telemetry-defaults:1.4.17-SNAPSHOT")
    api("aws.smithy.kotlin:http-client:1.4.17-SNAPSHOT")
    api("aws.smithy.kotlin:runtime-core:1.4.17-SNAPSHOT")
    api("aws.smithy.kotlin:smithy-client:1.4.17-SNAPSHOT")
    api("aws.smithy.kotlin:telemetry-api:1.4.17-SNAPSHOT")
    testImplementation("org.jetbrains.kotlin:kotlin-test:2.1.0")
    testImplementation("aws.smithy.kotlin:smithy-test:1.4.17-SNAPSHOT")
}

val optInAnnotations = listOf(
    "aws.smithy.kotlin.runtime.InternalApi"
)

kotlin {
    explicitApi()
    sourceSets.all {
        optInAnnotations.forEach { languageSettings.optIn(it) }
    }
}

tasks.test {
    useJUnitPlatform()
    testLogging {
        events("passed", "skipped", "failed")
        showStandardStreams = true
        showStackTraces = true
        showExceptions = true
        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
    }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
