### PR TITLE
fix(build): exclude JetBrains libraries from mavenLocal resolution

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,13 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                excludeGroupByRegex("""org\.jetbrains\.kotlin.*""")
+                excludeGroupByRegex("""org\.jetbrains\.kotlinx.*""")
+                excludeGroup("org.jetbrains")
+            }
+        }
         mavenCentral()
         google()
         maven {


### PR DESCRIPTION
## Issue \#
N/A
`mavenLocal` may contain incomplete artifacts missing Gradle Module Metadata (`.module` files), causing multiplatform metadata compilation to fail with unresolved references to standard Kotlin symbols.

## Description of changes
While working on making Kotlin SDK build work on Windows, `aws-crt-kotlin` was giving error due to unresolved standard Kotlin library.

_Root Cause_
The `kotlin-stdlib-2.3.21` artifact in the local Maven repository (`~/.m2/repository`) was missing its .module (Gradle Module Metadata) file. Since `mavenLocal()` is listed first in the repository order in `settings.gradle.kts`, Gradle resolved `kotlin-stdlib` from there without the metadata needed for multiplatform compilation.

Without the `.module` file, Gradle falls back to POM-only resolution and provides only the JVM jar to the compiler. The metadata compilation task (`compileCommonMainKotlinMetadata`) needs the common/metadata klib variant of kotlin-stdlib — which contains declarations like `RuntimeException`, `buildString`, `let`, `append`, etc. With only the JVM jar on the classpath, all of these appear as unresolved references.

The workaround used to unblock local build was to delete the incomplete stdlib from maven local.

However, to prevent such confusing issue in future, it was decided to implement long-term fix to exclude standard Kotlin libraries from being cached in `mavenLocal()`.

**NOTE:** We could have also scoped `mavenLocal()` with `exclusiveContent` so it's only consulted for SDK's project's artifacts:

```Kotlin
mavenLocal {
    content {
        includeGroupByRegex("aws\\.sdk\\.kotlin.*")
    }
}
```
But based on discussion with @ianbotsf, we also used other tools for testing locally and it will be scalable to maintain this list everytime local cache is needed. Hence it was decided to keep `mavenLocal()` open for everything else (docgenerator, etc.) while ensuring Kotlin standard libraries always resolve from `mavenCentral()` with complete metadata.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
