### PR TITLE
fix: Add `-Xjdk-release=1.8` everywhere we set `jvmTarget`

### DIFF
--- a/codegen/smithy-kotlin-codegen-testutils/build.gradle.kts
+++ b/codegen/smithy-kotlin-codegen-testutils/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.add("-Xjdk-release=1.8")
         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
     }
 }

--- a/codegen/smithy-kotlin-codegen/build.gradle.kts
+++ b/codegen/smithy-kotlin-codegen/build.gradle.kts
@@ -58,6 +58,7 @@ val generateSdkRuntimeVersion by tasks.registering {
 tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.add("-Xjdk-release=1.8")
         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
     }
     dependsOn(generateSdkRuntimeVersion)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -21,6 +21,7 @@ import software.amazon.smithy.rulesengine.language.EndpointRuleSet
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
 import software.amazon.smithy.rulesengine.traits.EndpointTestCase
 import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait
+import java.util.stream.Collectors
 
 /**
  * Get all shapes of a particular type from the model.
@@ -32,7 +33,7 @@ import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait
  * shape's closure for example)
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-inline fun <reified T : Shape> Model.shapes(): List<T> = shapes(T::class.java).toList()
+inline fun <reified T : Shape> Model.shapes(): List<T> = shapes(T::class.java).collect(Collectors.toList())
 
 /**
  * Extension function to return a shape of expected type.

--- a/dokka-smithy/build.gradle.kts
+++ b/dokka-smithy/build.gradle.kts
@@ -34,6 +34,7 @@ tasks.test {
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.add("-Xjdk-release=1.8")
         allWarningsAsErrors.set(false) // FIXME Dokka bundles stdlib into the classpath, causing an unfixable warning
     }
 }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -65,6 +65,7 @@ subprojects {
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
+            freeCompilerArgs.add("-Xjdk-release=1.8")
             freeCompilerArgs.add("-Xexpect-actual-classes")
         }
     }

--- a/tests/integration/slf4j-1x-consumer/build.gradle.kts
+++ b/tests/integration/slf4j-1x-consumer/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
 tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.add("-Xjdk-release=1.8")
     }
 }
 

--- a/tests/integration/slf4j-2x-consumer/build.gradle.kts
+++ b/tests/integration/slf4j-2x-consumer/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.add("-Xjdk-release=1.8")
     }
 }
 

--- a/tests/integration/slf4j-hybrid-consumer/build.gradle.kts
+++ b/tests/integration/slf4j-hybrid-consumer/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
+        freeCompilerArgs.add("-Xjdk-release=1.8")
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This will fix issues that arise when building this project on JDK21

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Closes https://github.com/smithy-lang/smithy-kotlin/issues/1295


## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
