### PR TITLE
make CI to use up-to-dated aws-kotlin-repo-tools

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -381,7 +381,7 @@ jobs:
       with:
         path: 'aws-kotlin-repo-tools'
         repository: 'aws/aws-kotlin-repo-tools'
-        ref: 'main'
+        ref: '0.6.1'
         sparse-checkout: |
           .github
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -381,7 +381,7 @@ jobs:
       with:
         path: 'aws-kotlin-repo-tools'
         repository: 'aws/aws-kotlin-repo-tools'
-        ref: '0.2.3'
+        ref: 'main'
         sparse-checkout: |
           .github
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Use latest merge queue changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
