### PR TITLE
feat: add support for `@requiresLength` trait

### DIFF
--- a/.changes/f5b78bb8-2279-4c39-a981-107be08e1925.json
+++ b/.changes/f5b78bb8-2279-4c39-a981-107be08e1925.json
@@ -1,0 +1,8 @@
+{
+    "id": "f5b78bb8-2279-4c39-a981-107be08e1925",
+    "type": "feature",
+    "description": "Add support for Smithy's [`@requiresLength`](https://smithy.io/2.0/spec/streaming.html#smithy-api-requireslength-trait) and verify that annotated blob shapes include a `Content-Length`",
+    "issues": [
+        "https://github.com/smithy-lang/smithy-kotlin/issues/363"
+    ]
+}

--- a/codegen/codegen/api/codegen.api
+++ b/codegen/codegen/api/codegen.api
@@ -834,6 +834,7 @@ public final class aws/smithy/kotlin/codegen/core/RuntimeTypes$HttpClient$Interc
 	public final fun getHttpChecksumRequiredInterceptor ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getHttpInterceptor ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getRequestCompressionInterceptor ()Lsoftware/amazon/smithy/codegen/core/Symbol;
+	public final fun getRequiresLengthInterceptor ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getResponseLengthValidationInterceptor ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getSmokeTestsFailureException ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getSmokeTestsInterceptor ()Lsoftware/amazon/smithy/codegen/core/Symbol;
@@ -2540,6 +2541,21 @@ public final class aws/smithy/kotlin/codegen/rendering/protocol/ProtocolMiddlewa
 
 public final class aws/smithy/kotlin/codegen/rendering/protocol/ProtocolMiddlewareKt {
 	public static final fun replace (Ljava/util/List;Laws/smithy/kotlin/codegen/rendering/protocol/ProtocolMiddleware;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class aws/smithy/kotlin/codegen/rendering/protocol/RequiresLengthIntegration : aws/smithy/kotlin/codegen/integration/KotlinIntegration {
+	public fun <init> ()V
+	public fun additionalServiceConfigProps (Laws/smithy/kotlin/codegen/core/CodegenContext;)Ljava/util/List;
+	public fun authSchemes (Laws/smithy/kotlin/codegen/rendering/protocol/ProtocolGenerator$GenerationContext;)Ljava/util/List;
+	public fun customizeEndpointResolution (Laws/smithy/kotlin/codegen/rendering/protocol/ProtocolGenerator$GenerationContext;)Laws/smithy/kotlin/codegen/rendering/endpoints/EndpointCustomization;
+	public fun customizeMiddleware (Laws/smithy/kotlin/codegen/rendering/protocol/ProtocolGenerator$GenerationContext;Ljava/util/List;)Ljava/util/List;
+	public fun decorateSymbolProvider (Laws/smithy/kotlin/codegen/KotlinSettings;Lsoftware/amazon/smithy/model/Model;Lsoftware/amazon/smithy/codegen/core/SymbolProvider;)Lsoftware/amazon/smithy/codegen/core/SymbolProvider;
+	public fun enabledForService (Lsoftware/amazon/smithy/model/Model;Laws/smithy/kotlin/codegen/KotlinSettings;)Z
+	public fun getOrder ()B
+	public fun getProtocolGenerators ()Ljava/util/List;
+	public fun getSectionWriters ()Ljava/util/List;
+	public fun preprocessModel (Lsoftware/amazon/smithy/model/Model;Laws/smithy/kotlin/codegen/KotlinSettings;)Lsoftware/amazon/smithy/model/Model;
+	public fun writeAdditionalFiles (Laws/smithy/kotlin/codegen/core/CodegenContext;Laws/smithy/kotlin/codegen/core/KotlinDelegator;)V
 }
 
 public final class aws/smithy/kotlin/codegen/rendering/protocol/TestContainmentMode : java/lang/Enum {

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -88,6 +88,7 @@ object RuntimeTypes {
             val FlexibleChecksumsResponseInterceptor = symbol("FlexibleChecksumsResponseInterceptor")
             val ResponseLengthValidationInterceptor = symbol("ResponseLengthValidationInterceptor")
             val RequestCompressionInterceptor = symbol("RequestCompressionInterceptor")
+            val RequiresLengthInterceptor = symbol("RequiresLengthInterceptor")
             val SmokeTestsInterceptor = symbol("SmokeTestsInterceptor")
             val SmokeTestsFailureException = symbol("SmokeTestsFailureException")
             val SmokeTestsSuccessException = symbol("SmokeTestsSuccessException")

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/RequiresLengthIntegration.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/RequiresLengthIntegration.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.codegen.rendering.protocol
+
+import aws.smithy.kotlin.codegen.KotlinSettings
+import aws.smithy.kotlin.codegen.core.KotlinWriter
+import aws.smithy.kotlin.codegen.core.RuntimeTypes
+import aws.smithy.kotlin.codegen.integration.KotlinIntegration
+import aws.smithy.kotlin.codegen.model.hasTrait
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.traits.RequiresLengthTrait
+import software.amazon.smithy.model.traits.StreamingTrait
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * Adds the [RequiresLengthInterceptor] to operations whose input contains a streaming member
+ * targeting a blob with the `@requiresLength` trait.
+ */
+class RequiresLengthIntegration : KotlinIntegration {
+    override fun enabledForService(model: Model, settings: KotlinSettings): Boolean = model
+        .isTraitApplied(RequiresLengthTrait::class.java)
+
+    override fun customizeMiddleware(
+        ctx: ProtocolGenerator.GenerationContext,
+        resolved: List<ProtocolMiddleware>,
+    ): List<ProtocolMiddleware> = resolved + RequiresLengthMiddleware
+}
+
+private object RequiresLengthMiddleware : ProtocolMiddleware {
+    override val name: String = "RequiresLengthMiddleware"
+
+    override fun isEnabledFor(ctx: ProtocolGenerator.GenerationContext, op: OperationShape): Boolean {
+        val input = op.input.orElse(null) ?: return false
+        val inputShape = ctx.model.expectShape(input, StructureShape::class.java)
+        return inputShape.members().any { member ->
+            val target = ctx.model.expectShape(member.target)
+            target.hasTrait<StreamingTrait>() && target.hasTrait<RequiresLengthTrait>()
+        }
+    }
+
+    override fun render(ctx: ProtocolGenerator.GenerationContext, op: OperationShape, writer: KotlinWriter) {
+        writer.write("op.interceptors.add(#T())", RuntimeTypes.HttpClient.Interceptors.RequiresLengthInterceptor)
+    }
+}

--- a/codegen/codegen/src/main/resources/META-INF/services/aws.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/codegen/codegen/src/main/resources/META-INF/services/aws.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -14,5 +14,6 @@ aws.smithy.kotlin.codegen.rendering.compression.RequestCompressionIntegration
 aws.smithy.kotlin.codegen.rendering.auth.SigV4AsymmetricAuthSchemeIntegration
 aws.smithy.kotlin.codegen.rendering.smoketests.SmokeTestsIntegration
 aws.smithy.kotlin.codegen.rendering.checksums.HttpChecksumRequiredIntegration
+aws.smithy.kotlin.codegen.rendering.protocol.RequiresLengthIntegration
 aws.smithy.kotlin.codegen.ProtocolGeneratorSupplier
 aws.smithy.kotlin.codegen.rendering.longpoll.LongPollingIntegration

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/RequiresLengthIntegrationTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/RequiresLengthIntegrationTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.codegen.rendering.protocol
+
+import aws.smithy.kotlin.codegen.core.KotlinWriter
+import aws.smithy.kotlin.codegen.test.*
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+class RequiresLengthIntegrationTest {
+    private val modelWithRequiresLength = """
+        @http(method: "PUT", uri: "/upload")
+        operation Upload {
+            input: UploadInput
+        }
+
+        structure UploadInput {
+            @httpPayload
+            @required
+            body: FiniteStreamingBlob
+        }
+
+        @streaming
+        @requiresLength
+        blob FiniteStreamingBlob
+    """.prependNamespaceAndService(
+        protocol = AwsProtocolModelDeclaration.REST_JSON,
+        operations = listOf("Upload"),
+    ).toSmithyModel()
+
+    private val modelWithoutRequiresLength = """
+        @http(method: "PUT", uri: "/upload")
+        operation Upload {
+            input: UploadInput
+        }
+
+        structure UploadInput {
+            @httpPayload
+            @required
+            body: StreamingBlob
+        }
+
+        @streaming
+        blob StreamingBlob
+    """.prependNamespaceAndService(
+        protocol = AwsProtocolModelDeclaration.REST_JSON,
+        operations = listOf("Upload"),
+    ).toSmithyModel()
+
+    @Test
+    fun `it adds RequiresLengthInterceptor for operations with requiresLength`() {
+        val ctx = modelWithRequiresLength.newTestContext(integrations = listOf(RequiresLengthIntegration()))
+        val writer = KotlinWriter(TestModelDefault.NAMESPACE)
+        val httpGenerator = ctx.generator as HttpBindingProtocolGenerator
+        val generator = TestProtocolClientGenerator(
+            ctx.generationCtx,
+            httpGenerator.getHttpMiddleware(ctx.generationCtx),
+            HttpTraitResolver(ctx.generationCtx, "application/json"),
+        )
+        generator.render(writer)
+        val contents = writer.toString()
+        assertContains(contents, "RequiresLengthInterceptor()")
+    }
+
+    @Test
+    fun `it does not add RequiresLengthInterceptor without requiresLength`() {
+        val ctx = modelWithoutRequiresLength.newTestContext(integrations = listOf(RequiresLengthIntegration()))
+        val writer = KotlinWriter(TestModelDefault.NAMESPACE)
+        val httpGenerator = ctx.generator as HttpBindingProtocolGenerator
+        val generator = TestProtocolClientGenerator(
+            ctx.generationCtx,
+            httpGenerator.getHttpMiddleware(ctx.generationCtx),
+            HttpTraitResolver(ctx.generationCtx, "application/json"),
+        )
+        generator.render(writer)
+        val contents = writer.toString()
+        assertFalse(contents.contains("RequiresLengthInterceptor"))
+    }
+}

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -411,6 +411,29 @@ public final class aws/smithy/kotlin/runtime/http/interceptors/RequestCompressio
 	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
 }
 
+public final class aws/smithy/kotlin/runtime/http/interceptors/RequiresLengthInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
+	public fun <init> ()V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
 public final class aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
 	public fun <init> ()V
 	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/RequiresLengthInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/RequiresLengthInterceptor.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+
+/**
+ * An interceptor that validates the request body has a known content length.
+ * This is used for operations with streaming input members marked with the `@requiresLength` trait.
+ */
+@InternalApi
+public class RequiresLengthInterceptor : HttpInterceptor {
+    override suspend fun modifyBeforeSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
+        val req = context.protocolRequest
+        if (req.body.contentLength == null) {
+            throw ClientException("Operation requires a content length but the request body size is unknown. Provide a ByteStream with a known contentLength.")
+        }
+        return req
+    }
+}

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/RequiresLengthInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/RequiresLengthInterceptorTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
+import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.HttpMethod
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.url
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.net.url.Url
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+class RequiresLengthInterceptorTest {
+    private fun context(request: HttpRequest) = object : ProtocolRequestInterceptorContext<Any, HttpRequest> {
+        override val protocolRequest: HttpRequest = request
+        override val executionContext: ExecutionContext get() = error("Shouldn't be called")
+        override val request: Any get() = error("Shouldn't be called")
+    }
+
+    private fun request(contentLength: Long?) = HttpRequest {
+        method = HttpMethod.PUT
+        url(Url.parse("https://localhost"))
+        body = object : HttpBody.SourceContent() {
+            override val contentLength: Long? = contentLength
+            override fun readFrom(): SdkSource = error("Shouldn't be called")
+        }
+    }
+
+    @Test
+    fun testThrowsWhenContentLengthNull() = runTest {
+        val req = request(null)
+        val interceptor = RequiresLengthInterceptor()
+        assertFailsWith<ClientException> {
+            interceptor.modifyBeforeSigning(context(req))
+        }
+    }
+
+    @Test
+    fun testPassesWhenContentLengthSet() = runTest {
+        val req = request(1024)
+        val interceptor = RequiresLengthInterceptor()
+        val result = interceptor.modifyBeforeSigning(context(req))
+        assertSame(req, result)
+    }
+}


### PR DESCRIPTION
## Issue \#

Closes #363 

## Description of changes

This change adds support for [Smithy's `@requiresLength` trait](https://smithy.io/2.0/spec/streaming.html#smithy-api-requireslength-trait) by way of a new interceptor that ensures the body `ByteStream` has a non-null `contentLength`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
