### PR TITLE
chore: re-enable ignored Kotlin/Native tests

### DIFF
--- a/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/SigV4aSignatureCalculatorTest.kt
+++ b/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/SigV4aSignatureCalculatorTest.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.auth.awssigning
 
-import aws.smithy.kotlin.runtime.IgnoreNative
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.PlatformProvider
@@ -69,7 +68,6 @@ private val TESTS = listOf(
  * Tests for [SigV4aSignatureCalculator]. Currently only tests forming the string-to-sign.
  */
 class SigV4aSignatureCalculatorTest {
-    @IgnoreNative // FIXME test resources are not loadable on iOS: https://youtrack.jetbrains.com/issue/KT-49981/
     @Test
     fun testStringToSign() = TESTS.forEach { testId ->
         runTest {

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.auth
 
-import aws.smithy.kotlin.runtime.IgnoreNative
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigner
@@ -127,7 +126,6 @@ public abstract class AwsHttpSignerTestBase(
         assertEquals(expectedSig, signed.headers["Authorization"])
     }
 
-    @IgnoreNative // FIXME Our JVM implementation does not sign `transfer-encoding`, but CRT does, causing a signature mismatch. Upgrade to latest version of aws-c-auth to get the fix.
     @Test
     public fun testSignAwsChunkedStreamNonReplayable(): TestResult = runTest {
         val op = buildOperation(streaming = true, replayable = false, requestBody = "a".repeat(AWS_CHUNKED_THRESHOLD + 1))
@@ -141,7 +139,6 @@ public abstract class AwsHttpSignerTestBase(
         assertEquals(expectedSig, signed.headers["Authorization"])
     }
 
-    @IgnoreNative // FIXME Our JVM implementation does not sign `transfer-encoding`, but CRT does, causing a signature mismatch. Upgrade to latest version of aws-c-auth to get the fix.
     @Test
     public fun testSignAwsChunkedStreamReplayable(): TestResult = runTest {
         val op = buildOperation(streaming = true, replayable = true, requestBody = "a".repeat(AWS_CHUNKED_THRESHOLD + 1))
@@ -155,7 +152,6 @@ public abstract class AwsHttpSignerTestBase(
         assertEquals(expectedSig, signed.headers["Authorization"])
     }
 
-    @IgnoreNative // FIXME Our JVM implementation does not sign `transfer-encoding`, but CRT does, causing a signature mismatch. Upgrade to latest version of aws-c-auth to get the fix.
     @Test
     public fun testSignOneShotStream(): TestResult = runTest {
         val op = buildOperation(streaming = true, replayable = false)

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import aws.sdk.kotlin.gradle.dsl.configurePublishing
-import aws.sdk.kotlin.gradle.kmp.*
-import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.withType
+import aws.sdk.kotlin.gradle.kmp.configureKmpTargets
+import aws.sdk.kotlin.gradle.kmp.kotlin
+import aws.sdk.kotlin.gradle.kmp.needsKmpConfigured
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
 
@@ -117,6 +117,18 @@ subprojects {
      */
     tasks.withType<KotlinNativeSimulatorTest> {
         enabled = false
+    }
+
+    tasks.withType<AbstractTestTask> {
+        if (this is Test) useJUnitPlatform()
+
+        testLogging {
+            events("passed", "skipped", "failed")
+            showStandardStreams = true
+            showStackTraces = true
+            showExceptions = true
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        }
     }
 }
 

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -33,9 +33,6 @@ public final class aws/smithy/kotlin/runtime/ErrorMetadata$Companion {
 public abstract interface annotation class aws/smithy/kotlin/runtime/ExperimentalApi : java/lang/annotation/Annotation {
 }
 
-public abstract interface annotation class aws/smithy/kotlin/runtime/IgnoreNative : java/lang/annotation/Annotation {
-}
-
 public abstract interface annotation class aws/smithy/kotlin/runtime/InternalApi : java/lang/annotation/Annotation {
 }
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Annotations.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Annotations.kt
@@ -58,9 +58,3 @@ public annotation class ExperimentalApi
  */
 @DslMarker
 public annotation class SdkDsl
-
-/**
- * Marks a test that should be ignored on Native platforms
- */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-public expect annotation class IgnoreNative()

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/AnnotationsJvm.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/AnnotationsJvm.kt
@@ -1,9 +1,0 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
-package aws.smithy.kotlin.runtime
-
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-public actual annotation class IgnoreNative

--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/AnnotationsNative.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/AnnotationsNative.kt
@@ -1,8 +1,0 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
-package aws.smithy.kotlin.runtime
-
-public actual typealias IgnoreNative = kotlin.test.Ignore


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Re-enables all `@IgnoreNative` tests after the fixes in https://github.com/awslabs/aws-crt-kotlin/pull/175 and https://github.com/awslabs/aws-crt-kotlin/pull/176

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
