### PR TITLE
fix: add import references when needed

### DIFF
--- a/.changes/bbe2e7de-79d3-4aea-97d1-d5c244ede433.json
+++ b/.changes/bbe2e7de-79d3-4aea-97d1-d5c244ede433.json
@@ -1,0 +1,5 @@
+{
+  "id": "bbe2e7de-79d3-4aea-97d1-d5c244ede433",
+  "type": "bugfix",
+  "description": "Adds import to the symbols references when needed. This issue surfaced when building the protocol tests with the latest Smithy release"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -267,13 +267,10 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
     private fun getDefaultValueForTimestamp(builder: Symbol.Builder, node: NumberNode): String {
         builder.addReferences(RuntimeTypes.Core.Instant)
         return if (node.isFloatingPointNumber) {
-            builder.addReferences(RuntimeTypes.Core.fromEpochMilliseconds)
-
             val value = node.value as Double
             val ms = round(value * 1e3).toLong()
             "Instant.fromEpochMilliseconds($ms)"
         } else {
-            builder.addReferences(RuntimeTypes.Core.Instant)
             "Instant.fromEpochSeconds(${node.value}, 0)"
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -252,7 +252,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
             }
 
             targetShape.isDocumentShape -> getDefaultValueForDocument(node)
-            targetShape.isTimestampShape -> getDefaultValueForTimestamp(node.asNumberNode().get())
+            targetShape.isTimestampShape -> getDefaultValueForTimestamp(this, node.asNumberNode().get())
 
             node.isNumberNode -> getDefaultValueForNumber(targetShape.type, node.toString())
             node.isArrayNode -> "listOf()"
@@ -264,17 +264,17 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         defaultValue(defaultValue)
     }
 
-    private fun getDefaultValueForTimestamp(node: NumberNode): String {
-        val instant = RuntimeTypes.Core.Instant
-
+    private fun getDefaultValueForTimestamp(builder: Symbol.Builder, node: NumberNode): String {
+        builder.addReferences(RuntimeTypes.Core.Instant)
         return if (node.isFloatingPointNumber) {
-            val fromEpochMilliseconds = RuntimeTypes.Core.fromEpochMilliseconds
+            builder.addReferences(RuntimeTypes.Core.fromEpochMilliseconds)
 
             val value = node.value as Double
             val ms = round(value * 1e3).toLong()
-            "$fromEpochMilliseconds.invoke($instant, $ms)"
+            "Instant.fromEpochMilliseconds($ms)"
         } else {
-            "$instant.fromEpochSeconds(${node.value}, 0)"
+            builder.addReferences(RuntimeTypes.Core.Instant)
+            "Instant.fromEpochSeconds(${node.value}, 0)"
         }
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -6,6 +6,7 @@ package software.amazon.smithy.kotlin.codegen.rendering
 
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.SymbolProvider
+import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.model.SymbolProperty
 import software.amazon.smithy.kotlin.codegen.model.hasTrait
@@ -90,9 +91,9 @@ class ShapeValueGenerator(
     private fun mapDeclaration(writer: KotlinWriter, shape: MapShape, block: () -> Unit) {
         writer.pushState()
         writer.trimTrailingSpaces(false)
-
-        val collectionGeneratorFunction = symbolProvider.toSymbol(shape).expectProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION)
-
+        val mapSymbol = symbolProvider.toSymbol(shape)
+        writer.addImportReferences(mapSymbol, SymbolReference.ContextOption.USE)
+        val collectionGeneratorFunction = mapSymbol.expectProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION)
         writer.writeInline("$collectionGeneratorFunction(")
             .ensureNewline()
             .indent()
@@ -109,11 +110,8 @@ class ShapeValueGenerator(
         writer.trimTrailingSpaces(false)
 
         val collectionSymbol = symbolProvider.toSymbol(shape)
+        writer.addImportReferences(collectionSymbol, SymbolReference.ContextOption.USE)
         val generatorFn = collectionSymbol.expectProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION)
-
-        collectionSymbol.references.forEach {
-            writer.addImport(it.symbol)
-        }
         writer.writeInline("$generatorFn(")
             .ensureNewline()
             .indent()

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
@@ -5,6 +5,7 @@
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
 import software.amazon.smithy.codegen.core.CodegenException
+import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.DefaultValueSerializationMode
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.model.*
@@ -595,6 +596,7 @@ open class SerializeStructGenerator(
         val postfix = if (memberShape.hasTrait<IdempotencyTokenTrait>()) idempotencyTokenPostfix(memberShape) else ""
         val memberSymbol = ctx.symbolProvider.toSymbol(memberShape)
         val memberName = ctx.symbolProvider.toMemberName(memberShape)
+        writer.addImportReferences(memberSymbol, SymbolReference.ContextOption.USE)
         if (memberSymbol.isNullable) {
             val identifier = valueToSerializeName("it")
             val fn = serializerFn.format(memberShape, identifier)

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -186,8 +186,8 @@ class SymbolProviderTest {
         "boolean,true,true",
         "bigInteger,5,5",
         "bigDecimal,9.0123456789,9.0123456789",
-        "timestamp,1684869901,'aws.smithy.kotlin.runtime.time.Instant.fromEpochSeconds(1684869901, 0)'",
-        "timestamp,1.5,'aws.smithy.kotlin.runtime.time.fromEpochMilliseconds.invoke(aws.smithy.kotlin.runtime.time.Instant, 1500)'",
+        "timestamp,1684869901,'Instant.fromEpochSeconds(1684869901, 0)'",
+        "timestamp,1.5,'Instant.fromEpochMilliseconds(1500)'",
     )
     fun `can default simple types`(typeName: String, modeledDefault: String, expectedDefault: String) {
         val model = """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#1287

https://github.com/smithy-lang/smithy-kotlin/issues/1287

<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes

This change imports the symbol references to add them to the resulting Kotlin file. Without this the codegen for protocol tests with the latest Smithy model complains about missing symbols such as 

* `decodeBase64`
* `fromEpochMilliseconds`

Some of the references were added but not imported. Some others needed being added and imported.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
