### PR TITLE
chore: migrate to pull_request_target for some workflows that require GH token permissions

### DIFF
--- a/.github/workflows/artifact-size-metrics.yml
+++ b/.github/workflows/artifact-size-metrics.yml
@@ -1,6 +1,6 @@
 name: Artifact Size Metrics
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
     branches:
       - main
@@ -40,7 +40,7 @@ jobs:
       - name: Put Artifact Size Metrics in CloudWatch
         run: ./gradlew putArtifactSizeMetricsInCloudWatch -Prelease=${{ github.event.release.tag_name }}
   size-check:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources

--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -4,7 +4,7 @@ permissions:
   id-token: write
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
     branches:
       - main

--- a/.github/workflows/kat-transform.yml
+++ b/.github/workflows/kat-transform.yml
@@ -1,7 +1,7 @@
 name: Kat Transform
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
     branches:
       - main


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

As described by [this FAQ entry](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544), this PR enables Depenabot PRs to successfully run workflows which require GH token permissions (e.g., to fetch AWS credentials).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
