### PR TITLE
misc: enable gradle cache

### DIFF
--- a/codegen/smithy-kotlin-codegen/build.gradle.kts
+++ b/codegen/smithy-kotlin-codegen/build.gradle.kts
@@ -20,8 +20,7 @@ val codegenVersion: String by project
 group = "software.amazon.smithy.kotlin"
 version = codegenVersion
 
-val sdkVersion: String by project
-val runtimeVersion = sdkVersion
+val runtimeVersion: Provider<String> = providers.gradleProperty("sdkVersion")
 
 dependencies {
     api(libs.smithy.codegen.core)
@@ -42,16 +41,17 @@ dependencies {
 }
 
 val generateSdkRuntimeVersion by tasks.registering {
-    // generate the version of the runtime to use as a resource.
-    // this keeps us from having to manually change version numbers in multiple places
-    val resourcesDir = layout.buildDirectory.dir("resources/main/software/amazon/smithy/kotlin/codegen/core").get()
-    val versionFile = file("$resourcesDir/sdk-version.txt")
-    val gradlePropertiesFile = rootProject.file("gradle.properties")
-    inputs.file(gradlePropertiesFile)
+    val resourcesDir = layout.buildDirectory.dir("resources/main/software/amazon/smithy/kotlin/codegen/core")
+    val versionFile = resourcesDir.map { it.file("sdk-version.txt") }
+
+    // declare inputs/outputs via providers
+    inputs.property("runtimeVersion", runtimeVersion)
     outputs.file(versionFile)
-    sourceSets.main.get().output.dir(resourcesDir)
+
     doLast {
-        versionFile.writeText(runtimeVersion)
+        val version = inputs.properties["runtimeVersion"] as String
+        val file = versionFile.get().asFile
+        file.writeText(version)
     }
 }
 

--- a/codegen/smithy-kotlin-codegen/build.gradle.kts
+++ b/codegen/smithy-kotlin-codegen/build.gradle.kts
@@ -44,7 +44,6 @@ val generateSdkRuntimeVersion by tasks.registering {
     val resourcesDir = layout.buildDirectory.dir("resources/main/software/amazon/smithy/kotlin/codegen/core")
     val versionFile = resourcesDir.map { it.file("sdk-version.txt") }
 
-    // declare inputs/outputs via providers
     inputs.property("runtimeVersion", runtimeVersion)
     outputs.file(versionFile)
 

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -129,7 +129,7 @@ val testTasks = listOf("allTests", "jvmTest")
 tasks.jvmTest {
     // set test environment for proxy tests
     systemProperty("MITM_PROXY_SCRIPTS_ROOT", projectDir.resolve("proxy-scripts").absolutePath)
-    systemProperty("SSL_CONFIG_PATH", testServerService.get().parameters.sslConfigPath)
+    systemProperty("SSL_CONFIG_PATH", testServerService.get().parameters.sslConfigPath.get())
 
     val enableProxyTestsProp = "aws.test.http.enableProxyTests"
     val runningInCodeBuild = System.getenv().containsKey("CODEBUILD_BUILD_ID")

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -78,8 +78,8 @@ abstract class TestServerService :
             val loader = URLClassLoader(urlClassLoaderSource, ClassLoader.getSystemClassLoader())
 
             val mainClass = loader.loadClass(parameters.mainClass.get())
-            val method = mainClass.getMethod("startServers", String::class.java)
-            server = method.invoke(null, parameters.sslConfigPath.get()) as Closeable
+            val main = mainClass.getMethod("startServers", String::class.java)
+            server = main.invoke(null, parameters.sslConfigPath.get()) as Closeable
             println("[TestServers] started")
         } catch (cause: Throwable) {
             println("[TestServers] failed: ${cause.message}")

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -58,8 +58,6 @@ kotlin {
     }
 }
 
-val osName = System.getProperty("os.name")
-
 abstract class TestServerService :
     BuildService<TestServerService.Params>,
     AutoCloseable {
@@ -111,6 +109,8 @@ abstract class StartTestServersTask : DefaultTask() {
         serverService.get().startServers()
     }
 }
+
+val osName = System.getProperty("os.name")
 
 val startTestServers = tasks.register<StartTestServersTask>("startTestServers") {
     dependsOn(tasks["jvmJar"])

--- a/tests/benchmarks/serde-benchmarks/build.gradle.kts
+++ b/tests/benchmarks/serde-benchmarks/build.gradle.kts
@@ -85,27 +85,27 @@ tasks.generateSmithyProjections {
     buildClasspath.set(codegen)
 }
 
-data class BenchmarkModel(val name: String) {
-    val projectionRootDir: File
-        get() = layout.buildDirectory.dir("smithyprojections/${project.name}/$name/kotlin-codegen/src/main/kotlin").get().asFile.absoluteFile
+abstract class StageGeneratedSourcesTask : DefaultTask() {
+    @get:Input
+    abstract val projectName: Property<String>
 
-    val sourceSetRootDir: File
-        get() = layout.buildDirectory.dir("generated-src/src").get().asFile.absoluteFile
-}
+    @get:InputDirectory
+    abstract val smithyProjectionsDir: DirectoryProperty
 
-val benchmarkModels = listOf(
-    "twitter",
-    "countries-states",
-).map { BenchmarkModel(it) }
+    @get:OutputDirectory
+    abstract val generatedSourcesDir: DirectoryProperty
 
-val stageGeneratedSources = tasks.register("stageGeneratedSources") {
-    group = "codegen"
-    dependsOn(tasks.generateSmithyProjections)
-    doLast {
-        benchmarkModels.forEach {
-            copy {
-                from("${it.projectionRootDir}")
-                into("${it.sourceSetRootDir}")
+    @get:Inject
+    abstract val fs: FileSystemOperations
+
+    @TaskAction
+    fun stage() {
+        val models = listOf("twitter", "countries-states")
+
+        models.forEach { modelName ->
+            fs.copy {
+                from("$smithyProjectionsDir/$projectName/$modelName/kotlin-codegen/src/main/kotlin")
+                into(generatedSourcesDir.get().asFile)
                 include("**/model/*.kt")
                 include("**/serde/*.kt")
                 exclude("**/serde/*OperationSerializer.kt")
@@ -113,6 +113,14 @@ val stageGeneratedSources = tasks.register("stageGeneratedSources") {
             }
         }
     }
+}
+
+val stageGeneratedSources = tasks.register<StageGeneratedSourcesTask>("stageGeneratedSources") {
+    group = "codegen"
+    dependsOn(tasks.generateSmithyProjections)
+    projectName.set(project.name)
+    smithyProjectionsDir.set(layout.buildDirectory.dir("smithyprojections"))
+    generatedSourcesDir.set(layout.buildDirectory.dir("generated-src/src"))
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
refactor ```build.gradle.kts``` to fix Gradle configuration cache compatibility issues in build script

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
