### PR TITLE
fix: correct the Brazil mapping for aws-crt-kotlin 0.10.*

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -10,6 +10,7 @@
     "io.opentelemetry:opentelemetry-api:1.*": "Maven-io-opentelemetry_opentelemetry-api-1.x",
     "io.opentelemetry:opentelemetry-extension-kotlin:1.*": "Maven-io-opentelemetry_opentelemetry-extension-kotlin-1.x",
     "org.slf4j:slf4j-api:2.*": "Maven-org-slf4j_slf4j-api-2.x",
+    "aws.sdk.kotlin.crt:aws-crt-kotlin:0.10.*": "AwsCrtKotlin-0.10.x",
     "aws.sdk.kotlin.crt:aws-crt-kotlin:0.9.*": "AwsCrtKotlin-0.9.x",
     "aws.sdk.kotlin.crt:aws-crt-kotlin:0.8.*": "AwsCrtKotlin-0.8.x",
     "com.squareup.okhttp3:okhttp:4.*": "OkHttp3-4.x",


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change adds the correct mapping for **aws-crt-kotlin** in Brazil transformation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
