### PR TITLE
chore: authenticate to ECR for building Docker images to reduce throttling errors; add retry to Docker build

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -177,6 +177,12 @@ jobs:
         with:
           path: 'smithy-kotlin'
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: us-west-2
+
       - name: Configure Gradle
         uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
         with:
@@ -186,8 +192,17 @@ jobs:
         uses: ./smithy-kotlin/.github/actions/setup-build
 
       - name: Configure CRT Docker Images
-        run: |
-          ./aws-crt-kotlin/docker-images/build-all.sh
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 30
+          command: |
+            ./aws-crt-kotlin/docker-images/build-all.sh
+          on_retry_command: |
+            echo "Docker image build failed. Waiting for 10s before trying again..."
+            sleep 10        
+
 
       - name: Build and Test on Linux with Cross-Compile
         working-directory: ./smithy-kotlin


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Downstream for https://github.com/aws/aws-crt-kotlin/pull/282. Attempts to improve the reliability of our Docker image build by:
* Authenticating to Public ECR before building images. In theory, this gets us a higher throttling limit.
* Adding a retry loop around the Docker image build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.