### PR TITLE
chore: silence Dependabot alerts for Netty because it's a test-only dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 version: 2
 updates:
+  # Gradle but only non-runtime dependencies
+  - package-ecosystem: gradle
+    directory: /
+    open-pull-requests-limit: 0 # Disable alerts
+    groups:
+      non-runtime-dependencies:
+        applies-to: security-updates
+        patterns:
+          - "io.netty:*"
+
+  # All runtime dependencies
   - package-ecosystem: gradle
     directory: /
     schedule:


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This is a _speculative_ change to see if we can ignore Netty security alerts from Dependabot while still getting version update PRs. 🤞

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
