### PR TITLE
fix CRT

### DIFF
--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -188,16 +188,8 @@ internal class SdkStreamResponseHandler(
     }
 
     override fun onResponseComplete(stream: HttpStream, errorCode: Int) {
-        // stream is only valid until the end of this callback, ensure any further data being read downstream
-        // doesn't call incrementWindow on a resource that has been free'd
-        lock.withLock {
-            crtStream?.close()
-            crtStream = null
-            streamCompleted = true
-        }
-        stream.close()
-
-        // close the body channel
+        // close the body channel and signal response BEFORE closing the stream,
+        // since signalResponse needs to read stream.responseStatusCode
         if (errorCode != 0) {
             val ex = crtException(errorCode)
             responseReady.close(ex)
@@ -208,6 +200,15 @@ internal class SdkStreamResponseHandler(
             // ensure a response was signalled (will close the channel on it's own if it wasn't already sent)
             signalResponse(stream)
         }
+
+        // stream is only valid until the end of this callback, ensure any further data being read downstream
+        // doesn't call incrementWindow on a resource that has been freed
+        lock.withLock {
+            crtStream?.close()
+            crtStream = null
+            streamCompleted = true
+        }
+        stream.close()
     }
 
     internal suspend fun waitForResponse(): HttpResponse = responseReady.receive()

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
@@ -22,8 +22,16 @@ import kotlinx.coroutines.yield
 import kotlin.test.*
 
 class SdkStreamResponseHandlerTest {
-    private class MockHttpStream(override val responseStatusCode: Int) : HttpStream {
+    private class MockHttpStream(private val statusCode: Int) : HttpStream {
         var closed: Boolean = false
+        var statusReadAfterClose: Boolean = false
+
+        override val responseStatusCode: Int
+            get() {
+                if (closed) statusReadAfterClose = true
+                return statusCode
+            }
+
         override fun activate() {}
         override suspend fun writeChunk(chunkData: ByteArray, isFinalChunk: Boolean) {
             TODO("Not yet implemented")
@@ -83,6 +91,22 @@ class SdkStreamResponseHandlerTest {
 
         val resp = handler.waitForResponse()
         assertEquals(HttpStatusCode.OK, resp.status)
+    }
+
+    @Test
+    fun testResponseSignalledBeforeStreamClosed() = runTest {
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext)
+        val stream = MockHttpStream(204)
+        launch {
+            handler.onResponseComplete(stream, 0)
+        }
+
+        val resp = handler.waitForResponse()
+        assertEquals(HttpStatusCode.NoContent, resp.status)
+
+        // the status code must have been read while the stream was still valid (before close)
+        assertTrue(stream.closed)
+        assertFalse(stream.statusReadAfterClose, "responseStatusCode was read after the stream was closed")
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
close the body channel and signal response BEFORE closing the stream, since signalResponse needs to read stream.responseStatusCode


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
