### PR TITLE
fix: validate OkHttp header values do not contain CR or LF

### DIFF
--- a/.changes/3d3ef467-7538-4a74-85b8-c0c6c77f4aad.json
+++ b/.changes/3d3ef467-7538-4a74-85b8-c0c6c77f4aad.json
@@ -1,0 +1,5 @@
+{
+    "id": "3d3ef467-7538-4a74-85b8-c0c6c77f4aad",
+    "type": "bugfix",
+    "description": "Validate that OkHttp header values do not contain CR or LF"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
@@ -87,6 +87,7 @@ public fun HttpRequest.toOkHttpRequest(
 public fun Headers.toOkHttpHeaders(): OkHttpHeaders = OkHttpHeaders.Builder().also { okHeaders ->
     forEach { key, values ->
         values.forEach { value ->
+            assertValidHeader(key, value)
             okHeaders.addUnsafeNonAscii(key, value)
         }
     }
@@ -96,6 +97,10 @@ public fun Headers.toOkHttpHeaders(): OkHttpHeaders = OkHttpHeaders.Builder().al
         okHeaders.addUnsafeNonAscii("Accept-Encoding", "identity")
     }
 }.build()
+
+private fun assertValidHeader(key: String, value: String) = require('\r' !in value && '\n' !in value) {
+    "Invalid header value for \"$key\": must not contain CR or LF characters"
+}
 
 /**
  * Convert an [okhttp3.Response] to an SDK [HttpResponse]

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/HeaderTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/HeaderTest.kt
@@ -15,7 +15,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class HeaderTest : AbstractEngineTest() {
-
     // https://github.com/awslabs/aws-sdk-kotlin/issues/1163
     @Test
     fun testNonAsciiHeaderValue() = testEngines {
@@ -30,6 +29,62 @@ class HeaderTest : AbstractEngineTest() {
             val call = client.call(req)
             call.complete()
             assertEquals(HttpStatusCode.OK, call.response.status)
+        }
+    }
+
+    // tt/V2228436368/F1 - Verifies that CRLF header injection attacks fail across all engines
+    @Test
+    fun testCrlfInHeaderValueDoesNotInjectExtraHeaders() = testEngines {
+        test { _, client ->
+            val maliciousValue = "innocent\r\nx-injected-header: pwned"
+
+            val call = try {
+                client.call(
+                    HttpRequest {
+                        testSetup()
+                        url.path.decoded = "echo-headers"
+                        headers.append("x-amz-meta-note", maliciousValue)
+                    },
+                )
+            } catch (_: Exception) {
+                // If the engine rejects the header value with an exception, that's acceptable
+                return@test
+            }
+
+            try {
+                // If the request went through, verify the server did NOT see an injected header
+                val injectedCount = call.response.headers["x-injected-count"]?.toIntOrNull() ?: 0
+                assertEquals(0, injectedCount, "CRLF injection detected: server received $injectedCount injected header(s)")
+            } finally {
+                call.complete()
+            }
+        }
+    }
+
+    // tt/V2228436368/F1 - Verifies that CRLF header injection attacks fail across all engines
+    @Test
+    fun testCrlfInHeaderValueWithMultipleInjectedHeaders() = testEngines {
+        test { _, client ->
+            val maliciousValue = "innocent\r\nx-injected-one: first\r\nx-injected-two: second"
+
+            val call = try {
+                client.call(
+                    HttpRequest {
+                        testSetup()
+                        url.path.decoded = "echo-headers"
+                        headers.append("x-amz-meta-data", maliciousValue)
+                    },
+                )
+            } catch (_: Exception) {
+                return@test
+            }
+
+            try {
+                val injectedCount = call.response.headers["x-injected-count"]?.toIntOrNull() ?: 0
+                assertEquals(0, injectedCount, "CRLF injection detected: server received $injectedCount injected header(s)")
+            } finally {
+                call.complete()
+            }
         }
     }
 }

--- a/runtime/protocol/http-client-engines/test-suite/jvmAndNative/src/aws/smithy/kotlin/runtime/http/test/suite/Header.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvmAndNative/src/aws/smithy/kotlin/runtime/http/test/suite/Header.kt
@@ -16,5 +16,16 @@ internal fun Application.headerTests() {
                 call.respond(HttpStatusCode.OK)
             }
         }
+
+        route("echo-headers") {
+            get {
+                // Echo back all request headers as response headers prefixed with "x-echo-"
+                // and return the count of headers whose name starts with "x-]]" (injection marker)
+                val injectedCount = call.request.headers.names()
+                    .count { it.startsWith("x-injected", ignoreCase = true) }
+                call.response.header("x-injected-count", injectedCount.toString())
+                call.respond(HttpStatusCode.OK)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Adds verification and validation of CRLF handling in OkHttp headers. Note that the CRT engine already rejects CRLF values and does not need any changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
