### PR TITLE
fix: limit exponent expansion to prevent OOM

### DIFF
--- a/.changes/31cb979a-e70c-4d6c-b5d3-9745ee91bdd1.json
+++ b/.changes/31cb979a-e70c-4d6c-b5d3-9745ee91bdd1.json
@@ -1,0 +1,5 @@
+{
+    "id": "31cb979a-e70c-4d6c-b5d3-9745ee91bdd1",
+    "type": "bugfix",
+    "description": "Limit exponent scale to prevent OOM errors when expanding exponents"
+}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -466,6 +466,10 @@ public final class aws/smithy/kotlin/runtime/content/BigDecimal : java/lang/Numb
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class aws/smithy/kotlin/runtime/content/BigDecimalKt {
+	public static final field MAX_DECIMAL_FRACTION_EXPONENT I
+}
+
 public final class aws/smithy/kotlin/runtime/content/BigInteger : java/lang/Number, java/lang/Comparable {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> ([B)V

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigDecimal.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigDecimal.kt
@@ -108,3 +108,11 @@ public expect class BigDecimal(value: String) :
      */
     public override operator fun compareTo(other: BigDecimal): Int
 }
+
+internal fun assertExponent(value: Int) {
+    require(value in -MAX_DECIMAL_FRACTION_EXPONENT..MAX_DECIMAL_FRACTION_EXPONENT) {
+        "BigDecimal exponent $value exceeds maximum allowed magnitude of $MAX_DECIMAL_FRACTION_EXPONENT"
+    }
+}
+
+internal fun assertExponent(value: Long) = assertExponent(value.toInt())

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigDecimal.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigDecimal.kt
@@ -115,4 +115,8 @@ internal fun assertExponent(value: Int) {
     }
 }
 
