### PR TITLE
fix: address issues caused by shape members named result 

### DIFF
--- a/.changes/ebc2a1ba-151a-48ed-afcd-0679c9d3a9ef.json
+++ b/.changes/ebc2a1ba-151a-48ed-afcd-0679c9d3a9ef.json
@@ -1,0 +1,5 @@
+{
+    "id": "ebc2a1ba-151a-48ed-afcd-0679c9d3a9ef",
+    "type": "bugfix",
+    "description": "Address issues caused by shape members named result"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -138,7 +138,7 @@ class StructureGenerator(
                     write("var result = #1L#2L", memberNameSymbolIndex[sortedMembers[0]]!!.first, selectHashFunctionForShape(sortedMembers[0]))
                     if (sortedMembers.size > 1) {
                         sortedMembers.drop(1).forEach { memberShape ->
-                            write("result = 31 * result + (#1L#2L)", memberNameSymbolIndex[memberShape]!!.first, selectHashFunctionForShape(memberShape))
+                            write("result = 31 * result + (this.#1L#2L)", memberNameSymbolIndex[memberShape]!!.first, selectHashFunctionForShape(memberShape))
                         }
                     }
                     write("return result")

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
@@ -134,14 +134,14 @@ class StructureGeneratorTest {
         val expected = """
         override fun hashCode(): kotlin.Int {
             var result = bar
-            result = 31 * result + (baz ?: 0)
-            result = 31 * result + (byteValue?.toInt() ?: 0)
-            result = 31 * result + (defaultString.hashCode())
-            result = 31 * result + (foo?.hashCode() ?: 0)
-            result = 31 * result + (`object`?.hashCode() ?: 0)
-            result = 31 * result + (quux?.hashCode() ?: 0)
-            result = 31 * result + (requiredInt)
-            result = 31 * result + (requiredIntButNullable ?: 0)
+            result = 31 * result + (this.baz ?: 0)
+            result = 31 * result + (this.byteValue?.toInt() ?: 0)
+            result = 31 * result + (this.defaultString.hashCode())
+            result = 31 * result + (this.foo?.hashCode() ?: 0)
+            result = 31 * result + (this.`object`?.hashCode() ?: 0)
+            result = 31 * result + (this.quux?.hashCode() ?: 0)
+            result = 31 * result + (this.requiredInt)
+            result = 31 * result + (this.requiredIntButNullable ?: 0)
             return result
         }
         """.formatForTest()
@@ -474,7 +474,7 @@ class StructureGeneratorTest {
         val expectedHashCodeContent = """
             override fun hashCode(): kotlin.Int {
                 var result = bar?.hashCode() ?: 0
-                result = 31 * result + (foo?.contentHashCode() ?: 0)
+                result = 31 * result + (this.foo?.contentHashCode() ?: 0)
                 return result
             }
         """.formatForTest()
@@ -784,7 +784,7 @@ class StructureGeneratorTest {
         val expected = """
             override fun hashCode(): kotlin.Int {
                 var result = aInt ?: 0
-                result = 31 * result + (bInt)
+                result = 31 * result + (this.bInt)
                 return result
             }
         """.formatForTest()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Shapes with members named "`result`" would cause naming collisions due to the local variable also named "`result`" in the `hashcode` function. If we access the `result` member using `this` we're able to remove ambiguity caused by the naming collision.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
