### PR TITLE
fix: add `explicitReceiver` parameter to `ShapeValueGenerator`

### DIFF
--- a/.changes/bdcf7bc9-094c-4434-aa34-1df7f4f4c936.json
+++ b/.changes/bdcf7bc9-094c-4434-aa34-1df7f4f4c936.json
@@ -1,0 +1,5 @@
+{
+    "id": "bdcf7bc9-094c-4434-aa34-1df7f4f4c936",
+    "type": "bugfix",
+    "description": "Explicitly qualify shape member names in smoke tests and protocol tests"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -26,7 +26,7 @@ import kotlin.math.round
 class ShapeValueGenerator(
     internal val model: Model,
     internal val symbolProvider: SymbolProvider,
-    internal val explicitReceiver: Boolean = false
+    internal val explicitReceiver: Boolean = false,
 ) {
 
     /**

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -19,10 +19,14 @@ import kotlin.math.round
 
 /**
  * Generates a shape type declaration based on the parameters provided.
+ * @param model the model which contains the shape being generated
+ * @param symbolProvider the symbol provider for the model
+ * @param explicitReceiver Whether shape members should be fully qualified, prefixed with `this.`
  */
 class ShapeValueGenerator(
     internal val model: Model,
     internal val symbolProvider: SymbolProvider,
+    internal val explicitReceiver: Boolean = false
 ) {
 
     /**
@@ -61,7 +65,7 @@ class ShapeValueGenerator(
     }
 
     private fun writeShapeValuesInline(writer: KotlinWriter, shape: Shape, params: Node) {
-        val nodeVisitor = ShapeValueNodeVisitor(writer, this, shape)
+        val nodeVisitor = ShapeValueNodeVisitor(writer, this, shape, explicitReceiver)
         when (shape.type) {
             ShapeType.STRUCTURE -> params.accept(nodeVisitor)
             ShapeType.MAP -> mapDeclaration(writer, shape.asMapShape().get()) {
@@ -158,6 +162,7 @@ class ShapeValueGenerator(
         val writer: KotlinWriter,
         val generator: ShapeValueGenerator,
         val currShape: Shape,
+        val explicitReceiver: Boolean = false,
     ) : NodeVisitor<Unit> {
 
         override fun objectNode(node: ObjectNode) {
@@ -178,7 +183,10 @@ class ShapeValueGenerator(
                         }
                         memberShape = generator.model.expectShape(member.target)
                         val memberName = generator.symbolProvider.toMemberName(member)
-                        writer.writeInline("#L = ", memberName)
+                        val memberPrefix = if (explicitReceiver) "this." else ""
+
+                        writer.writeInline("#L#L = ", memberPrefix, memberName)
+
                         generator.instantiateShapeInline(writer, memberShape, valueNode)
                         if (i < node.members.size - 1) {
                             writer.ensureNewline()

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestRequestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestRequestGenerator.kt
@@ -189,7 +189,7 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
                     writer.writeInline("\nval input = ")
                         .indent()
                         .call {
-                            ShapeValueGenerator(model, symbolProvider).instantiateShapeInline(writer, inputShape, test.params)
+                            ShapeValueGenerator(model, symbolProvider, explicitReceiver = true).instantiateShapeInline(writer, inputShape, test.params)
                         }
                         .dedent()
                         .write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestResponseGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestResponseGenerator.kt
@@ -80,7 +80,7 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
                     .call {
                         outputShape?.let {
                             writer.writeInline("\nresponse = ")
-                            ShapeValueGenerator(model, symbolProvider).instantiateShapeInline(writer, it, test.params)
+                            ShapeValueGenerator(model, symbolProvider, explicitReceiver = true).instantiateShapeInline(writer, it, test.params)
                         }
                     }
                     .write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGenerator.kt
@@ -211,7 +211,7 @@ class SmokeTestsRunnerGenerator(
         } else {
             writer.withBlock("(", ")") {
                 val inputShape = model.expectShape(operation.input.get())
-                ShapeValueGenerator(model, symbolProvider).instantiateShapeInline(writer, inputShape, inputParams)
+                ShapeValueGenerator(model, symbolProvider, explicitReceiver = true).instantiateShapeInline(writer, inputShape, inputParams)
             }
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
@@ -172,6 +172,50 @@ listOf<List<String>>(
 
     @Test
     fun `it renders structs`() {
+        val contents = renderTestStruct()
+
+        val expected = """
+            MyStruct {
+                stringMember = "v1"
+                boolMember = true
+                intMember = 1
+                structMember = Nested {
+                    tsMember = Instant.fromEpochSeconds(11223344, 0)
+                }
+                enumMember = MyEnum.fromValue("fooey")
+                floatMember = 2.toFloat()
+                doubleMember = 3.0.toDouble()
+                nullMember = null
+            }
+        """.trimIndent()
+
+        contents.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
+    fun `it renders structs with an explicit receiver`() {
+        val contents = renderTestStruct(explicitReceiver = true)
+
+        val expected = """
+            MyStruct {
+                this.stringMember = "v1"
+                this.boolMember = true
+                this.intMember = 1
+                this.structMember = Nested {
+                    this.tsMember = Instant.fromEpochSeconds(11223344, 0)
+                }
+                this.enumMember = MyEnum.fromValue("fooey")
+                this.floatMember = 2.toFloat()
+                this.doubleMember = 3.0.toDouble()
+                this.nullMember = null
+            }
+        """.trimIndent()
+
+        contents.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+
+    fun renderTestStruct(explicitReceiver: Boolean = false): String {
         val model = """
             structure MyStruct {
                 stringMember: String,
@@ -218,26 +262,10 @@ listOf<List<String>>(
             .withMember("nullMember", Node.nullNode())
             .build()
 
-        ShapeValueGenerator(model, provider).instantiateShapeInline(writer, structShape, params)
-        val contents = writer.toString()
-
-        val expected = """
-MyStruct {
-    stringMember = "v1"
-    boolMember = true
-    intMember = 1
-    structMember = Nested {
-        tsMember = Instant.fromEpochSeconds(11223344, 0)
+        ShapeValueGenerator(model, provider, explicitReceiver).instantiateShapeInline(writer, structShape, params)
+        return writer.toString()
     }
-    enumMember = MyEnum.fromValue("fooey")
-    floatMember = 2.toFloat()
-    doubleMember = 3.0.toDouble()
-    nullMember = null
-}
-        """.trimIndent()
 
-        contents.shouldContainOnlyOnceWithDiff(expected)
-    }
 
     @Test
     fun `it renders null structs`() {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
@@ -214,7 +214,6 @@ listOf<List<String>>(
         contents.shouldContainOnlyOnceWithDiff(expected)
     }
 
-
     fun renderTestStruct(explicitReceiver: Boolean = false): String {
         val model = """
             structure MyStruct {
@@ -265,7 +264,6 @@ listOf<List<String>>(
         ShapeValueGenerator(model, provider, explicitReceiver).instantiateShapeInline(writer, structShape, params)
         return writer.toString()
     }
-
 
     @Test
     fun `it renders null structs`() {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/smoketests/SmokeTestsRunnerGeneratorTest.kt
@@ -136,7 +136,7 @@ class SmokeTestsRunnerGeneratorTest {
                         }.use { client ->
                             client.testOperation(
                                 TestOperationRequest {
-                                    bar = "2"
+                                    this.bar = "2"
                                 }
                             )
                         }
@@ -174,7 +174,7 @@ class SmokeTestsRunnerGeneratorTest {
                         }.use { client ->
                             client.testOperation(
                                 TestOperationRequest {
-                                    bar = "föö"
+                                    this.bar = "föö"
                                 }
                             )
                         }
@@ -213,7 +213,7 @@ class SmokeTestsRunnerGeneratorTest {
                         }.use { client ->
                             client.testOperation(
                                 TestOperationRequest {
-                                    bar = "föö"
+                                    this.bar = "föö"
                                 }
                             )
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Addresses issues with name clashes in generated smoke tests by adding and using an `explicitReceiver` parameter, which prefixes shape member names with `this.`

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
