### PR TITLE
chore: skip changelog verification for Dependabot PRs

### DIFF
--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   changelog-verification:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'dependabot[bot]' # no changelogs for Dependabot version bumps
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Dependabot version upgrade PRs don't include changelog entries and that's just fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
