### PR TITLE
fix: limit the parsing depth of JSON, XML, and CBOR parsers

### DIFF
--- a/.changes/0c6de8ff-1483-4c9b-b134-097aaf072ae9.json
+++ b/.changes/0c6de8ff-1483-4c9b-b134-097aaf072ae9.json
@@ -1,0 +1,5 @@
+{
+    "id": "0c6de8ff-1483-4c9b-b134-097aaf072ae9",
+    "type": "bugfix",
+    "description": "Limit serde parsing depth to 1,000 levels of nesting to prevent `StackOverflowError`"
+}

--- a/runtime/serde/api/serde.api
+++ b/runtime/serde/api/serde.api
@@ -1,8 +1,16 @@
-public final class aws/smithy/kotlin/runtime/serde/DeserializationException : aws/smithy/kotlin/runtime/ClientException {
+public final class aws/smithy/kotlin/runtime/serde/ConstantsKt {
+	public static final field MAX_RECURSION_DEPTH I
+}
+
+public class aws/smithy/kotlin/runtime/serde/DeserializationException : aws/smithy/kotlin/runtime/ClientException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public final class aws/smithy/kotlin/runtime/serde/DeserializationRecursionException : aws/smithy/kotlin/runtime/serde/DeserializationException {
+	public fun <init> (I)V
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/serde/Deserializer {

--- a/runtime/serde/api/serde.api
+++ b/runtime/serde/api/serde.api
@@ -10,7 +10,12 @@ public class aws/smithy/kotlin/runtime/serde/DeserializationException : aws/smit
 }
 
 public final class aws/smithy/kotlin/runtime/serde/DeserializationRecursionException : aws/smithy/kotlin/runtime/serde/DeserializationException {
-	public fun <init> (I)V
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/DeserializationRecursionException$Companion;
+	public fun <init> ()V
+}
+
+public final class aws/smithy/kotlin/runtime/serde/DeserializationRecursionException$Companion {
+	public final fun assertDepth (I)V
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/serde/Deserializer {

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Constants.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Constants.kt
@@ -6,7 +6,7 @@ package aws.smithy.kotlin.runtime.serde
 
 /**
  * The maximum allowed depth of recursion when parsing data through serde. In practice, this limits the levels of
- * nesting of objects, maps, lists, and arrays. For example, a limit of `1_000` allows the following:
+ * nesting of objects, maps, lists, and arrays. For example, a limit of `100` allows the following:
  *
  * ```json
  * {
@@ -14,7 +14,7 @@ package aws.smithy.kotlin.runtime.serde
  *     "obj2": {
  *       "obj3": {
  *         ...
- *           "obj1000": "foo"
+ *           "obj100": "foo"
  *         ...
  *       }
  *     }
@@ -30,8 +30,8 @@ package aws.smithy.kotlin.runtime.serde
  *     "obj2": {
  *       "obj3": {
  *         ...
- *           "obj1000": {
- *             "obj1001": "foo"
+ *           "obj100": {
+ *             "obj101": "foo"
  *           }
  *         ...
  *       }
@@ -40,4 +40,4 @@ package aws.smithy.kotlin.runtime.serde
  * }
  * ```
  */
-public const val MAX_RECURSION_DEPTH: Int = 1_000
+public const val MAX_RECURSION_DEPTH: Int = 100

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Constants.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Constants.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.serde
+
+/**
+ * The maximum allowed depth of recursion when parsing data through serde. In practice, this limits the levels of
+ * nesting of objects, maps, lists, and arrays. For example, a limit of `1_000` allows the following:
+ *
+ * ```json
+ * {
+ *   "obj1": {
+ *     "obj2": {
+ *       "obj3": {
+ *         ...
+ *           "obj1000": "foo"
+ *         ...
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * But prohibits the following:
+ *
+ * ```json
+ * {
+ *   "obj1": {
+ *     "obj2": {
+ *       "obj3": {
+ *         ...
+ *           "obj1000": {
+ *             "obj1001": "foo"
+ *           }
+ *         ...
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+public const val MAX_RECURSION_DEPTH: Int = 1_000

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Exceptions.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Exceptions.kt
@@ -25,7 +25,7 @@ public class SerializationException : ClientException {
 /**
  * Exception class for all deserialization errors
  */
-public class DeserializationException : ClientException {
+public open class DeserializationException : ClientException {
 
     public constructor() : super()
 
@@ -34,6 +34,27 @@ public class DeserializationException : ClientException {
     public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
     public constructor(cause: Throwable?) : super(cause)
+}
+
+/**
+ * Exception thrown when deserialization exceeds the maximum allowed recursion depth.
+ */
+public class DeserializationRecursionException : DeserializationException(
+    "Max recursion depth ($MAX_RECURSION_DEPTH) exceeded during deserialization",
+) {
+    @InternalApi
+    public companion object {
+        /**
+         * Compares [currentDepth] to [MAX_RECURSION_DEPTH] and throws [DeserializationRecursionException] if the former
+         * exceeds the latter. Otherwise, returns silently.
+         */
+        @InternalApi
+        public fun assertDepth(currentDepth: Int) {
+            if (currentDepth > MAX_RECURSION_DEPTH) {
+                throw DeserializationRecursionException()
+            }
+        }
+    }
 }
 
 /**

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Exceptions.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Exceptions.kt
@@ -39,9 +39,7 @@ public open class DeserializationException : ClientException {
 /**
  * Exception thrown when deserialization exceeds the maximum allowed recursion depth.
  */
-public class DeserializationRecursionException : DeserializationException(
-    "Max recursion depth ($MAX_RECURSION_DEPTH) exceeded during deserialization",
-) {
+public class DeserializationRecursionException : DeserializationException("Max recursion depth ($MAX_RECURSION_DEPTH) exceeded during deserialization") {
     @InternalApi
     public companion object {
         /**

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkObjectDescriptor.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkObjectDescriptor.kt
@@ -36,7 +36,7 @@ public class SdkObjectDescriptor private constructor(builder: Builder) :
             traits.add(trait)
         }
 
-        @PublishedApi
-        internal fun build(): SdkObjectDescriptor = SdkObjectDescriptor(this)
+        @InternalApi
+        public fun build(): SdkObjectDescriptor = SdkObjectDescriptor(this)
     }
 }

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializer.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializer.kt
@@ -183,7 +183,7 @@ private class CborFieldIterator(
     PrimitiveDeserializer by CborPrimitiveDeserializer(buffer) {
     var currentLength: ULong = 0uL
 
-    override fun findNextFieldIndex(): Int? {
+    override tailrec fun findNextFieldIndex(): Int? {
         if (buffer.exhausted() && expectedLength != currentLength) {
             throw DeserializationException("Buffer is unexpectedly exhausted, expected $expectedLength elements, got $currentLength")
         } else if (expectedLength == currentLength) {

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
@@ -20,8 +20,8 @@ internal class TextString(val value: String) : Value {
     }
 
     internal companion object {
-        fun decode(buffer: SdkBufferedSource): TextString = if (peekMinorByte(buffer) == Minor.INDEFINITE.value) {
-            val list = IndefiniteList.decode(buffer).value
+        fun decode(buffer: SdkBufferedSource, depth: Int = 0): TextString = if (peekMinorByte(buffer) == Minor.INDEFINITE.value) {
+            val list = IndefiniteList.decode(buffer, depth).value
 
             val sb = StringBuilder()
             list.forEach {
@@ -53,8 +53,8 @@ internal class ByteString(val value: ByteArray) : Value {
     }
 
     internal companion object {
-        fun decode(buffer: SdkBufferedSource): ByteString = if (peekMinorByte(buffer) == Minor.INDEFINITE.value) {
-            val list = IndefiniteList.decode(buffer).value
+        fun decode(buffer: SdkBufferedSource, depth: Int = 0): ByteString = if (peekMinorByte(buffer) == Minor.INDEFINITE.value) {
+            val list = IndefiniteList.decode(buffer, depth).value
 
             val tempBuffer = SdkBuffer()
             list.forEach {

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
@@ -86,12 +86,12 @@ internal class List(val value: kotlin.collections.List<Value>) : Value {
     }
 
     internal companion object {
-        internal fun decode(buffer: SdkBufferedSource): List {
+        internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): List {
             val length = decodeArgument(buffer).toInt()
             val valuesList = mutableListOf<Value>()
 
             for (i in 0 until length) {
-                valuesList.add(Value.decode(buffer))
+                valuesList.add(Value.decode(buffer, depth + 1))
             }
 
             return List(valuesList)
@@ -119,13 +119,13 @@ internal class IndefiniteList(val value: Collection<Value> = listOf()) : Value {
     }
 
     internal companion object {
-        internal fun decode(buffer: SdkBufferedSource): IndefiniteList {
+        internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): IndefiniteList {
             buffer.readByte() // discard head
 
             val list = mutableListOf<Value>()
 
             while (!buffer.nextValueIsIndefiniteBreak) {
-                list.add(Value.decode(buffer))
+                list.add(Value.decode(buffer, depth + 1))
             }
 
             IndefiniteBreak.decode(buffer)
@@ -148,13 +148,13 @@ internal class Map(val value: kotlin.collections.Map<Value, Value>) : Value {
     }
 
     internal companion object {
-        internal fun decode(buffer: SdkBufferedSource): Map {
+        internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): Map {
             val valueMap = mutableMapOf<Value, Value>()
             val length = decodeArgument(buffer).toInt()
 
             for (i in 0 until length) {
-                val key = Value.decode(buffer)
-                val value = Value.decode(buffer)
+                val key = Value.decode(buffer, depth + 1)
+                val value = Value.decode(buffer, depth + 1)
                 valueMap[key] = value
             }
 
@@ -184,13 +184,13 @@ internal class IndefiniteMap(val value: kotlin.collections.Map<Value, Value> = m
     }
 
     internal companion object {
-        internal fun decode(buffer: SdkBufferedSource): IndefiniteMap {
+        internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): IndefiniteMap {
             buffer.readByte() // discard head byte
             val valueMap = mutableMapOf<Value, Value>()
 
             while (!buffer.nextValueIsIndefiniteBreak) {
-                val key = Value.decode(buffer)
-                val value = Value.decode(buffer)
+                val key = Value.decode(buffer, depth + 1)
+                val value = Value.decode(buffer, depth + 1)
                 valueMap[key] = value
             }
 

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Tag.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Tag.kt
@@ -36,14 +36,14 @@ internal class Tag(val id: ULong, val value: Value) : Value {
     }
 
     internal companion object {
-        fun decode(buffer: SdkBufferedSource): Tag {
+        fun decode(buffer: SdkBufferedSource, depth: Int = 0): Tag {
             val id = decodeArgument(buffer)
 
             val value: Value = when (id) {
                 TagId.TIMESTAMP.value -> Timestamp.decode(buffer)
-                TagId.BIG_NUM.value -> BigNum.decode(buffer)
-                TagId.NEG_BIG_NUM.value -> NegBigNum.decode(buffer)
-                TagId.DECIMAL_FRACTION.value -> DecimalFraction.decode(buffer)
+                TagId.BIG_NUM.value -> BigNum.decode(buffer, depth)
+                TagId.NEG_BIG_NUM.value -> NegBigNum.decode(buffer, depth)
+                TagId.DECIMAL_FRACTION.value -> DecimalFraction.decode(buffer, depth)
                 else -> throw DeserializationException("Unsupported tag ID $id")
             }
 
@@ -100,8 +100,8 @@ internal class BigNum(val value: BigInteger) : Value {
     override fun encode(into: SdkBufferedSink) = Tag(2u, ByteString(value.toByteArray())).encode(into)
 
     internal companion object {
-        internal fun decode(buffer: SdkBufferedSource): BigNum {
-            val bytes = ByteString.decode(buffer).value
+        internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): BigNum {
+            val bytes = ByteString.decode(buffer, depth).value
             return BigNum(BigInteger(bytes))
         }
     }
@@ -118,8 +118,8 @@ internal class NegBigNum(val value: BigInteger) : Value {
     }
 
     internal companion object {
-        internal fun decode(buffer: SdkBufferedSource): NegBigNum {
-            val bytes = ByteString.decode(buffer).value
+        internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): NegBigNum {
+            val bytes = ByteString.decode(buffer, depth).value
 
             // note: CBOR encoding implies (-1 - $value), add one to get the real value.
             val bigInteger = BigInteger(bytes) + BigInteger("1")
@@ -160,8 +160,8 @@ internal class DecimalFraction(val value: BigDecimal) : Value {
     }
 
     internal companion object {
-        internal fun decode(buffer: SdkBufferedSource): DecimalFraction {
-            val list = List.decode(buffer).value
+        internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): DecimalFraction {
+            val list = List.decode(buffer, depth).value
             check(list.size == 2) { "Expected array of length 2 for decimal fraction, got ${list.size}" }
 
             val (exponentValue, mantissaValue) = list

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Value.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Value.kt
@@ -8,6 +8,7 @@ import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.io.SdkBufferedSink
 import aws.smithy.kotlin.runtime.io.SdkBufferedSource
 import aws.smithy.kotlin.runtime.serde.DeserializationException
+import aws.smithy.kotlin.runtime.serde.DeserializationRecursionException
 
 /**
  * Represents an encodable / decodable CBOR value.
@@ -23,8 +24,11 @@ internal interface Value {
         /**
          * Decode a [Value] from the given [buffer]
          * @param buffer the [SdkBufferedSource] to read the next [Value] from
+         * @param depth the current recursion depth
          */
-        fun decode(buffer: SdkBufferedSource): Value {
+        fun decode(buffer: SdkBufferedSource, depth: Int = 0): Value {
+            DeserializationRecursionException.assertDepth(depth)
+
             val major = peekMajor(buffer)
             val minor = peekMinorByte(buffer)
 
@@ -33,33 +37,31 @@ internal interface Value {
                 Major.NEG_INT -> NegInt.decode(buffer)
                 Major.BYTE_STRING -> ByteString.decode(buffer)
                 Major.STRING -> TextString.decode(buffer)
-                Major.LIST -> {
-                    return if (minor == Minor.INDEFINITE.value) {
-                        IndefiniteList.decode(buffer)
-                    } else {
-                        List.decode(buffer)
-                    }
+
+                Major.LIST -> if (minor == Minor.INDEFINITE.value) {
+                    IndefiniteList.decode(buffer, depth)
+                } else {
+                    List.decode(buffer, depth)
                 }
-                Major.MAP -> {
-                    if (minor == Minor.INDEFINITE.value) {
-                        IndefiniteMap.decode(buffer)
-                    } else {
-                        Map.decode(buffer)
-                    }
+
+                Major.MAP -> if (minor == Minor.INDEFINITE.value) {
+                    IndefiniteMap.decode(buffer, depth)
+                } else {
+                    Map.decode(buffer, depth)
                 }
+
                 Major.TAG -> Tag.decode(buffer)
-                Major.TYPE_7 -> {
-                    when (minor) {
-                        Minor.TRUE.value -> Boolean.decode(buffer)
-                        Minor.FALSE.value -> Boolean.decode(buffer)
-                        Minor.NULL.value -> Null.decode(buffer)
-                        Minor.UNDEFINED.value -> Null.decode(buffer)
-                        Minor.FLOAT16.value -> Float16.decode(buffer)
-                        Minor.FLOAT32.value -> Float32.decode(buffer)
-                        Minor.FLOAT64.value -> Float64.decode(buffer)
-                        Minor.INDEFINITE.value -> IndefiniteBreak.decode(buffer)
-                        else -> throw DeserializationException("Unexpected type 7 minor value $minor")
-                    }
+
+                Major.TYPE_7 -> when (minor) {
+                    Minor.TRUE.value -> Boolean.decode(buffer)
+                    Minor.FALSE.value -> Boolean.decode(buffer)
+                    Minor.NULL.value -> Null.decode(buffer)
+                    Minor.UNDEFINED.value -> Null.decode(buffer)
+                    Minor.FLOAT16.value -> Float16.decode(buffer)
+                    Minor.FLOAT32.value -> Float32.decode(buffer)
+                    Minor.FLOAT64.value -> Float64.decode(buffer)
+                    Minor.INDEFINITE.value -> IndefiniteBreak.decode(buffer)
+                    else -> throw DeserializationException("Unexpected type 7 minor value $minor")
                 }
             }
         }

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Value.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Value.kt
@@ -35,8 +35,8 @@ internal interface Value {
             return when (major) {
                 Major.U_INT -> UInt.decode(buffer)
                 Major.NEG_INT -> NegInt.decode(buffer)
-                Major.BYTE_STRING -> ByteString.decode(buffer)
-                Major.STRING -> TextString.decode(buffer)
+                Major.BYTE_STRING -> ByteString.decode(buffer, depth)
+                Major.STRING -> TextString.decode(buffer, depth)
 
                 Major.LIST -> if (minor == Minor.INDEFINITE.value) {
                     IndefiniteList.decode(buffer, depth)
@@ -50,7 +50,7 @@ internal interface Value {
                     Map.decode(buffer, depth)
                 }
 
-                Major.TAG -> Tag.decode(buffer)
+                Major.TAG -> Tag.decode(buffer, depth)
 
                 Major.TYPE_7 -> when (minor) {
                     Minor.TRUE.value -> Boolean.decode(buffer)

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
@@ -138,5 +138,4 @@ class CborDeserializerTest {
         val result = iter.findNextFieldIndex()
         assertNull(result)
     }
-
 }

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
@@ -66,26 +66,6 @@ class CborDeserializerTest {
         aws.smithy.kotlin.runtime.serde.cbor.encoding.Value.decode(buffer)
     }
 
-    @Test
-    fun testFindNextFieldIndexRecursion() {
-        // CBOR indef map with n × (empty-string key, null value): 0xbf (0x60 0xf6)×n 0xff
-        // This tests tailrec iteration, not nesting depth — should complete without throwing.
-        val n = 50000
-        val p = ByteArray(1 + 2 * n + 1)
-        p[0] = 0xbf.toByte()
-        for (i in 0..<n) {
-            p[1 + 2 * i] = 0x60
-            p[2 + 2 * i] = 0xf6.toByte()
-        }
-        p[p.size - 1] = 0xff.toByte()
-
-        // Descriptor with one field "" so candidate is computed → null-skip path → tailrec iteration
-        val b = SdkObjectDescriptor.Builder()
-        b.field(SdkFieldDescriptor(SerialKind.String, CborSerialName("")))
-
-        CborDeserializer(p).deserializeStruct(b.build()).findNextFieldIndex()
-    }
-
     /**
      * tt/P441722592/F9: A CBOR payload with an unknown field containing deeply nested arrays must throw
      * DeserializationRecursionException, not StackOverflowError. The depth check in Value.decode catches this before

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
@@ -5,9 +5,12 @@
 package aws.smithy.kotlin.runtime.serde.cbor
 
 import aws.smithy.kotlin.runtime.io.SdkBuffer
+import aws.smithy.kotlin.runtime.serde.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 class CborDeserializerTest {
     @Test
@@ -27,4 +30,113 @@ class CborDeserializerTest {
         assertFails { deserializer.deserializeByte() }
         assertEquals(Long.MAX_VALUE, deserializer.deserializeLong())
     }
+
+    @Test
+    fun testRecursionLimitingThrows() {
+        // Indef map { "x": [0x81 × n, 0x00] } — "x" is unknown → skipValue → Value.decode recursion.
+        val n = MAX_RECURSION_DEPTH + 1
+        val p = ByteArray(1 + 2 + n + 1 + 1)
+        var i = 0
+        p[i++] = 0xbf.toByte() // indef map start
+        p[i++] = 0x61
+        p[i++] = 'x'.code.toByte() // text(1) "x"
+        for (j in 0..<n) p[i++] = 0x81.toByte() // array(1) nested
+        p[i++] = 0x00 // uint 0
+        p[i++] = 0xff.toByte() // break
+
+        val desc = SdkObjectDescriptor.Builder().build() // no fields → "x" is unknown
+
+        val iter = CborDeserializer(p).deserializeStruct(desc)
+        assertFailsWith<DeserializationRecursionException> {
+            while (iter.findNextFieldIndex() != null) {
+                iter.skipValue()
+            }
+        }
+    }
+
+    @Test
+    fun testNestingAtExactLimitSucceeds() {
+        // array(1) nested exactly MAX_RECURSION_DEPTH times, innermost contains uint 0
+        val n = MAX_RECURSION_DEPTH
+        val p = ByteArray(n + 1)
+        for (i in 0..<n) p[i] = 0x81.toByte() // array(1)
+        p[n] = 0x00 // uint 0
+
+        val buffer = SdkBuffer().apply { write(p) }
+        aws.smithy.kotlin.runtime.serde.cbor.encoding.Value.decode(buffer)
+    }
+
+    @Test
+    fun testFindNextFieldIndexRecursion() {
+        // CBOR indef map with n × (empty-string key, null value): 0xbf (0x60 0xf6)×n 0xff
+        // This tests tailrec iteration, not nesting depth — should complete without throwing.
+        val n = 50000
+        val p = ByteArray(1 + 2 * n + 1)
+        p[0] = 0xbf.toByte()
+        for (i in 0..<n) {
+            p[1 + 2 * i] = 0x60
+            p[2 + 2 * i] = 0xf6.toByte()
+        }
+        p[p.size - 1] = 0xff.toByte()
+
+        // Descriptor with one field "" so candidate is computed → null-skip path → tailrec iteration
+        val b = SdkObjectDescriptor.Builder()
+        b.field(SdkFieldDescriptor(SerialKind.String, CborSerialName("")))
+
+        CborDeserializer(p).deserializeStruct(b.build()).findNextFieldIndex()
+    }
+
+    /**
+     * tt/P441722592/F9: A CBOR payload with an unknown field containing deeply nested arrays must throw
+     * DeserializationRecursionException, not StackOverflowError. The depth check in Value.decode catches this before
+     * the stack is exhausted.
+     */
+    @Test
+    fun valueDecodeSkipRecursionThrowsRecursionException() {
+        val n = MAX_RECURSION_DEPTH + 1
+        val p = ByteArray(1 + 2 + n + 1 + 1)
+        var i = 0
+        p[i++] = 0xbf.toByte() // indef map start
+        p[i++] = 0x61 // text(1)
+        p[i++] = 'x'.code.toByte() // "x"
+        for (j in 0..<n) p[i++] = 0x81.toByte() // array(1) nested
+        p[i++] = 0x00 // uint 0
+        p[i++] = 0xff.toByte() // break
+
+        val desc = SdkObjectDescriptor.Builder().build() // no fields → "x" is unknown
+        val iter = CborDeserializer(p).deserializeStruct(desc)
+
+        assertFailsWith<DeserializationRecursionException> {
+            while (iter.findNextFieldIndex() != null) {
+                iter.skipValue()
+            }
+        }
+    }
+
+    /**
+     * tt/P441722592/F10: A flat CBOR indef map with many null-valued known fields must not cause StackOverflowError.
+     * The tailrec annotation on findNextFieldIndex ensures the null-skip path is compiled to a loop.
+     */
+    @Test
+    fun findNextFieldIndexNullSkipDoesNotStackOverflow() {
+        // CBOR indef map with n × (empty-string key, null value): 0xbf (0x60 0xf6)×n 0xff
+        val n = 50_000
+        val p = ByteArray(1 + 2 * n + 1)
+        p[0] = 0xbf.toByte()
+        for (i in 0..<n) {
+            p[1 + 2 * i] = 0x60
+            p[2 + 2 * i] = 0xf6.toByte()
+        }
+        p[p.size - 1] = 0xff.toByte()
+
+        val desc = SdkObjectDescriptor.build {
+            field(SdkFieldDescriptor(SerialKind.String, CborSerialName("")))
+        }
+
+        val iter = CborDeserializer(p).deserializeStruct(desc)
+        // Should return null (all fields are null → all skipped) without StackOverflowError
+        val result = iter.findNextFieldIndex()
+        assertNull(result)
+    }
+
 }

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
@@ -6,6 +6,7 @@ package aws.smithy.kotlin.runtime.serde.cbor
 
 import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.serde.*
+import aws.smithy.kotlin.runtime.serde.cbor.encoding.Value
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -63,7 +64,7 @@ class CborDeserializerTest {
         p[n] = 0x00 // uint 0
 
         val buffer = SdkBuffer().apply { write(p) }
-        aws.smithy.kotlin.runtime.serde.cbor.encoding.Value.decode(buffer)
+        Value.decode(buffer)
     }
 
     /**
@@ -120,8 +121,8 @@ class CborDeserializerTest {
     }
 
     /**
-     * Deeply nested DecimalFraction tags bypass the recursion depth limit because Tag.decode does not
-     * propagate depth, and DecimalFraction.decode calls List.decode(buffer) with depth defaulting to 0.
+     * Verify that deeply-nested `DecimalFraction` tags do not bypass the recursion depth limit by resetting the
+     * recursion depth to 0.
      *
      * Payload structure (repeated n times):
      *   0xC4        — Tag(4) = DecimalFraction
@@ -157,7 +158,7 @@ class CborDeserializerTest {
         // The depth limit should fire, but it doesn't — Tag.decode doesn't propagate depth.
         // With the fix, this will throw DeserializationRecursionException.
         assertFailsWith<DeserializationRecursionException> {
-            aws.smithy.kotlin.runtime.serde.cbor.encoding.Value.decode(buffer)
+            Value.decode(buffer)
         }
     }
 
@@ -187,7 +188,7 @@ class CborDeserializerTest {
 
         val buffer = SdkBuffer().apply { write(p) }
         assertFailsWith<DeserializationRecursionException> {
-            aws.smithy.kotlin.runtime.serde.cbor.encoding.Value.decode(buffer)
+            Value.decode(buffer)
         }
     }
 }

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerTest.kt
@@ -138,4 +138,76 @@ class CborDeserializerTest {
         val result = iter.findNextFieldIndex()
         assertNull(result)
     }
+
+    /**
+     * Deeply nested DecimalFraction tags bypass the recursion depth limit because Tag.decode does not
+     * propagate depth, and DecimalFraction.decode calls List.decode(buffer) with depth defaulting to 0.
+     *
+     * Payload structure (repeated n times):
+     *   0xC4        — Tag(4) = DecimalFraction
+     *   0x82        — List(2)
+     *   0x00        — UInt(0) exponent
+     *   [next level or terminal mantissa]
+     *
+     * Terminal mantissa: 0xC2 0x41 0x01 — Tag(2) BigNum, ByteString(1) [0x01]
+     *
+     * This should throw DeserializationRecursionException but currently does NOT because
+     * depth resets to 0 at each DecimalFraction.decode → List.decode call.
+     * Instead it recurses freely and throws a different exception (type mismatch) at the bottom,
+     * proving the depth check was never triggered despite exceeding MAX_RECURSION_DEPTH.
+     */
+    @Test
+    fun nestedDecimalFractionTagsBypassesDepthLimit() {
+        val n = MAX_RECURSION_DEPTH + 1
+        // Each level: 0xC4 0x82 0x00 (3 bytes), terminal: 0xC2 0x41 0x01 (3 bytes)
+        val p = ByteArray(n * 3 + 3)
+        var i = 0
+        for (j in 0..<n) {
+            p[i++] = 0xC4.toByte() // Tag(4) DecimalFraction
+            p[i++] = 0x82.toByte() // List(2)
+            p[i++] = 0x00 // UInt(0) exponent
+            // mantissa is the next level (or terminal)
+        }
+        // Terminal mantissa: BigNum tag wrapping ByteString
+        p[i++] = 0xC2.toByte() // Tag(2) BigNum
+        p[i++] = 0x41 // ByteString(1)
+        p[i++] = 0x01 // byte value
+
+        val buffer = SdkBuffer().apply { write(p) }
+        // The depth limit should fire, but it doesn't — Tag.decode doesn't propagate depth.
+        // With the fix, this will throw DeserializationRecursionException.
+        assertFailsWith<DeserializationRecursionException> {
+            aws.smithy.kotlin.runtime.serde.cbor.encoding.Value.decode(buffer)
+        }
+    }
+
+    /**
+     * Nested indefinite-length TextStrings bypass the depth limit because TextString.decode calls
+     * IndefiniteList.decode(buffer) without a depth parameter (defaults to 0).
+     *
+     * Each indefinite text string level: 0x7F (indef string start) ... 0xFF (break)
+     * Inside, Value.decode dispatches STRING major back to TextString.decode, which again
+     * calls IndefiniteList.decode(buffer) with depth=0, creating unbounded recursion.
+     *
+     * Payload: n nested indefinite text strings, innermost contains a definite chunk "a".
+     *   0x7F 0x7F 0x7F ... 0x61 0x61 ... 0xFF 0xFF 0xFF
+     *
+     * This should throw DeserializationRecursionException but currently causes StackOverflowError.
+     */
+    @Test
+    fun indefiniteTextStringResetsDepthCounter() {
+        val n = MAX_RECURSION_DEPTH + 1
+        // n × 0x7F (indef text start) + definite chunk "a" (0x61 0x61) + n × 0xFF (break)
+        val p = ByteArray(n + 2 + n)
+        var i = 0
+        for (j in 0..<n) p[i++] = 0x7F.toByte() // indefinite-length text string
+        p[i++] = 0x61 // text(1)
+        p[i++] = 0x61 // "a"
+        for (j in 0..<n) p[i++] = 0xFF.toByte() // break
+
+        val buffer = SdkBuffer().apply { write(p) }
+        assertFailsWith<DeserializationRecursionException> {
+            aws.smithy.kotlin.runtime.serde.cbor.encoding.Value.decode(buffer)
+        }
+    }
 }

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
@@ -195,41 +195,43 @@ private class JsonFieldIterator(
     PrimitiveDeserializer by deserializer {
 
     override fun findNextFieldIndex(): Int? {
-        val candidate = when (reader.peek()) {
-            JsonToken.EndObject -> {
-                // consume the token
-                reader.nextTokenOf<JsonToken.EndObject>()
-                null
-            }
-            JsonToken.EndDocument -> null
-            JsonToken.Null -> {
-                reader.nextTokenOf<JsonToken.Null>()
-                null
-            }
-            else -> {
-                val token = reader.nextTokenOf<JsonToken.Name>()
-                val propertyName = token.value
-                val field = descriptor.fields.find { it.serialName == propertyName }
+        while (true) {
+            val candidate = when (reader.peek()) {
+                JsonToken.EndObject -> {
+                    // consume the token
+                    reader.nextTokenOf<JsonToken.EndObject>()
+                    null
+                }
+                JsonToken.EndDocument -> null
+                JsonToken.Null -> {
+                    reader.nextTokenOf<JsonToken.Null>()
+                    null
+                }
+                else -> {
+                    val token = reader.nextTokenOf<JsonToken.Name>()
+                    val propertyName = token.value
+                    val field = descriptor.fields.find { it.serialName == propertyName }
 
-                if (IgnoreKey(propertyName) in descriptor.traits) {
-                    reader.skipNext() // the value of the ignored key
-                    return findNextFieldIndex()
-                } else {
-                    field?.index ?: Deserializer.FieldIterator.UNKNOWN_FIELD
+                    if (IgnoreKey(propertyName) in descriptor.traits) {
+                        reader.skipNext() // the value of the ignored key
+                        continue
+                    } else {
+                        field?.index ?: Deserializer.FieldIterator.UNKNOWN_FIELD
+                    }
                 }
             }
-        }
 
-        if (candidate != null) {
-            // found a field
-            if (reader.peek() == JsonToken.Null) {
-                // skip explicit nulls
-                reader.nextTokenOf<JsonToken.Null>()
-                return findNextFieldIndex()
+            if (candidate != null) {
+                // found a field
+                if (reader.peek() == JsonToken.Null) {
+                    // skip explicit nulls
+                    reader.nextTokenOf<JsonToken.Null>()
+                    continue
+                }
             }
-        }
 
-        return candidate
+            return candidate
+        }
     }
 
     override fun skipValue() {

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonLexer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonLexer.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.serde.json
 
 import aws.smithy.kotlin.runtime.collections.*
 import aws.smithy.kotlin.runtime.serde.DeserializationException
+import aws.smithy.kotlin.runtime.serde.DeserializationRecursionException
 
 private val DIGITS = ('0'..'9').toSet()
 private val EXP = setOf('e', 'E')
@@ -145,6 +146,7 @@ internal class JsonLexer(
 
     // discards the '{' character and pushes 'ObjectFirstKeyOrEnd' state
     private fun startObject(): JsonToken {
+        DeserializationRecursionException.assertDepth(state.size)
         consume('{')
         state.mutate { it.push(LexerState.ObjectFirstKeyOrEnd) }
         return JsonToken.BeginObject
@@ -161,6 +163,7 @@ internal class JsonLexer(
 
     // discards the '[' and pushes 'ArrayFirstValueOrEnd' state
     private fun startArray(): JsonToken {
+        DeserializationRecursionException.assertDepth(state.size)
         consume('[')
         state.mutate { it.push(LexerState.ArrayFirstValueOrEnd) }
         return JsonToken.BeginArray

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
@@ -820,4 +820,102 @@ class JsonDeserializerTest {
 
         testDeserializeDocument(doc, expected)
     }
+
+    @Test
+    fun testDeeplyNestedArraysThrows() {
+        val payload = "[".repeat(MAX_RECURSION_DEPTH + 1) + "]".repeat(MAX_RECURSION_DEPTH + 1)
+        val reader = jsonStreamReader(payload.encodeToByteArray())
+        assertFailsWith<DeserializationRecursionException> {
+            while (true) {
+                reader.nextToken()
+            }
+        }
+    }
+
+    @Test
+    fun testDeeplyNestedObjectsThrows() {
+        val payload = buildString {
+            repeat(MAX_RECURSION_DEPTH + 1) { append("""{"a":""") }
+            append("1")
+            repeat(MAX_RECURSION_DEPTH + 1) { append("}") }
+        }
+        val reader = jsonStreamReader(payload.encodeToByteArray())
+        assertFailsWith<DeserializationRecursionException> {
+            while (true) {
+                reader.nextToken()
+            }
+        }
+    }
+
+    @Test
+    fun testNestingAtExactLimitSucceeds() {
+        val payload = "[".repeat(MAX_RECURSION_DEPTH) + "]".repeat(MAX_RECURSION_DEPTH)
+        val reader = jsonStreamReader(payload.encodeToByteArray())
+        while (reader.peek() != JsonToken.EndDocument) {
+            reader.nextToken()
+        }
+    }
+
+    /**
+     * F21: A flat JSON object with many null-valued known fields must not cause StackOverflowError.
+     * The null-skip path in findNextFieldIndex recurses once per null field. With 50,000 null fields
+     * this previously caused SOE. After fix (tailrec or loop), it should complete normally.
+     */
+    @Test
+    fun findNextFieldIndexNullSkipDoesNotStackOverflow() {
+        val n = 50_000
+        val json = buildString {
+            append("{")
+            repeat(n) { i ->
+                if (i > 0) append(",")
+                append("\"k\":null")
+            }
+            append("}")
+        }
+
+        val descriptor = SdkObjectDescriptor.build {
+            field(SdkFieldDescriptor(SerialKind.String, JsonSerialName("k")))
+        }
+
+        val deserializer = JsonDeserializer(json.encodeToByteArray())
+        val iter = deserializer.deserializeStruct(descriptor)
+        // Should return null (all fields are null → all skipped) without StackOverflowError
+        val result = iter.findNextFieldIndex()
+        assertNull(result)
+    }
+
+    /**
+     * tt/P441722592/F22: Deeply nested JSON arrays in a document must throw DeserializationRecursionException,
+     * not StackOverflowError. The lexer depth check catches this before the recursive deserializeDocumentImpl can
+     * exhaust the stack.
+     */
+    @Test
+    fun deserializeDocumentNestedArraysThrowsRecursionException() {
+        val n = MAX_RECURSION_DEPTH + 1
+        val json = "[".repeat(n) + "0" + "]".repeat(n)
+
+        val deserializer = JsonDeserializer(json.encodeToByteArray())
+        assertFailsWith<DeserializationRecursionException> {
+            deserializer.deserializeDocument()
+        }
+    }
+
+    /**
+     * tt/P441722592/F22: Deeply nested JSON objects in a document must throw DeserializationRecursionException,
+     * not StackOverflowError.
+     */
+    @Test
+    fun f22_deserializeDocumentNestedObjectsThrowsRecursionException() {
+        val n = MAX_RECURSION_DEPTH + 1
+        val json = buildString {
+            repeat(n) { append("""{"a":""") }
+            append("1")
+            repeat(n) { append("}") }
+        }
+
+        val deserializer = JsonDeserializer(json.encodeToByteArray())
+        assertFailsWith<DeserializationRecursionException> {
+            deserializer.deserializeDocument()
+        }
+    }
 }

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/deserialization/XmlLexer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/deserialization/XmlLexer.kt
@@ -6,6 +6,7 @@ package aws.smithy.kotlin.runtime.serde.xml.deserialization
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.serde.DeserializationException
+import aws.smithy.kotlin.runtime.serde.DeserializationRecursionException
 import aws.smithy.kotlin.runtime.serde.xml.XmlToken
 import aws.smithy.kotlin.runtime.text.codePointToChars
 
@@ -220,6 +221,7 @@ public class XmlLexer(internal val source: StringTextStream) {
             }
 
             state = nextState
+            DeserializationRecursionException.assertDepth(nextState.depth)
             XmlToken.BeginElement(nextState.depth, name, attributes, nsDeclarations)
         }
 

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderTest.kt
@@ -5,6 +5,8 @@
 package aws.smithy.kotlin.runtime.serde.xml
 
 import aws.smithy.kotlin.runtime.serde.DeserializationException
+import aws.smithy.kotlin.runtime.serde.DeserializationRecursionException
+import aws.smithy.kotlin.runtime.serde.MAX_RECURSION_DEPTH
 import kotlin.test.*
 
 class XmlStreamReaderTest {
@@ -746,7 +748,22 @@ class XmlStreamReaderTest {
         reader.nextToken()
         assertEquals(XmlToken.Text(1, "This is a <test/> of CDATA"), reader.nextToken())
     }
-}
+
+    @Test
+    fun testDeeplyNestedElementsThrows() {
+        val payload = "<a>".repeat(MAX_RECURSION_DEPTH + 1) + "</a>".repeat(MAX_RECURSION_DEPTH + 1)
+        val reader = xmlStreamReader(payload.encodeToByteArray())
+        assertFailsWith<DeserializationRecursionException> {
+            while (reader.nextToken() != null) {}
+        }
+    }
+
+    @Test
+    fun testNestingAtExactLimitSucceeds() {
+        val payload = "<a>".repeat(MAX_RECURSION_DEPTH) + "</a>".repeat(MAX_RECURSION_DEPTH)
+        val reader = xmlStreamReader(payload.encodeToByteArray())
+        while (reader.nextToken() != null) {}
+    }}
 
 fun XmlStreamReader.allTokens(): List<XmlToken> {
     val tokenList = mutableListOf<XmlToken>()

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderTest.kt
@@ -90,7 +90,8 @@ class XmlStreamReaderTest {
 
     @Test
     fun garbageInGarbageOut() {
-        val payload = """you try to parse me once, jokes on me..try twice jokes on you bucko.""".trimIndent().encodeToByteArray()
+        val payload =
+            """you try to parse me once, jokes on me..try twice jokes on you bucko.""".trimIndent().encodeToByteArray()
         assertFailsWith(DeserializationException::class) { xmlStreamReader(payload).allTokens() }
     }
 
@@ -377,7 +378,11 @@ class XmlStreamReaderTest {
 
         val expected = listOf(
             // root element belongs to default namespace declared
-            XmlToken.BeginElement(1, XmlToken.QualifiedName("MyStructure"), nsDeclarations = listOf(XmlToken.Namespace("http://foo.com"))),
+            XmlToken.BeginElement(
+                1,
+                XmlToken.QualifiedName("MyStructure"),
+                nsDeclarations = listOf(XmlToken.Namespace("http://foo.com")),
+            ),
             XmlToken.BeginElement(2, XmlToken.QualifiedName("foo")),
             XmlToken.Text(2, "bar"),
             XmlToken.EndElement(2, XmlToken.QualifiedName("foo")),
@@ -398,7 +403,11 @@ class XmlStreamReaderTest {
         val actual = xmlStreamReader(payload).allTokens()
 
         val expected = listOf(
-            XmlToken.BeginElement(1, XmlToken.QualifiedName("MyStructure"), nsDeclarations = listOf(XmlToken.Namespace("http://foo.com", "baz"))),
+            XmlToken.BeginElement(
+                1,
+                XmlToken.QualifiedName("MyStructure"),
+                nsDeclarations = listOf(XmlToken.Namespace("http://foo.com", "baz")),
+            ),
             XmlToken.BeginElement(2, "foo"),
             XmlToken.Text(2, "what"),
             XmlToken.EndElement(2, "foo"),
@@ -421,7 +430,11 @@ class XmlStreamReaderTest {
         val actual = xmlStreamReader(payload).allTokens()
 
         val expected = listOf(
-            XmlToken.BeginElement(1, XmlToken.QualifiedName("MyStructure"), nsDeclarations = listOf(XmlToken.Namespace("http://foo.com", "baz"))),
+            XmlToken.BeginElement(
+                1,
+                XmlToken.QualifiedName("MyStructure"),
+                nsDeclarations = listOf(XmlToken.Namespace("http://foo.com", "baz")),
+            ),
             XmlToken.BeginElement(2, "foo", attributes = mapOf(XmlToken.QualifiedName("k1", "baz") to "v1")),
             XmlToken.EndElement(2, "foo"),
             XmlToken.EndElement(1, "MyStructure"),
@@ -754,7 +767,8 @@ class XmlStreamReaderTest {
         val payload = "<a>".repeat(MAX_RECURSION_DEPTH + 1) + "</a>".repeat(MAX_RECURSION_DEPTH + 1)
         val reader = xmlStreamReader(payload.encodeToByteArray())
         assertFailsWith<DeserializationRecursionException> {
-            while (reader.nextToken() != null) {}
+            while (reader.nextToken() != null) {
+            }
         }
     }
 
@@ -762,8 +776,9 @@ class XmlStreamReaderTest {
     fun testNestingAtExactLimitSucceeds() {
         val payload = "<a>".repeat(MAX_RECURSION_DEPTH) + "</a>".repeat(MAX_RECURSION_DEPTH)
         val reader = xmlStreamReader(payload.encodeToByteArray())
-        while (reader.nextToken() != null) {}
-    }}
+        while (reader.nextToken() != null) { }
+    }
+}
 
 fun XmlStreamReader.allTokens(): List<XmlToken> {
     val tokenList = mutableListOf<XmlToken>()


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change introduces a new limit of 1,000 levels of recursion when parsing JSON, XML, and CBOR documents, providing a way to gracefully handle malformed documents which nest too deeply. While this trades one throwable (`StackOverflowError`) for another (`DeserializationRecursionException`), it prevents stack exhaustion that might otherwise bring down the whole runtime and can be caught by calling code while there's still a chance to recover.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