-internal fun assertExponent(value: Long) = assertExponent(value.toInt())
+internal fun assertExponent(value: Long) {
+    require(value in -MAX_DECIMAL_FRACTION_EXPONENT..MAX_DECIMAL_FRACTION_EXPONENT) {
+        "BigDecimal exponent $value exceeds maximum allowed magnitude of $MAX_DECIMAL_FRACTION_EXPONENT"
+    }
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigDecimal.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/BigDecimal.kt
@@ -5,6 +5,12 @@
 package aws.smithy.kotlin.runtime.content
 
 /**
+ * Maximum allowed magnitude for a [BigDecimal] exponent. Exponents beyond this limit would cause
+ * excessive memory allocation when the value is materialized as a plain string.
+ */
+public const val MAX_DECIMAL_FRACTION_EXPONENT: Int = 1000
+
+/**
  * A floating point decimal number with arbitrary precision.
  * @param value the [String] representation of this decimal number
  */

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Parsers.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Parsers.kt
@@ -161,12 +161,17 @@ internal fun parseIso8601(input: String): ParsedDatetime {
 
 private val exponentialNotationNumber = """(-)?(\d+(.(\d+))?)E(-?\d+)""".toRegex(RegexOption.IGNORE_CASE)
 
+private const val MAX_EPOCH_EXPONENT = 20
+
 private fun expandExponent(input: String): String = exponentialNotationNumber.matchEntire(input)?.let { match ->
     val (baseSign, base, _, _, exp) = match.destructured
     buildString {
         append(baseSign)
         val (mantissa, oldDecimalPos) = base.removeChar('.')
         val shift = exp.toIntOrNull() ?: throw ParseException(input, "Failed to read exponent", 0)
+        if (shift !in -MAX_EPOCH_EXPONENT..MAX_EPOCH_EXPONENT) {
+            throw ParseException(input, "Exponent $shift exceeds maximum allowed magnitude of $MAX_EPOCH_EXPONENT", 0)
+        }
         val newDecimalPos = oldDecimalPos + shift
         val (int, frac) = mantissa.splitAt(newDecimalPos)
         append(int)

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/BigDecimalTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/BigDecimalTest.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.content
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.fail
 
 class BigDecimalTest {
     @Test
@@ -25,5 +26,46 @@ class BigDecimalTest {
     fun testEquals() {
         val value = "0.340282366920938463463374607431768211456"
         assertEquals(BigDecimal(value), BigDecimal(value))
+    }
+
+    @Test
+    fun testExponents() {
+        var counter = 0
+        data class TestCase(val value: String, val mantissa: BigInteger, val exponent: Int, val id: Int = ++counter)
+
+        val tests = listOf(
+            TestCase("0.0", BigInteger("0"), 0),
+            TestCase("1.0", BigInteger("1"), 0),
+            TestCase("10.0", BigInteger("1"), 1),
+            TestCase("11.0", BigInteger("11"), 1),
+            TestCase("0.1", BigInteger("1"), -1),
+        )
+
+        val failed = tests.flatMap { (value, mantissa, exponent, id) ->
+            val bd = BigDecimal(value)
+            listOfNotNull(
+                runCatching { assertEquals(mantissa, bd.mantissa, "#$id Wrong mantissa") }.exceptionOrNull(),
+                runCatching { assertEquals(exponent, bd.exponent, "#$id Wrong exponent") }.exceptionOrNull(),
+            )
+        }
+
+        if (failed.isNotEmpty()) {
+            val msg = failed.joinToString("\n  ", "Failed ${failed.size}/${tests.size} tests:\n  ") { it.message ?: "(null)" }
+            throw AssertionError(msg).apply {
+                failed.forEach { addSuppressed(it) }
+            }
+        }
+    }
+
+    @Test
+    fun testExponent() {
+        val mantissa = BigInteger("123456789")
+        val exponent = 10
+        val value = BigDecimal(mantissa, exponent)
+        assertEquals("1.23456789E+10", value.toString())
+        assertEquals(mantissa, value.mantissa)
+        assertEquals(10, value.exponent)
+
+        assertEquals("12345678900", value.toPlainString())
     }
 }

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
@@ -22,10 +22,17 @@ public actual class BigDecimal private constructor(private val delegate: JvmBigD
             right.delegate -> right
             else -> BigDecimal(value)
         }
+
+        fun checkedCreate(mantissa: BigInteger, exponent: Int): JvmBigDecimal {
+            require(exponent in -MAX_DECIMAL_FRACTION_EXPONENT..MAX_DECIMAL_FRACTION_EXPONENT) {
+                "BigDecimal exponent $exponent exceeds maximum allowed magnitude of $MAX_DECIMAL_FRACTION_EXPONENT"
+            }
+            return JvmBigDecimal(mantissa.delegate, exponent)
+        }
     }
 
     public actual constructor(value: String) : this(JvmBigDecimal(value))
-    public actual constructor(mantissa: BigInteger, exponent: Int) : this(JvmBigDecimal(mantissa.delegate, exponent))
+    public actual constructor(mantissa: BigInteger, exponent: Int) : this(checkedCreate(mantissa, exponent))
 
     public actual fun toPlainString(): String = delegate.toPlainString()
     public actual override fun toString(): String = delegate.toString()

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
@@ -22,15 +22,15 @@ public actual class BigDecimal private constructor(private val delegate: JvmBigD
             right.delegate -> right
             else -> BigDecimal(value)
         }
-
-        fun checkedCreate(mantissa: BigInteger, exponent: Int): JvmBigDecimal {
-            assertExponent(exponent)
-            return JvmBigDecimal(mantissa.delegate, exponent)
-        }
     }
 
     public actual constructor(value: String) : this(JvmBigDecimal(value))
-    public actual constructor(mantissa: BigInteger, exponent: Int) : this(checkedCreate(mantissa, exponent))
+    public actual constructor(mantissa: BigInteger, exponent: Int) : this(
+        JvmBigDecimal(
+            mantissa.delegate,
+            mantissa.delegate.abs().toString().length - 1 - exponent,
+        ),
+    )
 
     init {
         assertExponent(delegate.scale())
@@ -45,14 +45,19 @@ public actual class BigDecimal private constructor(private val delegate: JvmBigD
     public actual override fun toLong(): Long = delegate.toLong()
     public actual override fun toShort(): Short = delegate.toShort()
 
-    public actual override fun equals(other: Any?): Boolean = other is BigDecimal && delegate == other.delegate
+    public actual override fun equals(other: Any?): Boolean = other is BigDecimal && (delegate.compareTo(other.delegate) == 0)
+
     public actual override fun hashCode(): Int = 31 + delegate.hashCode()
 
+    private val stripped: JvmBigDecimal by lazy {
+        if (delegate.signum() == 0) JvmBigDecimal.ZERO else delegate.stripTrailingZeros()
+    }
+
     public actual val mantissa: BigInteger
-        get() = BigInteger(delegate.unscaledValue())
+        get() = BigInteger(stripped.unscaledValue())
 
     public actual val exponent: Int
-        get() = delegate.scale()
+        get() = if (delegate.signum() == 0) 0 else stripped.unscaledValue().abs().toString().length - 1 - stripped.scale()
 
     public val value: String = delegate.toString()
 
@@ -61,10 +66,4 @@ public actual class BigDecimal private constructor(private val delegate: JvmBigD
     public actual operator fun minus(other: BigDecimal): BigDecimal = coalesceOrCreate(delegate - other.delegate, this, other)
 
     actual override fun compareTo(other: BigDecimal): Int = delegate.compareTo(other.delegate)
-}
-
-private fun assertExponent(value: Int) {
-    require(value in -MAX_DECIMAL_FRACTION_EXPONENT..MAX_DECIMAL_FRACTION_EXPONENT) {
-        "BigDecimal exponent $value exceeds maximum allowed magnitude of $MAX_DECIMAL_FRACTION_EXPONENT"
-    }
 }

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
@@ -47,17 +47,17 @@ public actual class BigDecimal private constructor(private val delegate: JvmBigD
 
     public actual override fun equals(other: Any?): Boolean = other is BigDecimal && (delegate.compareTo(other.delegate) == 0)
 
-    public actual override fun hashCode(): Int = 31 + delegate.hashCode()
+    public actual override fun hashCode(): Int = 31 * normalized.hashCode()
 
-    private val stripped: JvmBigDecimal by lazy {
+    private val normalized: JvmBigDecimal by lazy {
         if (delegate.signum() == 0) JvmBigDecimal.ZERO else delegate.stripTrailingZeros()
     }
 
     public actual val mantissa: BigInteger
-        get() = BigInteger(stripped.unscaledValue())
+        get() = BigInteger(normalized.unscaledValue())
 
     public actual val exponent: Int
-        get() = if (delegate.signum() == 0) 0 else stripped.unscaledValue().abs().toString().length - 1 - stripped.scale()
+        get() = if (delegate.signum() == 0) 0 else normalized.unscaledValue().abs().toString().length - 1 - normalized.scale()
 
     public val value: String = delegate.toString()
 
@@ -65,5 +65,5 @@ public actual class BigDecimal private constructor(private val delegate: JvmBigD
 
     public actual operator fun minus(other: BigDecimal): BigDecimal = coalesceOrCreate(delegate - other.delegate, this, other)
 
-    actual override fun compareTo(other: BigDecimal): Int = delegate.compareTo(other.delegate)
+    actual override fun compareTo(other: BigDecimal): Int = normalized.compareTo(other.normalized)
 }

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/BigDecimalJVM.kt
@@ -24,15 +24,17 @@ public actual class BigDecimal private constructor(private val delegate: JvmBigD
         }
 
         fun checkedCreate(mantissa: BigInteger, exponent: Int): JvmBigDecimal {
-            require(exponent in -MAX_DECIMAL_FRACTION_EXPONENT..MAX_DECIMAL_FRACTION_EXPONENT) {
-                "BigDecimal exponent $exponent exceeds maximum allowed magnitude of $MAX_DECIMAL_FRACTION_EXPONENT"
-            }
+            assertExponent(exponent)
             return JvmBigDecimal(mantissa.delegate, exponent)
         }
     }
 
     public actual constructor(value: String) : this(JvmBigDecimal(value))
     public actual constructor(mantissa: BigInteger, exponent: Int) : this(checkedCreate(mantissa, exponent))
+
+    init {
+        assertExponent(delegate.scale())
+    }
 
     public actual fun toPlainString(): String = delegate.toPlainString()
     public actual override fun toString(): String = delegate.toString()
@@ -59,4 +61,10 @@ public actual class BigDecimal private constructor(private val delegate: JvmBigD
     public actual operator fun minus(other: BigDecimal): BigDecimal = coalesceOrCreate(delegate - other.delegate, this, other)
 
     actual override fun compareTo(other: BigDecimal): Int = delegate.compareTo(other.delegate)
+}
+
+private fun assertExponent(value: Int) {
+    require(value in -MAX_DECIMAL_FRACTION_EXPONENT..MAX_DECIMAL_FRACTION_EXPONENT) {
+        "BigDecimal exponent $value exceeds maximum allowed magnitude of $MAX_DECIMAL_FRACTION_EXPONENT"
+    }
 }

--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigDecimalNative.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigDecimalNative.kt
@@ -22,12 +22,18 @@ public actual class BigDecimal private constructor(private val delegate: IonSpin
             right.delegate -> right
             else -> BigDecimal(value)
         }
+
+        fun checkedCreate(mantissa: BigInteger, exponent: Int): IonSpinBigDecimal {
+            require(exponent in -MAX_DECIMAL_FRACTION_EXPONENT..MAX_DECIMAL_FRACTION_EXPONENT) {
+                "BigDecimal exponent $exponent exceeds maximum allowed magnitude of $MAX_DECIMAL_FRACTION_EXPONENT"
+            }
+            return IonSpinBigDecimal.fromBigIntegerWithExponent(mantissa.delegate, exponent.toLong())
+        }
     }
 
     public actual constructor(value: String) : this(IonSpinBigDecimal.parseString(value, 10))
 
-    public actual constructor(mantissa: BigInteger, exponent: Int) :
-        this(IonSpinBigDecimal.fromBigIntegerWithExponent(mantissa.delegate, exponent.toLong()))
+    public actual constructor(mantissa: BigInteger, exponent: Int) : this(checkedCreate(mantissa, exponent))
 
     actual override fun toByte(): Byte = delegate.byteValue(exactRequired = false)
     actual override fun toDouble(): Double = delegate.doubleValue(exactRequired = false)

--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigDecimalNative.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigDecimalNative.kt
@@ -61,9 +61,9 @@ public actual class BigDecimal private constructor(private val delegate: IonSpin
     public actual val exponent: Int
         get() = normalized.exponent.toInt()
 
-    actual override fun compareTo(other: BigDecimal): Int = delegate.compare(other.delegate)
+    actual override fun compareTo(other: BigDecimal): Int = normalized.compare(other.normalized)
     public actual override fun equals(other: Any?): Boolean = other is BigDecimal && (delegate.compareTo(other.delegate) == 0)
-    actual override fun hashCode(): Int = 31 + delegate.hashCode()
+    actual override fun hashCode(): Int = 31 * normalized.hashCode()
     public actual fun toPlainString(): String = delegate.toPlainString()
     actual override fun toString(): String = delegate.toString()
 

--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigDecimalNative.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/content/BigDecimalNative.kt
@@ -5,6 +5,7 @@
 package aws.smithy.kotlin.runtime.content
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal as IonSpinBigDecimal
+import com.ionspin.kotlin.bignum.integer.BigInteger as IonSpinBigInteger
 
 public actual class BigDecimal private constructor(private val delegate: IonSpinBigDecimal) :
     Number(),
@@ -22,18 +23,30 @@ public actual class BigDecimal private constructor(private val delegate: IonSpin
             right.delegate -> right
             else -> BigDecimal(value)
         }
-
-        fun checkedCreate(mantissa: BigInteger, exponent: Int): IonSpinBigDecimal {
-            require(exponent in -MAX_DECIMAL_FRACTION_EXPONENT..MAX_DECIMAL_FRACTION_EXPONENT) {
-                "BigDecimal exponent $exponent exceeds maximum allowed magnitude of $MAX_DECIMAL_FRACTION_EXPONENT"
-            }
-            return IonSpinBigDecimal.fromBigIntegerWithExponent(mantissa.delegate, exponent.toLong())
-        }
     }
 
     public actual constructor(value: String) : this(IonSpinBigDecimal.parseString(value, 10))
 
-    public actual constructor(mantissa: BigInteger, exponent: Int) : this(checkedCreate(mantissa, exponent))
+    public actual constructor(mantissa: BigInteger, exponent: Int) : this(
+        IonSpinBigDecimal.fromBigIntegerWithExponent(mantissa.delegate, exponent.toLong()),
+    )
+
+    private val normalized by lazy {
+        if (delegate.significand.isZero()) {
+            delegate
+        } else {
+            val sig = delegate.significand
+            var stripped = sig
+            while (stripped.mod(IonSpinBigInteger.TEN) == IonSpinBigInteger.ZERO && !stripped.isZero()) {
+                stripped = stripped.div(IonSpinBigInteger.TEN)
+            }
+            IonSpinBigDecimal.fromBigIntegerWithExponent(stripped, delegate.exponent)
+        }
+    }
+
+    init {
+        assertExponent(exponent)
+    }
 
     actual override fun toByte(): Byte = delegate.byteValue(exactRequired = false)
     actual override fun toDouble(): Double = delegate.doubleValue(exactRequired = false)
@@ -43,13 +56,13 @@ public actual class BigDecimal private constructor(private val delegate: IonSpin
     actual override fun toShort(): Short = delegate.shortValue(exactRequired = false)
 
     public actual val mantissa: BigInteger
-        get() = BigInteger(delegate.significand)
+        get() = BigInteger(normalized.significand)
 
     public actual val exponent: Int
-        get() = delegate.exponent.toInt()
+        get() = normalized.exponent.toInt()
 
     actual override fun compareTo(other: BigDecimal): Int = delegate.compare(other.delegate)
-    actual override fun equals(other: Any?): Boolean = other is BigDecimal && other.delegate == delegate
+    public actual override fun equals(other: Any?): Boolean = other is BigDecimal && (delegate.compareTo(other.delegate) == 0)
     actual override fun hashCode(): Int = 31 + delegate.hashCode()
     public actual fun toPlainString(): String = delegate.toPlainString()
     actual override fun toString(): String = delegate.toString()

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Tag.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Tag.kt
@@ -183,7 +183,11 @@ internal class DecimalFraction(val value: BigDecimal) : Value {
                 else -> throw DeserializationException("Expected integer for CBOR decimal fraction exponent value, got $exponentValue.")
             }
 
-            return DecimalFraction(BigDecimal(mantissa, -exponent))
+            return try {
+                DecimalFraction(BigDecimal(mantissa, -exponent))
+            } catch (iae: IllegalArgumentException) {
+                throw DeserializationException("Cannot deserialize unsupported BigDecimal value", iae)
+            }
         }
     }
 }

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerErrorTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerErrorTest.kt
@@ -5,6 +5,7 @@
 package aws.smithy.kotlin.runtime.serde.cbor
 
 import aws.smithy.kotlin.runtime.io.SdkBuffer
+import aws.smithy.kotlin.runtime.serde.DeserializationException
 import aws.smithy.kotlin.runtime.serde.SdkFieldDescriptor
 import aws.smithy.kotlin.runtime.serde.SerialKind
 import aws.smithy.kotlin.runtime.serde.cbor.encoding.Tag
@@ -781,7 +782,7 @@ class CborDeserializerErrorTest {
         val buffer = SdkBuffer().apply { write(payload) }
         val deserializer = CborPrimitiveDeserializer(buffer)
 
-        assertFailsWith<Exception> {
+        assertFailsWith<DeserializationException> {
             val result = deserializer.deserializeBigDecimal()
             // If deserialization doesn't reject it, toPlainString() will OOM
             result.toPlainString()

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerErrorTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerErrorTest.kt
@@ -777,15 +777,24 @@ class CborDeserializerErrorTest {
      */
     @Test
     fun testDecimalFractionExponentDoesNotOom() {
-        val payload = "0xc4821a3b9ac9ff01".toByteArray()
+        val payloads = listOf(
+            "0xc48219270f01", // 1E9999
+            "0xc4821a0001869f01", // 1E99999
+            "0xc4821a000f423f01", // 1E999999
+            "0xc4821a0098967f01", // 1E9999999
+            "0xc4821a05f5e0ff01", // 1E99999999
+            "0xc4821a3b9ac9ff01", // 1E999999999
+        ).map { it.toByteArray() }
 
-        val buffer = SdkBuffer().apply { write(payload) }
-        val deserializer = CborPrimitiveDeserializer(buffer)
+        payloads.forEach { payload ->
+            val buffer = SdkBuffer().apply { write(payload) }
+            val deserializer = CborPrimitiveDeserializer(buffer)
 
-        assertFailsWith<DeserializationException> {
-            val result = deserializer.deserializeBigDecimal()
-            // If deserialization doesn't reject it, toPlainString() will OOM
-            result.toPlainString()
+            assertFailsWith<DeserializationException> {
+                val result = deserializer.deserializeBigDecimal()
+                // If deserialization doesn't reject it, toPlainString() will OOM
+                result.toPlainString()
+            }
         }
     }
 }

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerErrorTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerErrorTest.kt
@@ -12,6 +12,7 @@ import aws.smithy.kotlin.runtime.serde.deserializeList
 import aws.smithy.kotlin.runtime.serde.deserializeMap
 import kotlin.test.Test
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class CborDeserializerErrorTest {
     @Test
@@ -764,6 +765,26 @@ class CborDeserializerErrorTest {
 
         assertFails {
             Tag.decode(buffer)
+        }
+    }
+
+    /**
+     * tt/V2228436368/F20: CBOR decimal fraction (tag 4) with exponent 999999999 and mantissa 1 should not create a
+     * [BigDecimal][aws.smithy.kotlin.runtime.content.BigDecimal] with huge scale that causes OOM when `toPlainString`
+     * is invoked. Instead, the deserializer should reject exponents this large rather than creating a dangerous
+     * `BigDecimal`.
+     */
+    @Test
+    fun testDecimalFractionExponentDoesNotOom() {
+        val payload = "0xc4821a3b9ac9ff01".toByteArray()
+
+        val buffer = SdkBuffer().apply { write(payload) }
+        val deserializer = CborPrimitiveDeserializer(buffer)
+
+        assertFailsWith<Exception> {
+            val result = deserializer.deserializeBigDecimal()
+            // If deserialization doesn't reject it, toPlainString() will OOM
+            result.toPlainString()
         }
     }
 }

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborSerializerTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborSerializerTest.kt
@@ -201,7 +201,7 @@ class CborSerializerTest {
 
     @Test
     fun testBigDecimal() {
-        val tests = listOf<BigDecimal>(
+        val tests = listOf(
             BigDecimal("-123453450934503474823945734895.4563458734895738978902384902384908"),
             BigDecimal("-123.456"),
             BigDecimal("-0.000000000000000000000000000000000000000000000000000000000000000000000000000000000001"),
@@ -229,7 +229,8 @@ class CborSerializerTest {
         val deserializer = CborPrimitiveDeserializer(buffer)
 
         tests.forEach {
-            assertEquals(it, deserializer.deserializeBigDecimal())
+            val actual = deserializer.deserializeBigDecimal()
+            assertEquals(it, actual)
         }
         assertEquals(0, buffer.size)
 

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
@@ -11,6 +11,7 @@ import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.serde.*
 import aws.smithy.kotlin.runtime.text.encoding.decodeBase64Bytes
 import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.ParseException
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 
 /**
@@ -144,11 +145,15 @@ public class JsonDeserializer(payload: ByteArray) :
 
     override fun deserializeByteArray(): ByteArray = deserializeString().decodeBase64Bytes()
 
-    override fun deserializeInstant(format: TimestampFormat): Instant = when (format) {
-        TimestampFormat.EPOCH_SECONDS -> deserializeString().let { Instant.fromEpochSeconds(it) }
-        TimestampFormat.ISO_8601 -> deserializeString().let { Instant.fromIso8601(it) }
-        TimestampFormat.RFC_5322 -> deserializeString().let { Instant.fromRfc5322(it) }
-        else -> throw DeserializationException("unknown timestamp format: $format")
+    override fun deserializeInstant(format: TimestampFormat): Instant = try {
+        when (format) {
+            TimestampFormat.EPOCH_SECONDS -> deserializeString().let { Instant.fromEpochSeconds(it) }
+            TimestampFormat.ISO_8601 -> deserializeString().let { Instant.fromIso8601(it) }
+            TimestampFormat.RFC_5322 -> deserializeString().let { Instant.fromRfc5322(it) }
+            else -> throw DeserializationException("unknown timestamp format: $format")
+        }
+    } catch (pe: ParseException) {
+        throw DeserializationException("Cannot deserialize unsupported timestamp format", pe)
     }
 
     override fun nextHasValue(): Boolean = reader.peek() != JsonToken.Null

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
@@ -153,7 +153,7 @@ public class JsonDeserializer(payload: ByteArray) :
             else -> throw DeserializationException("unknown timestamp format: $format")
         }
     } catch (pe: ParseException) {
-        throw DeserializationException("Cannot deserialize unsupported timestamp format", pe)
+        throw DeserializationException("Cannot deserialize timestamp value", pe)
     }
 
     override fun nextHasValue(): Boolean = reader.peek() != JsonToken.Null

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
@@ -829,7 +829,7 @@ class JsonDeserializerTest {
     fun testEpochExponentDoesNotOOM() {
         val payload = "\"1e999999999\"".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
-        assertFailsWith<Exception> {
+        assertFailsWith<DeserializationException> {
             deserializer.deserializeInstant(TimestampFormat.EPOCH_SECONDS)
         }
     }

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.serde.json
 import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.content.buildDocument
 import aws.smithy.kotlin.runtime.serde.*
+import aws.smithy.kotlin.runtime.time.TimestampFormat
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.maps.shouldContainExactly
 import kotlin.math.abs
@@ -819,5 +820,17 @@ class JsonDeserializerTest {
         }
 
         testDeserializeDocument(doc, expected)
+    }
+
+    /**
+     * tt/V2228436368/F20: "1e999999999" in an epoch-seconds field should not be expanded and cause OOM
+     */
+    @Test
+    fun testEpochExponentDoesNotOOM() {
+        val payload = "\"1e999999999\"".encodeToByteArray()
+        val deserializer = JsonDeserializer(payload)
+        assertFailsWith<Exception> {
+            deserializer.deserializeInstant(TimestampFormat.EPOCH_SECONDS)
+        }
     }
 }

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlPrimitiveDeserializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlPrimitiveDeserializer.kt
@@ -10,6 +10,7 @@ import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.serde.*
 import aws.smithy.kotlin.runtime.text.encoding.decodeBase64Bytes
 import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.ParseException
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 
 /**
@@ -75,10 +76,14 @@ internal class XmlPrimitiveDeserializer(private val reader: XmlStreamReader, pri
 
     override fun deserializeByteArray(): ByteArray = deserializeString().decodeBase64Bytes()
 
-    override fun deserializeInstant(format: TimestampFormat): Instant = when (format) {
-        TimestampFormat.EPOCH_SECONDS -> deserializeString().let { Instant.fromEpochSeconds(it) }
-        TimestampFormat.ISO_8601 -> deserializeString().let { Instant.fromIso8601(it) }
-        TimestampFormat.RFC_5322 -> deserializeString().let { Instant.fromRfc5322(it) }
-        else -> throw DeserializationException("unknown timestamp format: $format")
+    override fun deserializeInstant(format: TimestampFormat): Instant = try {
+        when (format) {
+            TimestampFormat.EPOCH_SECONDS -> deserializeString().let { Instant.fromEpochSeconds(it) }
+            TimestampFormat.ISO_8601 -> deserializeString().let { Instant.fromIso8601(it) }
+            TimestampFormat.RFC_5322 -> deserializeString().let { Instant.fromRfc5322(it) }
+            else -> throw DeserializationException("unknown timestamp format: $format")
+        }
+    } catch (pe: ParseException) {
+        throw DeserializationException("Cannot deserialize unsupported timestamp format", pe)
     }
 }

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlTagReaderTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlTagReaderTest.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.serde.xml
 
+import aws.smithy.kotlin.runtime.serde.DeserializationException
 import aws.smithy.kotlin.runtime.serde.SdkFieldDescriptor
 import aws.smithy.kotlin.runtime.serde.SerialKind
 import aws.smithy.kotlin.runtime.serde.parseInt
@@ -147,7 +148,7 @@ class XmlTagReaderTest {
         val payload = "<Timestamp>1e999999999</Timestamp>".encodeToByteArray()
         val fieldDescriptor = SdkFieldDescriptor(SerialKind.Timestamp, XmlSerialName("Timestamp"))
         val deserializer = XmlPrimitiveDeserializer(payload, fieldDescriptor)
-        assertFailsWith<Exception> {
+        assertFailsWith<DeserializationException> {
             deserializer.deserializeInstant(TimestampFormat.EPOCH_SECONDS)
         }
     }

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlTagReaderTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlTagReaderTest.kt
@@ -4,7 +4,10 @@
  */
 package aws.smithy.kotlin.runtime.serde.xml
 
+import aws.smithy.kotlin.runtime.serde.SdkFieldDescriptor
+import aws.smithy.kotlin.runtime.serde.SerialKind
 import aws.smithy.kotlin.runtime.serde.parseInt
+import aws.smithy.kotlin.runtime.time.TimestampFormat
 import kotlin.test.*
 
 class XmlTagReaderTest {
@@ -132,6 +135,20 @@ class XmlTagReaderTest {
             }
             // consume the current tag entirely before trying to process the next
             curr.drop()
+        }
+    }
+
+    /**
+     * tt/V2228436368/F20: "1e999999999" in an epoch-seconds XML text node should not be expanded and cause OOM
+     */
+    @Test
+    fun testEpochExponentDoesNotOOM() {
+        // F20: "1e999999999" in an epoch-seconds XML text node triggers expandExponent() → padEnd(999999999, '0') → OOM
+        val payload = "<Timestamp>1e999999999</Timestamp>".encodeToByteArray()
+        val fieldDescriptor = SdkFieldDescriptor(SerialKind.Timestamp, XmlSerialName("Timestamp"))
+        val deserializer = XmlPrimitiveDeserializer(payload, fieldDescriptor)
+        assertFailsWith<Exception> {
+            deserializer.deserializeInstant(TimestampFormat.EPOCH_SECONDS)
         }
     }
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change limits exponent expansion to prevent out-of-memory errors on numerical types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
