### PR TITLE
fix: always serialize defaults

### DIFF
--- a/.changes/d4f09e32-8bcc-406e-96e0-2743280c13d9.json
+++ b/.changes/d4f09e32-8bcc-406e-96e0-2743280c13d9.json
@@ -1,0 +1,8 @@
+{
+    "id": "d4f09e32-8bcc-406e-96e0-2743280c13d9",
+    "type": "bugfix",
+    "description": "Switch to always serialize defaults in requests. Previously fields were not serialized in requests if they weren't `@required` and hadn't been changed from the default value.",
+    "issues": [
+        "https://github.com/awslabs/aws-sdk-kotlin/issues/1608"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/ModelTestUtils.kt
+++ b/codegen/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/ModelTestUtils.kt
@@ -173,7 +173,7 @@ fun Model.defaultSettings(
     sdkId: String = TestModelDefault.SDK_ID,
     generateDefaultBuildFiles: Boolean = false,
     nullabilityCheckMode: CheckMode = CheckMode.CLIENT_CAREFUL,
-    defaultValueSerializationMode: DefaultValueSerializationMode = DefaultValueSerializationMode.WHEN_DIFFERENT,
+    defaultValueSerializationMode: DefaultValueSerializationMode = DefaultValueSerializationMode.DEFAULT,
 ): KotlinSettings {
     val serviceId = if (serviceName == null) {
         this.inferService()

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -21,6 +21,7 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.protocol.traits.Rpcv2CborTrait
 import java.util.*
 import java.util.logging.Logger
+import java.util.stream.Collectors
 
 // shapeId of service from which to generate an SDK
 private const val SERVICE = "service"
@@ -157,7 +158,7 @@ fun Model.inferService(): ShapeId {
     val services = shapes(ServiceShape::class.java)
         .map(Shape::getId)
         .sorted()
-        .toList()
+        .collect(Collectors.toList())
 
     return when {
         services.isEmpty() -> {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependency.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependency.kt
@@ -134,6 +134,7 @@ data class KotlinDependency(
         // External third-party dependencies
         val KOTLIN_STDLIB = KotlinDependency(GradleConfiguration.Implementation, "kotlin", "org.jetbrains.kotlin", "kotlin-stdlib", KOTLIN_COMPILER_VERSION)
         val KOTLIN_TEST = KotlinDependency(GradleConfiguration.TestImplementation, "kotlin.test", "org.jetbrains.kotlin", "kotlin-test", KOTLIN_COMPILER_VERSION)
+        val KOTLIN_TEST_IMPL = KOTLIN_TEST.copy(config = GradleConfiguration.Implementation)
     }
 
     override fun getDependencies(): List<SymbolDependency> {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
@@ -53,7 +53,8 @@ class HttpStringValuesMapSerializerTest {
 
     @Test
     fun `it handles primitive header shapes when different mode`() {
-        val contents = getTestContents(defaultModel, "com.test#PrimitiveShapesOperation", HttpBinding.Location.HEADER)
+        val settings = defaultModel.defaultSettings(defaultValueSerializationMode = DefaultValueSerializationMode.WHEN_DIFFERENT)
+        val contents = getTestContents(defaultModel, "com.test#PrimitiveShapesOperation", HttpBinding.Location.HEADER, settings)
         contents.assertBalancedBracesAndParens()
 
         val expectedContents = """
@@ -68,7 +69,8 @@ class HttpStringValuesMapSerializerTest {
 
     @Test
     fun `it handles primitive query shapes when different mode`() {
-        val contents = getTestContents(defaultModel, "com.test#PrimitiveShapesOperation", HttpBinding.Location.QUERY)
+        val settings = defaultModel.defaultSettings(defaultValueSerializationMode = DefaultValueSerializationMode.WHEN_DIFFERENT)
+        val contents = getTestContents(defaultModel, "com.test#PrimitiveShapesOperation", HttpBinding.Location.QUERY, settings)
         contents.assertBalancedBracesAndParens()
 
         val expectedContents = """
@@ -129,7 +131,8 @@ class HttpStringValuesMapSerializerTest {
             }
         """.prependNamespaceAndService(operations = listOf("Foo")).toSmithyModel()
 
-        val contents = getTestContents(model, "com.test#Foo", HttpBinding.Location.HEADER)
+        val settings = defaultModel.defaultSettings(defaultValueSerializationMode = DefaultValueSerializationMode.WHEN_DIFFERENT)
+        val contents = getTestContents(model, "com.test#Foo", HttpBinding.Location.HEADER, settings)
         contents.assertBalancedBracesAndParens()
 
         val expectedContents = """

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
@@ -72,7 +72,8 @@ class SerializeStructGeneratorTest {
             }
         """.trimIndent()
 
-        val actual = codegenSerializerForShape(model, "com.test#Foo")
+        val settings = model.defaultSettings(defaultValueSerializationMode = DefaultValueSerializationMode.WHEN_DIFFERENT)
+        val actual = codegenSerializerForShape(model, "com.test#Foo", settings = settings)
         actual.shouldContainOnlyOnceWithDiff(expected)
     }
 


### PR DESCRIPTION
## Issue \#

Resolves https://github.com/awslabs/aws-sdk-kotlin/issues/1608

## Description of changes

This change switches the default serialization mode from `WHEN_DIFFERENT` (meaning only if the value has been changed from the default) to `ALWAYS` (meaning...well, always). This is the current [recommendation from Smithy](https://smithy.io/2.0/spec/type-refinement-traits.html#default-value-serialization) and will offer more deterministic communication with services.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
