### PR TITLE
fix: remove unnecessary `-jvm-default=no-compatibility` compiler flag

### DIFF
--- a/runtime/auth/aws-credentials/api/aws-credentials.api
+++ b/runtime/auth/aws-credentials/api/aws-credentials.api
@@ -28,6 +28,11 @@ public final class aws/smithy/kotlin/runtime/auth/awscredentials/Credentials$Com
 	public static synthetic fun invoke$default (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
 }
 
+public final class aws/smithy/kotlin/runtime/auth/awscredentials/Credentials$DefaultImpls {
+	public static fun getProviderName (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;)Ljava/lang/String;
+	public static fun getSessionToken (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;)Ljava/lang/String;
+}
+
 public final class aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsKt {
 	public static final fun copy (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
 	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;

--- a/runtime/auth/http-auth-api/api/http-auth-api.api
+++ b/runtime/auth/http-auth-api/api/http-auth-api.api
@@ -4,6 +4,10 @@ public abstract interface class aws/smithy/kotlin/runtime/http/auth/AuthScheme {
 	public fun identityProvider (Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
 }
 
+public final class aws/smithy/kotlin/runtime/http/auth/AuthScheme$DefaultImpls {
+	public static fun identityProvider (Laws/smithy/kotlin/runtime/http/auth/AuthScheme;Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/http/auth/HttpAuthConfig {
 	public abstract fun getAuthSchemePreference ()Ljava/util/List;
 	public abstract fun getAuthSchemes ()Ljava/util/List;

--- a/runtime/auth/http-auth-aws/api/http-auth-aws.api
+++ b/runtime/auth/http-auth-aws/api/http-auth-aws.api
@@ -60,6 +60,7 @@ public final class aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme : aws/smi
 	public fun getSchemeId-DepwgT4 ()Ljava/lang/String;
 	public fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/AwsHttpSigner;
 	public synthetic fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/HttpSigner;
+	public fun identityProvider (Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
 }
 
 public final class aws/smithy/kotlin/runtime/http/auth/SigV4AuthSchemeKt {

--- a/runtime/auth/http-auth/api/http-auth.api
+++ b/runtime/auth/http-auth/api/http-auth.api
@@ -29,6 +29,7 @@ public final class aws/smithy/kotlin/runtime/http/auth/BearerTokenAuthScheme : a
 	public fun <init> ()V
 	public fun getSchemeId-DepwgT4 ()Ljava/lang/String;
 	public fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/HttpSigner;
+	public fun identityProvider (Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/http/auth/BearerTokenProvider : aws/smithy/kotlin/runtime/identity/IdentityProvider {

--- a/runtime/auth/identity-api/api/identity-api.api
+++ b/runtime/auth/identity-api/api/identity-api.api
@@ -59,6 +59,10 @@ public abstract interface class aws/smithy/kotlin/runtime/identity/IdentityProvi
 	public static synthetic fun resolve$default (Laws/smithy/kotlin/runtime/identity/IdentityProvider;Laws/smithy/kotlin/runtime/collections/Attributes;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class aws/smithy/kotlin/runtime/identity/IdentityProvider$DefaultImpls {
+	public static synthetic fun resolve$default (Laws/smithy/kotlin/runtime/identity/IdentityProvider;Laws/smithy/kotlin/runtime/collections/Attributes;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public abstract class aws/smithy/kotlin/runtime/identity/IdentityProviderChain : aws/smithy/kotlin/runtime/identity/CloseableIdentityProvider {
 	public fun <init> ([Laws/smithy/kotlin/runtime/identity/IdentityProvider;)V
 	public fun close ()V

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -66,7 +66,6 @@ subprojects {
             jvmTarget.set(JvmTarget.JVM_1_8)
             freeCompilerArgs.add("-Xjdk-release=1.8")
             freeCompilerArgs.add("-Xexpect-actual-classes")
-            freeCompilerArgs.add("-jvm-default=no-compatibility") // https://youtrack.jetbrains.com/issue/KT-77376
         }
     }
 

--- a/runtime/observability/telemetry-api/api/telemetry-api.api
+++ b/runtime/observability/telemetry-api/api/telemetry-api.api
@@ -192,6 +192,14 @@ public final class aws/smithy/kotlin/runtime/telemetry/logging/Logger$Companion 
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/logging/Logger;
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/logging/Logger$DefaultImpls {
+	public static synthetic fun debug$default (Laws/smithy/kotlin/runtime/telemetry/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun error$default (Laws/smithy/kotlin/runtime/telemetry/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun info$default (Laws/smithy/kotlin/runtime/telemetry/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun trace$default (Laws/smithy/kotlin/runtime/telemetry/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun warn$default (Laws/smithy/kotlin/runtime/telemetry/logging/Logger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+}
+
 public final class aws/smithy/kotlin/runtime/telemetry/logging/LoggerKt {
 	public static final fun debug (Laws/smithy/kotlin/runtime/telemetry/logging/Logger;Ljava/lang/String;)V
 	public static final fun error (Laws/smithy/kotlin/runtime/telemetry/logging/Logger;Ljava/lang/String;)V
@@ -266,6 +274,10 @@ public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/Asyn
 	public static synthetic fun record$default (Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurement;Ljava/lang/Number;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurement$DefaultImpls {
+	public static synthetic fun record$default (Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurement;Ljava/lang/Number;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle {
 	public static final field Companion Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle$Companion;
 	public abstract fun stop ()V
@@ -284,6 +296,10 @@ public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/Hist
 public final class aws/smithy/kotlin/runtime/telemetry/metrics/Histogram$Companion {
 	public final fun getDoubleNone ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
 	public final fun getLongNone ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/metrics/Histogram$DefaultImpls {
+	public static synthetic fun record$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;Ljava/lang/Number;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/metrics/HistogramKt {
@@ -317,6 +333,16 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/Meter$Companion {
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/metrics/Meter$DefaultImpls {
+	public static synthetic fun createAsyncUpDownCounter$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
+	public static synthetic fun createDoubleGauge$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
+	public static synthetic fun createDoubleHistogram$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public static synthetic fun createLongGauge$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
+	public static synthetic fun createLongHistogram$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public static synthetic fun createMonotonicCounter$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter;
+	public static synthetic fun createUpDownCounter$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/MeterProvider {
 	public static final field Companion Laws/smithy/kotlin/runtime/telemetry/metrics/MeterProvider$Companion;
 	public abstract fun getOrCreateMeter (Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;
@@ -336,6 +362,10 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter$
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter;
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter$DefaultImpls {
+	public static synthetic fun add$default (Laws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter;JLaws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter {
 	public static final field Companion Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter$Companion;
 	public abstract fun add (JLaws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;)V
@@ -344,6 +374,10 @@ public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/UpDo
 
 public final class aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter$Companion {
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter$DefaultImpls {
+	public static synthetic fun add$default (Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;JLaws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
 }
 
 public abstract class aws/smithy/kotlin/runtime/telemetry/trace/AbstractTraceSpan : aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan {
@@ -423,6 +457,11 @@ public final class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan$Companion
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan$DefaultImpls {
+	public static fun asContextElement (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;)Lkotlin/coroutines/CoroutineContext;
+	public static synthetic fun emitEvent$default (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;ILjava/lang/Object;)V
+}
+
 public final class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpanContext : kotlin/coroutines/AbstractCoroutineContextElement {
 	public static final field Key Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpanContext$Key;
 	public fun <init> (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;)V
@@ -451,6 +490,10 @@ public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/Tracer
 
 public final class aws/smithy/kotlin/runtime/telemetry/trace/Tracer$Companion {
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/trace/Tracer;
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/trace/Tracer$DefaultImpls {
+	public static synthetic fun createSpan$default (Laws/smithy/kotlin/runtime/telemetry/trace/Tracer;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/TracerProvider {

--- a/runtime/protocol/aws-json-protocols/api/aws-json-protocols.api
+++ b/runtime/protocol/aws-json-protocols/api/aws-json-protocols.api
@@ -1,5 +1,6 @@
 public final class aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocol : aws/smithy/kotlin/runtime/http/operation/ModifyRequestMiddleware {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 	public fun modifyRequest (Laws/smithy/kotlin/runtime/http/operation/OperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun modifyRequest (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/runtime/protocol/aws-protocol-core/api/aws-protocol-core.api
+++ b/runtime/protocol/aws-protocol-core/api/aws-protocol-core.api
@@ -36,7 +36,24 @@ public final class aws/smithy/kotlin/runtime/awsprotocol/ClockSkewInterceptor : 
 	public static final field Companion Laws/smithy/kotlin/runtime/awsprotocol/ClockSkewInterceptor$Companion;
 	public fun <init> ()V
 	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/ClockSkewInterceptor$Companion {

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/api/http-client-engine-okhttp.api
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/api/http-client-engine-okhttp.api
@@ -93,7 +93,12 @@ public final class aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineKt {
 public final class aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpHeadersAdapter : aws/smithy/kotlin/runtime/http/Headers {
 	public fun <init> (Lokhttp3/Headers;)V
 	public fun contains (Ljava/lang/String;)Z
+	public synthetic fun contains (Ljava/lang/String;Ljava/lang/Object;)Z
+	public fun contains (Ljava/lang/String;Ljava/lang/String;)Z
 	public fun entries ()Ljava/util/Set;
+	public fun forEach (Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun get (Ljava/lang/String;)Ljava/lang/Object;
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
 	public fun getAll (Ljava/lang/String;)Ljava/util/List;
 	public fun getCaseInsensitiveName ()Z
 	public fun isEmpty ()Z

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -34,6 +34,11 @@ public abstract interface class aws/smithy/kotlin/runtime/http/config/HttpEngine
 	public abstract fun setHttpClient (Laws/smithy/kotlin/runtime/http/engine/HttpClientEngine;)V
 }
 
+public final class aws/smithy/kotlin/runtime/http/config/HttpEngineConfig$Builder$DefaultImpls {
+	public static synthetic fun httpClient$default (Laws/smithy/kotlin/runtime/http/config/HttpEngineConfig$Builder;Laws/smithy/kotlin/runtime/http/config/EngineFactory;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun httpClient$default (Laws/smithy/kotlin/runtime/http/config/HttpEngineConfig$Builder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
 public abstract interface annotation class aws/smithy/kotlin/runtime/http/config/HttpEngineConfigDsl : java/lang/annotation/Annotation {
 }
 
@@ -256,7 +261,25 @@ public abstract class aws/smithy/kotlin/runtime/http/interceptors/CachingChecksu
 	public fun <init> ()V
 	public abstract fun applyChecksum (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Ljava/lang/String;)Laws/smithy/kotlin/runtime/http/request/HttpRequest;
 	public abstract fun calculateChecksum (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/ChecksumMismatchException : aws/smithy/kotlin/runtime/ClientException {
@@ -266,12 +289,48 @@ public final class aws/smithy/kotlin/runtime/http/interceptors/ChecksumMismatchE
 public final class aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
 	public fun <init> (J)V
 	public final fun getThresholdLengthBytes ()J
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/DiscoveredEndpointErrorInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;)V
 	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptor : aws/smithy/kotlin/runtime/http/interceptors/CachingChecksumInterceptor {
@@ -285,7 +344,25 @@ public class aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRespon
 	public static final field Companion Laws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptor$Companion;
 	public fun <init> (ZLaws/smithy/kotlin/runtime/client/config/ResponseHttpChecksumConfig;)V
 	public fun ignoreChecksum (Ljava/lang/String;Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)Z
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptor$Companion {
@@ -301,12 +378,48 @@ public final class aws/smithy/kotlin/runtime/http/interceptors/HttpChecksumRequi
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/RequestCompressionInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
 	public fun <init> (JLjava/util/List;Ljava/util/List;)V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
 	public fun <init> ()V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/SmokeTestsFailureException : java/lang/Exception {
@@ -316,7 +429,25 @@ public final class aws/smithy/kotlin/runtime/http/interceptors/SmokeTestsFailure
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/SmokeTestsInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
 	public fun <init> ()V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/SmokeTestsSuccessException : java/lang/Exception {
@@ -328,6 +459,7 @@ public final class aws/smithy/kotlin/runtime/http/middleware/DefaultValidateResp
 	public fun <init> ()V
 	public fun handle (Laws/smithy/kotlin/runtime/http/operation/OperationRequest;Laws/smithy/kotlin/runtime/io/Handler;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun handle (Ljava/lang/Object;Laws/smithy/kotlin/runtime/io/Handler;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/middleware/HttpResponseException : aws/smithy/kotlin/runtime/SdkBaseException {
@@ -350,6 +482,7 @@ public final class aws/smithy/kotlin/runtime/http/middleware/MutateHeaders : aws
 	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun append (Ljava/lang/String;Ljava/lang/String;)V
+	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 	public fun modifyRequest (Laws/smithy/kotlin/runtime/http/operation/OperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun modifyRequest (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun set (Ljava/lang/String;Ljava/lang/String;)V
@@ -414,6 +547,10 @@ public abstract interface class aws/smithy/kotlin/runtime/http/operation/Initial
 	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
 
+public final class aws/smithy/kotlin/runtime/http/operation/InitializeMiddleware$DefaultImpls {
+	public static fun install (Laws/smithy/kotlin/runtime/http/operation/InitializeMiddleware;Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/http/operation/InlineMiddleware {
 	public abstract fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
@@ -422,8 +559,16 @@ public abstract interface class aws/smithy/kotlin/runtime/http/operation/ModifyR
 	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
 
+public final class aws/smithy/kotlin/runtime/http/operation/ModifyRequestMiddleware$DefaultImpls {
+	public static fun install (Laws/smithy/kotlin/runtime/http/operation/ModifyRequestMiddleware;Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/http/operation/MutateMiddleware : aws/smithy/kotlin/runtime/io/middleware/Middleware {
 	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/MutateMiddleware$DefaultImpls {
+	public static fun install (Laws/smithy/kotlin/runtime/http/operation/MutateMiddleware;Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/OperationAuthConfig {
@@ -489,6 +634,10 @@ public final class aws/smithy/kotlin/runtime/http/operation/OperationTelemetryKt
 
 public abstract interface class aws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware : aws/smithy/kotlin/runtime/io/middleware/Middleware {
 	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware$DefaultImpls {
+	public static fun install (Laws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware;Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/ResolveEndpointRequest {

--- a/runtime/protocol/http/api/http.api
+++ b/runtime/protocol/http/api/http.api
@@ -23,6 +23,12 @@ public final class aws/smithy/kotlin/runtime/http/DeferredHeaders$Companion {
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/http/DeferredHeaders;
 }
 
+public final class aws/smithy/kotlin/runtime/http/DeferredHeaders$DefaultImpls {
+	public static fun contains (Laws/smithy/kotlin/runtime/http/DeferredHeaders;Ljava/lang/String;Lkotlinx/coroutines/Deferred;)Z
+	public static fun forEach (Laws/smithy/kotlin/runtime/http/DeferredHeaders;Lkotlin/jvm/functions/Function2;)V
+	public static fun get (Laws/smithy/kotlin/runtime/http/DeferredHeaders;Ljava/lang/String;)Lkotlinx/coroutines/Deferred;
+}
+
 public final class aws/smithy/kotlin/runtime/http/DeferredHeadersBuilder : aws/smithy/kotlin/runtime/collections/ValuesMapBuilder, aws/smithy/kotlin/runtime/util/CanDeepCopy {
 	public fun <init> ()V
 	public final fun add (Ljava/lang/String;Ljava/lang/String;)V
@@ -43,6 +49,12 @@ public abstract interface class aws/smithy/kotlin/runtime/http/Headers : aws/smi
 public final class aws/smithy/kotlin/runtime/http/Headers$Companion {
 	public final fun getEmpty ()Laws/smithy/kotlin/runtime/http/Headers;
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/http/Headers;
+}
+
+public final class aws/smithy/kotlin/runtime/http/Headers$DefaultImpls {
+	public static fun contains (Laws/smithy/kotlin/runtime/http/Headers;Ljava/lang/String;Ljava/lang/String;)Z
+	public static fun forEach (Laws/smithy/kotlin/runtime/http/Headers;Lkotlin/jvm/functions/Function2;)V
+	public static fun get (Laws/smithy/kotlin/runtime/http/Headers;Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class aws/smithy/kotlin/runtime/http/HeadersBuilder : aws/smithy/kotlin/runtime/collections/ValuesMapBuilder, aws/smithy/kotlin/runtime/util/CanDeepCopy {

--- a/runtime/protocol/smithy-rpcv2-protocols/api/smithy-rpcv2-protocols.api
+++ b/runtime/protocol/smithy-rpcv2-protocols/api/smithy-rpcv2-protocols.api
@@ -5,6 +5,24 @@ public final class aws/smithy/kotlin/runtime/awsprotocol/rpcv2/cbor/RpcV2CborErr
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/rpcv2/cbor/RpcV2CborSmithyProtocolResponseHeaderInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
 	public static final field INSTANCE Laws/smithy/kotlin/runtime/awsprotocol/rpcv2/cbor/RpcV2CborSmithyProtocolResponseHeaderInterceptor;
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -199,6 +199,11 @@ public abstract interface class aws/smithy/kotlin/runtime/collections/MultiMap :
 	public fun toMutableMultiMap ()Laws/smithy/kotlin/runtime/collections/MutableMultiMap;
 }
 
+public final class aws/smithy/kotlin/runtime/collections/MultiMap$DefaultImpls {
+	public static fun contains (Laws/smithy/kotlin/runtime/collections/MultiMap;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public static fun toMutableMultiMap (Laws/smithy/kotlin/runtime/collections/MultiMap;)Laws/smithy/kotlin/runtime/collections/MutableMultiMap;
+}
+
 public final class aws/smithy/kotlin/runtime/collections/MultiMapKt {
 	public static final fun multiMapOf ([Lkotlin/Pair;)Laws/smithy/kotlin/runtime/collections/MultiMap;
 }
@@ -223,6 +228,13 @@ public abstract interface class aws/smithy/kotlin/runtime/collections/MutableMul
 	public abstract fun removeElement (Ljava/lang/Object;Ljava/lang/Object;)Z
 	public abstract fun retainAll (Ljava/lang/Object;Ljava/util/Collection;)Ljava/lang/Boolean;
 	public fun toMultiMap ()Laws/smithy/kotlin/runtime/collections/MultiMap;
+}
+
+public final class aws/smithy/kotlin/runtime/collections/MutableMultiMap$DefaultImpls {
+	public static fun addAll (Laws/smithy/kotlin/runtime/collections/MutableMultiMap;Ljava/util/Map;)V
+	public static fun contains (Laws/smithy/kotlin/runtime/collections/MutableMultiMap;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public static fun put (Laws/smithy/kotlin/runtime/collections/MutableMultiMap;Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/List;
+	public static fun toMultiMap (Laws/smithy/kotlin/runtime/collections/MutableMultiMap;)Laws/smithy/kotlin/runtime/collections/MultiMap;
 }
 
 public final class aws/smithy/kotlin/runtime/collections/MutableMultiMapKt {
@@ -256,6 +268,12 @@ public abstract interface class aws/smithy/kotlin/runtime/collections/ValuesMap 
 	public abstract fun getCaseInsensitiveName ()Z
 	public abstract fun isEmpty ()Z
 	public abstract fun names ()Ljava/util/Set;
+}
+
+public final class aws/smithy/kotlin/runtime/collections/ValuesMap$DefaultImpls {
+	public static fun contains (Laws/smithy/kotlin/runtime/collections/ValuesMap;Ljava/lang/String;Ljava/lang/Object;)Z
+	public static fun forEach (Laws/smithy/kotlin/runtime/collections/ValuesMap;Lkotlin/jvm/functions/Function2;)V
+	public static fun get (Laws/smithy/kotlin/runtime/collections/ValuesMap;Ljava/lang/String;)Ljava/lang/Object;
 }
 
 public class aws/smithy/kotlin/runtime/collections/ValuesMapBuilder {
@@ -293,6 +311,8 @@ public class aws/smithy/kotlin/runtime/collections/ValuesMapImpl : aws/smithy/ko
 	public fun contains (Ljava/lang/String;Ljava/lang/Object;)Z
 	public fun entries ()Ljava/util/Set;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun forEach (Lkotlin/jvm/functions/Function2;)V
+	public fun get (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getAll (Ljava/lang/String;)Ljava/util/List;
 	public fun getCaseInsensitiveName ()Z
 	protected final fun getValues ()Ljava/util/Map;
@@ -696,6 +716,10 @@ public abstract interface class aws/smithy/kotlin/runtime/hashing/HashFunction {
 	public static synthetic fun update$default (Laws/smithy/kotlin/runtime/hashing/HashFunction;[BIIILjava/lang/Object;)V
 }
 
+public final class aws/smithy/kotlin/runtime/hashing/HashFunction$DefaultImpls {
+	public static synthetic fun update$default (Laws/smithy/kotlin/runtime/hashing/HashFunction;[BIIILjava/lang/Object;)V
+}
+
 public final class aws/smithy/kotlin/runtime/hashing/HashFunctionKt {
 	public static final fun hash ([BLaws/smithy/kotlin/runtime/hashing/HashFunction;)[B
 	public static final fun hash ([BLkotlin/jvm/functions/Function0;)[B
@@ -899,6 +923,11 @@ public abstract interface class aws/smithy/kotlin/runtime/io/SdkBufferedSink : a
 	public static synthetic fun writeUtf8$default (Laws/smithy/kotlin/runtime/io/SdkBufferedSink;Ljava/lang/String;IIILjava/lang/Object;)V
 }
 
+public final class aws/smithy/kotlin/runtime/io/SdkBufferedSink$DefaultImpls {
+	public static synthetic fun write$default (Laws/smithy/kotlin/runtime/io/SdkBufferedSink;[BIIILjava/lang/Object;)V
+	public static synthetic fun writeUtf8$default (Laws/smithy/kotlin/runtime/io/SdkBufferedSink;Ljava/lang/String;IIILjava/lang/Object;)V
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/io/SdkBufferedSource : aws/smithy/kotlin/runtime/io/SdkSource, java/nio/channels/ReadableByteChannel {
 	public abstract fun exhausted ()Z
 	public abstract fun getBuffer ()Laws/smithy/kotlin/runtime/io/SdkBuffer;
@@ -923,8 +952,16 @@ public abstract interface class aws/smithy/kotlin/runtime/io/SdkBufferedSource :
 	public abstract fun skip (J)V
 }
 
+public final class aws/smithy/kotlin/runtime/io/SdkBufferedSource$DefaultImpls {
+	public static synthetic fun read$default (Laws/smithy/kotlin/runtime/io/SdkBufferedSource;[BIIILjava/lang/Object;)I
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteChannel : aws/smithy/kotlin/runtime/io/SdkByteReadChannel, aws/smithy/kotlin/runtime/io/SdkByteWriteChannel {
 	public fun close ()V
+}
+
+public final class aws/smithy/kotlin/runtime/io/SdkByteChannel$DefaultImpls {
+	public static fun close (Laws/smithy/kotlin/runtime/io/SdkByteChannel;)V
 }
 
 public final class aws/smithy/kotlin/runtime/io/SdkByteChannelKt {
@@ -967,6 +1004,10 @@ public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteWriteChannel
 	public abstract fun getTotalBytesWritten ()J
 	public abstract fun isClosedForWrite ()Z
 	public abstract fun write (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun write$default (Laws/smithy/kotlin/runtime/io/SdkByteWriteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/io/SdkByteWriteChannel$DefaultImpls {
 	public static synthetic fun write$default (Laws/smithy/kotlin/runtime/io/SdkByteWriteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -1194,6 +1235,10 @@ public abstract interface class aws/smithy/kotlin/runtime/net/HostResolver {
 
 public final class aws/smithy/kotlin/runtime/net/HostResolver$Companion {
 	public final fun getDefault ()Laws/smithy/kotlin/runtime/net/HostResolver;
+}
+
+public final class aws/smithy/kotlin/runtime/net/HostResolver$DefaultImpls {
+	public static synthetic fun purgeCache$default (Laws/smithy/kotlin/runtime/net/HostResolver;Laws/smithy/kotlin/runtime/net/HostAddress;ILjava/lang/Object;)V
 }
 
 public abstract class aws/smithy/kotlin/runtime/net/IpAddr {
@@ -2125,6 +2170,11 @@ public abstract interface class aws/smithy/kotlin/runtime/text/encoding/Encoding
 public final class aws/smithy/kotlin/runtime/text/encoding/Encoding$Companion {
 }
 
+public final class aws/smithy/kotlin/runtime/text/encoding/Encoding$DefaultImpls {
+	public static fun encodableFromDecoded (Laws/smithy/kotlin/runtime/text/encoding/Encoding;Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
+	public static fun encodableFromEncoded (Laws/smithy/kotlin/runtime/text/encoding/Encoding;Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
+}
+
 public final class aws/smithy/kotlin/runtime/text/encoding/HexKt {
 	public static final fun decodeHex (Ljava/lang/String;)[B
 	public static final fun decodeHexBytes (Ljava/lang/String;)[B
@@ -2137,6 +2187,8 @@ public final class aws/smithy/kotlin/runtime/text/encoding/PercentEncoding : aws
 	public fun <init> (Ljava/lang/String;Ljava/util/Set;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun decode (Ljava/lang/String;)Ljava/lang/String;
+	public fun encodableFromDecoded (Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
+	public fun encodableFromEncoded (Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
 	public fun encode (Ljava/lang/String;)Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public final fun getSpecialMapping ()Ljava/util/Map;

--- a/runtime/serde/serde-xml/api/serde-xml.api
+++ b/runtime/serde/serde-xml/api/serde-xml.api
@@ -151,6 +151,11 @@ public abstract interface class aws/smithy/kotlin/runtime/serde/xml/XmlStreamRea
 	public static synthetic fun subTreeReader$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;
 }
 
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$DefaultImpls {
+	public static synthetic fun peek$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;IILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken;
+	public static synthetic fun subTreeReader$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;
+}
+
 public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth : java/lang/Enum {
 	public static final field CHILD Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;
 	public static final field CURRENT Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;
@@ -177,6 +182,13 @@ public abstract interface class aws/smithy/kotlin/runtime/serde/xml/XmlStreamWri
 	public abstract fun startTag (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
 	public static synthetic fun startTag$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
 	public abstract fun text (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter$DefaultImpls {
+	public static synthetic fun attribute$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
+	public static synthetic fun endTag$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
+	public static synthetic fun namespacePrefix$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun startTag$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
 }
 
 public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriterKt {

--- a/runtime/smithy-client/api/smithy-client.api
+++ b/runtime/smithy-client/api/smithy-client.api
@@ -51,6 +51,28 @@ public abstract interface class aws/smithy/kotlin/runtime/client/Interceptor {
 	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
+public final class aws/smithy/kotlin/runtime/client/Interceptor$DefaultImpls {
+	public static fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public static fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public static fun readAfterExecution (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public static fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public static fun readAfterSigning (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public static fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public static fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public static fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public static fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public static fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public static fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public static fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/Interceptor;Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
 public abstract class aws/smithy/kotlin/runtime/client/LogMode {
 	public static final field Companion Laws/smithy/kotlin/runtime/client/LogMode$Companion;
 	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -168,6 +190,10 @@ public abstract interface class aws/smithy/kotlin/runtime/client/SdkClientFactor
 	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/client/SdkClient;
 }
 
+public final class aws/smithy/kotlin/runtime/client/SdkClientFactory$DefaultImpls {
+	public static fun invoke (Laws/smithy/kotlin/runtime/client/SdkClientFactory;Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/client/SdkClient;
+}
+
 public final class aws/smithy/kotlin/runtime/client/SdkClientOption {
 	public static final field INSTANCE Laws/smithy/kotlin/runtime/client/SdkClientOption;
 	public final fun getClientName ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
@@ -200,6 +226,10 @@ public abstract interface class aws/smithy/kotlin/runtime/client/config/Compress
 public abstract interface class aws/smithy/kotlin/runtime/client/config/CompressionClientConfig$Builder {
 	public abstract fun getRequestCompression ()Laws/smithy/kotlin/runtime/client/config/RequestCompressionConfig$Builder;
 	public fun requestCompression (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class aws/smithy/kotlin/runtime/client/config/CompressionClientConfig$Builder$DefaultImpls {
+	public static fun requestCompression (Laws/smithy/kotlin/runtime/client/config/CompressionClientConfig$Builder;Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface annotation class aws/smithy/kotlin/runtime/client/config/CompressionClientConfigDsl : java/lang/annotation/Annotation {


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Removes unnecessary `-jvm-default=no-compatibility` flag added in #1313.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
