### PR TITLE
feat(http): add logRedactedHeaders config property for sanitizing sensitive headers in debug logging

### DIFF
--- a/.changes/533f6dab-71fc-4e3e-8fac-32ac2f16f53e.json
+++ b/.changes/533f6dab-71fc-4e3e-8fac-32ac2f16f53e.json
@@ -1,0 +1,9 @@
+{
+  "id": "533f6dab-71fc-4e3e-8fac-32ac2f16f53e",
+  "type": "feature",
+  "description": "Add configurable header redaction for request/response debug logging via `logRedactedHeaders` client config property",
+  "issues": [
+    "aws/aws-sdk-kotlin#1460"
+  ],
+  "module": "runtime"
+}

--- a/codegen/codegen/api/codegen.api
+++ b/codegen/codegen/api/codegen.api
@@ -1011,6 +1011,7 @@ public final class aws/smithy/kotlin/codegen/core/RuntimeTypes$SmithyClient : aw
 	public final fun getIdempotencyTokenProvider ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getIdempotencyTokenProviderExt ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getLogMode ()Lsoftware/amazon/smithy/codegen/core/Symbol;
+	public final fun getLogRedactionConfig ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getProtocolRequestInterceptorContext ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getRequestInterceptorContext ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getRetryClientConfig ()Lsoftware/amazon/smithy/codegen/core/Symbol;
@@ -3077,6 +3078,7 @@ public final class aws/smithy/kotlin/codegen/rendering/util/RuntimeConfigPropert
 	public final fun getHttpInterceptors ()Laws/smithy/kotlin/codegen/rendering/util/ConfigProperty;
 	public final fun getIdempotencyTokenProvider ()Laws/smithy/kotlin/codegen/rendering/util/ConfigProperty;
 	public final fun getLogMode ()Laws/smithy/kotlin/codegen/rendering/util/ConfigProperty;
+	public final fun getLogRedactedHeaders ()Laws/smithy/kotlin/codegen/rendering/util/ConfigProperty;
 	public final fun getRetryPolicy ()Laws/smithy/kotlin/codegen/rendering/util/ConfigProperty;
 	public final fun getRetryStrategy ()Laws/smithy/kotlin/codegen/rendering/util/ConfigProperty;
 	public final fun getTelemetryProvider ()Laws/smithy/kotlin/codegen/rendering/util/ConfigProperty;

--- a/codegen/codegen/api/codegen.api
+++ b/codegen/codegen/api/codegen.api
@@ -1226,11 +1226,15 @@ public final class aws/smithy/kotlin/codegen/lang/KotlinTypes$Collections : aws/
 	public final fun getMutableListOf ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getMutableMap ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getMutableMapOf ()Lsoftware/amazon/smithy/codegen/core/Symbol;
+	public final fun getMutableSet ()Lsoftware/amazon/smithy/codegen/core/Symbol;
+	public final fun getMutableSetOf ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getSet ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun list (Lsoftware/amazon/smithy/codegen/core/Symbol;ZLjava/lang/String;)Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public static synthetic fun list$default (Laws/smithy/kotlin/codegen/lang/KotlinTypes$Collections;Lsoftware/amazon/smithy/codegen/core/Symbol;ZLjava/lang/String;ILjava/lang/Object;)Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun mutableList (Lsoftware/amazon/smithy/codegen/core/Symbol;ZLjava/lang/String;)Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public static synthetic fun mutableList$default (Laws/smithy/kotlin/codegen/lang/KotlinTypes$Collections;Lsoftware/amazon/smithy/codegen/core/Symbol;ZLjava/lang/String;ILjava/lang/Object;)Lsoftware/amazon/smithy/codegen/core/Symbol;
+	public final fun mutableSet (Lsoftware/amazon/smithy/codegen/core/Symbol;ZLjava/lang/String;)Lsoftware/amazon/smithy/codegen/core/Symbol;
+	public static synthetic fun mutableSet$default (Laws/smithy/kotlin/codegen/lang/KotlinTypes$Collections;Lsoftware/amazon/smithy/codegen/core/Symbol;ZLjava/lang/String;ILjava/lang/Object;)Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun set (Lsoftware/amazon/smithy/codegen/core/Symbol;ZLjava/lang/String;)Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public static synthetic fun set$default (Laws/smithy/kotlin/codegen/lang/KotlinTypes$Collections;Lsoftware/amazon/smithy/codegen/core/Symbol;ZLjava/lang/String;ILjava/lang/Object;)Lsoftware/amazon/smithy/codegen/core/Symbol;
 }

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -238,6 +238,7 @@ object RuntimeTypes {
         val IdempotencyTokenProvider = symbol("IdempotencyTokenProvider")
         val IdempotencyTokenConfig = symbol("IdempotencyTokenConfig")
         val IdempotencyTokenProviderExt = symbol("idempotencyTokenProvider")
+        val LogRedactionConfig = symbol("LogRedactionConfig")
 
         object Config : RuntimeTypePackage(KotlinDependency.SMITHY_CLIENT, "config") {
             val RequestCompressionConfig = symbol("RequestCompressionConfig")

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/lang/KotlinTypes.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/lang/KotlinTypes.kt
@@ -46,6 +46,8 @@ object KotlinTypes {
         val mutableListOf: Symbol = stdlibSymbol("mutableListOf")
         val mutableMapOf: Symbol = stdlibSymbol("mutableMapOf")
         val Set: Symbol = stdlibSymbol("Set")
+        val MutableSet: Symbol = stdlibSymbol("MutableSet")
+        val mutableSetOf: Symbol = stdlibSymbol("mutableSetOf")
 
         private fun listType(
             listType: Symbol,
@@ -101,6 +103,15 @@ object KotlinTypes {
             isNullable: Boolean = false,
             default: String? = null,
         ): Symbol = setType(Set, target, isNullable, default)
+
+        /**
+         * Convenience function to get a `MutableSet<target>` as a symbol
+         */
+        fun mutableSet(
+            target: Symbol,
+            isNullable: Boolean = false,
+            default: String? = null,
+        ): Symbol = setType(MutableSet, target, isNullable, default)
     }
 
     object Jvm : RuntimeTypePackage(KotlinDependency.KOTLIN_STDLIB, "jvm") {

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
@@ -43,6 +43,7 @@ class ServiceClientConfigGenerator(
     private fun detectDefaultProps(context: CodegenContext, shape: ServiceShape): List<ConfigProperty> = buildList {
         add(RuntimeConfigProperty.ClientName)
         add(RuntimeConfigProperty.LogMode)
+        add(RuntimeConfigProperty.LogRedactedHeaders)
         if (context.protocolGenerator?.applicationProtocol?.isHttpProtocol == true) {
             add(RuntimeConfigProperty.HttpClient)
             add(RuntimeConfigProperty.HttpInterceptors)

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -355,6 +355,7 @@ open class HttpProtocolClientGenerator(
             putIfAbsent(RuntimeTypes.HttpClient.Operation.HttpOperationContext, "CallTimeout", nullable = true)
             putIfAbsent(RuntimeTypes.SmithyClient.SdkClientOption, "ClientName")
             putIfAbsent(RuntimeTypes.SmithyClient.SdkClientOption, "LogMode")
+            putIfAbsent(RuntimeTypes.SmithyClient.SdkClientOption, "LogRedactedHeaders")
             if (ctx.service.hasIdempotentTokenMember(ctx.model)) {
                 putIfAbsent(RuntimeTypes.SmithyClient.SdkClientOption, "IdempotencyTokenProvider", nullable = true)
             }

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
@@ -132,18 +132,19 @@ object RuntimeConfigProperty {
 
     val LogRedactedHeaders = ConfigProperty {
         name = "logRedactedHeaders"
+        val defaultValue = "${KotlinTypes.Collections.mutableSetOf.fullName}()"
         symbol = KotlinTypes.Collections.set(KotlinTypes.String, isNullable = false)
-        builderSymbol = KotlinTypes.Collections.set(KotlinTypes.String, isNullable = true)
-        toBuilderExpression = ""
-        propertyType = ConfigPropertyType.RequiredWithDefault("emptySet()")
+        builderSymbol = KotlinTypes.Collections.mutableSet(KotlinTypes.String, isNullable = false, default = defaultValue)
+        toBuilderExpression = ".toMutableSet()"
 
         baseClass = RuntimeTypes.SmithyClient.LogRedactionConfig
         useNestedBuilderBaseClass()
 
         documentation = """
-        Set of HTTP header names whose values will be replaced with "<REDACTED>" in
+        Set of HTTP header names whose values will be replaced with "*** Sensitive Data Redacted ***" in
         request/response debug logging. Matching is case-insensitive. Empty by default
-        (no headers are redacted).
+        (no headers are redacted). See [PotentiallySensitiveHeaders][aws.smithy.kotlin.runtime.http.PotentiallySensitiveHeaders] for
+        a pre-built set of commonly-sensitive headers.
         """.trimIndent()
     }
 

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
@@ -130,6 +130,23 @@ object RuntimeConfigProperty {
         """.trimIndent()
     }
 
+    val LogRedactedHeaders = ConfigProperty {
+        name = "logRedactedHeaders"
+        symbol = KotlinTypes.Collections.set(KotlinTypes.String, isNullable = false)
+        builderSymbol = KotlinTypes.Collections.set(KotlinTypes.String, isNullable = true)
+        toBuilderExpression = ""
+        propertyType = ConfigPropertyType.RequiredWithDefault("emptySet()")
+
+        baseClass = RuntimeTypes.SmithyClient.LogRedactionConfig
+        useNestedBuilderBaseClass()
+
+        documentation = """
+        Set of HTTP header names whose values will be replaced with "<REDACTED>" in
+        request/response debug logging. Matching is case-insensitive. Empty by default
+        (no headers are redacted).
+        """.trimIndent()
+    }
+
     var TelemetryProvider = ConfigProperty {
         symbol = RuntimeTypes.Observability.TelemetryApi.TelemetryProvider
         baseClass = RuntimeTypes.Observability.TelemetryApi.TelemetryConfig

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -54,7 +54,7 @@ class ServiceClientConfigGeneratorTest {
         contents.assertBalancedBracesAndParens()
 
         val expectedCtor = """
-public class Config private constructor(builder: Builder) : HttpAuthConfig, HttpClientConfig, HttpEngineConfig by builder.buildHttpEngineConfig(), IdempotencyTokenConfig, RetryClientConfig, RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig(), SdkClientConfig, TelemetryConfig, TimeoutConfig {
+public class Config private constructor(builder: Builder) : HttpAuthConfig, HttpClientConfig, HttpEngineConfig by builder.buildHttpEngineConfig(), IdempotencyTokenConfig, LogRedactionConfig, RetryClientConfig, RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig(), SdkClientConfig, TelemetryConfig, TimeoutConfig {
 """
         contents.shouldContainWithDiff(expectedCtor)
 
@@ -68,13 +68,14 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.Default
+    override val logRedactedHeaders: kotlin.collections.Set<kotlin.String> = builder.logRedactedHeaders ?: emptySet()
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
     override val telemetryProvider: TelemetryProvider = builder.telemetryProvider ?: TelemetryProvider.Global
 """
         contents.shouldContainWithDiff(expectedProps)
 
         val expectedBuilder = """
-    public class Builder : HttpAuthConfig.Builder, HttpClientConfig.Builder, HttpEngineConfig.Builder by HttpEngineConfigImpl.BuilderImpl(), IdempotencyTokenConfig.Builder, RetryClientConfig.Builder, RetryStrategyClientConfig.Builder by RetryStrategyClientConfigImpl.BuilderImpl(), SdkClientConfig.Builder<Config>, TelemetryConfig.Builder, TimeoutConfig.Builder {
+    public class Builder : HttpAuthConfig.Builder, HttpClientConfig.Builder, HttpEngineConfig.Builder by HttpEngineConfigImpl.BuilderImpl(), IdempotencyTokenConfig.Builder, LogRedactionConfig.Builder, RetryClientConfig.Builder, RetryStrategyClientConfig.Builder by RetryStrategyClientConfigImpl.BuilderImpl(), SdkClientConfig.Builder<Config>, TelemetryConfig.Builder, TimeoutConfig.Builder {
         /**
          * A reader-friendly name for the client.
          */
@@ -141,6 +142,13 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
          * debug purposes.
          */
         override var logMode: LogMode? = null
+
+        /**
+         * Set of HTTP header names whose values will be replaced with "<REDACTED>" in
+         * request/response debug logging. Matching is case-insensitive. Empty by default
+         * (no headers are redacted).
+         */
+        override var logRedactedHeaders: kotlin.collections.Set<kotlin.String>? = null
 
         /**
          * The policy to use for evaluating operation results and determining whether/how to retry.
@@ -280,6 +288,7 @@ public class Config private constructor(builder: Builder) {
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.LogRequest
+    override val logRedactedHeaders: kotlin.collections.Set<kotlin.String> = builder.logRedactedHeaders ?: emptySet()
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
     override val telemetryProvider: TelemetryProvider = builder.telemetryProvider ?: TelemetryProvider.Global"""
         contents.shouldContainWithDiff(expectedConfigValues)

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -68,7 +68,7 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.Default
-    override val logRedactedHeaders: kotlin.collections.Set<kotlin.String> = builder.logRedactedHeaders ?: emptySet()
+    override val logRedactedHeaders: kotlin.collections.Set<kotlin.String> = builder.logRedactedHeaders
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
     override val telemetryProvider: TelemetryProvider = builder.telemetryProvider ?: TelemetryProvider.Global
 """
@@ -144,11 +144,12 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
         override var logMode: LogMode? = null
 
         /**
-         * Set of HTTP header names whose values will be replaced with "<REDACTED>" in
+         * Set of HTTP header names whose values will be replaced with "*** Sensitive Data Redacted ***" in
          * request/response debug logging. Matching is case-insensitive. Empty by default
-         * (no headers are redacted).
+         * (no headers are redacted). See [PotentiallySensitiveHeaders][aws.smithy.kotlin.runtime.http.PotentiallySensitiveHeaders] for
+         * a pre-built set of commonly-sensitive headers.
          */
-        override var logRedactedHeaders: kotlin.collections.Set<kotlin.String>? = null
+        override var logRedactedHeaders: kotlin.collections.MutableSet<kotlin.String> = kotlin.collections.mutableSetOf()
 
         /**
          * The policy to use for evaluating operation results and determining whether/how to retry.
@@ -288,7 +289,7 @@ public class Config private constructor(builder: Builder) {
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.LogRequest
-    override val logRedactedHeaders: kotlin.collections.Set<kotlin.String> = builder.logRedactedHeaders ?: emptySet()
+    override val logRedactedHeaders: kotlin.collections.Set<kotlin.String> = builder.logRedactedHeaders
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
     override val telemetryProvider: TelemetryProvider = builder.telemetryProvider ?: TelemetryProvider.Global"""
         contents.shouldContainWithDiff(expectedConfigValues)

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/ServiceClientGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/ServiceClientGeneratorTest.kt
@@ -85,7 +85,7 @@ class ServiceClientGeneratorTest {
 
     @Test
     fun `it generates config`() {
-        val expected = "public class Config private constructor(builder: Builder) : IdempotencyTokenConfig, RetryClientConfig, RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig(), SdkClientConfig, TelemetryConfig"
+        val expected = "public class Config private constructor(builder: Builder) : IdempotencyTokenConfig, LogRedactionConfig, RetryClientConfig, RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig(), SdkClientConfig, TelemetryConfig"
         commonTestContents.shouldContainOnlyOnce(expected)
     }
 

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -12,6 +12,7 @@ import aws.smithy.kotlin.runtime.businessmetrics.emitBusinessMetric
 import aws.smithy.kotlin.runtime.client.LogMode
 import aws.smithy.kotlin.runtime.client.endpoints.authOptions
 import aws.smithy.kotlin.runtime.client.logMode
+import aws.smithy.kotlin.runtime.client.logRedactedHeaders
 import aws.smithy.kotlin.runtime.collections.attributesOf
 import aws.smithy.kotlin.runtime.collections.emptyAttributes
 import aws.smithy.kotlin.runtime.collections.merge
@@ -383,17 +384,18 @@ private class HttpCallMiddleware : Middleware<SdkHttpRequest, HttpCall> {
  */
 private suspend fun httpTraceMiddleware(request: SdkHttpRequest, next: Handler<SdkHttpRequest, HttpCall>): HttpCall {
     val logMode = request.context.logMode
+    val redactedHeaders = request.context.logRedactedHeaders
     val logger = coroutineContext.logger("httpTraceMiddleware")
 
     if (logMode.isEnabled(LogMode.LogRequest) || logMode.isEnabled(LogMode.LogRequestWithBody)) {
-        val formattedReq = dumpRequest(request.subject, logMode.isEnabled(LogMode.LogRequestWithBody))
+        val formattedReq = dumpRequest(request.subject, logMode.isEnabled(LogMode.LogRequestWithBody), redactedHeaders)
         logger.debug { "HttpRequest:\n$formattedReq" }
     }
 
     var call = next.call(request)
 
     if (logMode.isEnabled(LogMode.LogResponse) || logMode.isEnabled(LogMode.LogResponseWithBody)) {
-        val (resp, formattedResp) = dumpResponse(call.response, logMode.isEnabled(LogMode.LogResponseWithBody))
+        val (resp, formattedResp) = dumpResponse(call.response, logMode.isEnabled(LogMode.LogResponseWithBody), redactedHeaders)
         call = call.copy(response = resp)
         logger.debug { "HttpResponse:\n$formattedResp" }
     } else {

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -12,7 +12,6 @@ import aws.smithy.kotlin.runtime.businessmetrics.emitBusinessMetric
 import aws.smithy.kotlin.runtime.client.LogMode
 import aws.smithy.kotlin.runtime.client.endpoints.authOptions
 import aws.smithy.kotlin.runtime.client.logMode
-import aws.smithy.kotlin.runtime.client.logRedactedHeaders
 import aws.smithy.kotlin.runtime.collections.attributesOf
 import aws.smithy.kotlin.runtime.collections.emptyAttributes
 import aws.smithy.kotlin.runtime.collections.merge
@@ -384,18 +383,17 @@ private class HttpCallMiddleware : Middleware<SdkHttpRequest, HttpCall> {
  */
 private suspend fun httpTraceMiddleware(request: SdkHttpRequest, next: Handler<SdkHttpRequest, HttpCall>): HttpCall {
     val logMode = request.context.logMode
-    val redactedHeaders = request.context.logRedactedHeaders
     val logger = coroutineContext.logger("httpTraceMiddleware")
 
     if (logMode.isEnabled(LogMode.LogRequest) || logMode.isEnabled(LogMode.LogRequestWithBody)) {
-        val formattedReq = dumpRequest(request.subject, logMode.isEnabled(LogMode.LogRequestWithBody), redactedHeaders)
+        val formattedReq = dumpRequest(request.subject, request.context, logMode.isEnabled(LogMode.LogRequestWithBody))
         logger.debug { "HttpRequest:\n$formattedReq" }
     }
 
     var call = next.call(request)
 
     if (logMode.isEnabled(LogMode.LogResponse) || logMode.isEnabled(LogMode.LogResponseWithBody)) {
-        val (resp, formattedResp) = dumpResponse(call.response, logMode.isEnabled(LogMode.LogResponseWithBody), redactedHeaders)
+        val (resp, formattedResp) = dumpResponse(call.response, request.context, logMode.isEnabled(LogMode.LogResponseWithBody))
         call = call.copy(response = resp)
         logger.debug { "HttpResponse:\n$formattedResp" }
     } else {

--- a/runtime/protocol/http/api/http.api
+++ b/runtime/protocol/http/api/http.api
@@ -282,6 +282,11 @@ public final class aws/smithy/kotlin/runtime/http/HttpStatusCodeKt {
 	public static final fun isSuccess (Laws/smithy/kotlin/runtime/http/HttpStatusCode;)Z
 }
 
+public final class aws/smithy/kotlin/runtime/http/SensitiveHeaders {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/SensitiveHeaders;
+	public final fun getDefault ()Ljava/util/Set;
+}
+
 public final class aws/smithy/kotlin/runtime/http/compression/CompressRequestKt {
 	public static final fun compressRequest (Laws/smithy/kotlin/runtime/compression/CompressionAlgorithm;Laws/smithy/kotlin/runtime/http/request/HttpRequest;)Laws/smithy/kotlin/runtime/http/request/HttpRequest;
 }
@@ -315,6 +320,7 @@ public final class aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder : a
 }
 
 public final class aws/smithy/kotlin/runtime/http/request/HttpRequestBuilderKt {
+	public static final fun dumpRequest (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;ZLjava/util/Set;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun dumpRequest (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun header (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun headers (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
@@ -359,6 +365,7 @@ public final class aws/smithy/kotlin/runtime/http/response/HttpResponseKt {
 	public static synthetic fun HttpResponse$default (Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/Headers;Laws/smithy/kotlin/runtime/http/HttpBody;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
 	public static final fun copy (Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/Headers;Laws/smithy/kotlin/runtime/http/HttpBody;)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
 	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/Headers;Laws/smithy/kotlin/runtime/http/HttpBody;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
+	public static final fun dumpResponse (Laws/smithy/kotlin/runtime/http/response/HttpResponse;ZLjava/util/Set;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun dumpResponse (Laws/smithy/kotlin/runtime/http/response/HttpResponse;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getAllHeaders (Laws/smithy/kotlin/runtime/ProtocolResponse;Ljava/lang/String;)Ljava/util/List;
 	public static final fun header (Laws/smithy/kotlin/runtime/ProtocolResponse;Ljava/lang/String;)Ljava/lang/String;

--- a/runtime/protocol/http/api/http.api
+++ b/runtime/protocol/http/api/http.api
@@ -282,8 +282,8 @@ public final class aws/smithy/kotlin/runtime/http/HttpStatusCodeKt {
 	public static final fun isSuccess (Laws/smithy/kotlin/runtime/http/HttpStatusCode;)Z
 }
 
-public final class aws/smithy/kotlin/runtime/http/SensitiveHeaders {
-	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/SensitiveHeaders;
+public final class aws/smithy/kotlin/runtime/http/PotentiallySensitiveHeaders {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/PotentiallySensitiveHeaders;
 	public final fun getDefault ()Ljava/util/Set;
 }
 
@@ -320,7 +320,7 @@ public final class aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder : a
 }
 
 public final class aws/smithy/kotlin/runtime/http/request/HttpRequestBuilderKt {
-	public static final fun dumpRequest (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;ZLjava/util/Set;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun dumpRequest (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Laws/smithy/kotlin/runtime/operation/ExecutionContext;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun dumpRequest (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun header (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun headers (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
@@ -365,7 +365,7 @@ public final class aws/smithy/kotlin/runtime/http/response/HttpResponseKt {
 	public static synthetic fun HttpResponse$default (Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/Headers;Laws/smithy/kotlin/runtime/http/HttpBody;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
 	public static final fun copy (Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/Headers;Laws/smithy/kotlin/runtime/http/HttpBody;)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
 	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/Headers;Laws/smithy/kotlin/runtime/http/HttpBody;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
-	public static final fun dumpResponse (Laws/smithy/kotlin/runtime/http/response/HttpResponse;ZLjava/util/Set;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun dumpResponse (Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/operation/ExecutionContext;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun dumpResponse (Laws/smithy/kotlin/runtime/http/response/HttpResponse;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getAllHeaders (Laws/smithy/kotlin/runtime/ProtocolResponse;Ljava/lang/String;)Ljava/util/List;
 	public static final fun header (Laws/smithy/kotlin/runtime/ProtocolResponse;Ljava/lang/String;)Ljava/lang/String;

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HeaderRedaction.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HeaderRedaction.kt
@@ -4,14 +4,35 @@
  */
 package aws.smithy.kotlin.runtime.http
 
+import aws.smithy.kotlin.runtime.collections.AttributeKey
+
 /**
- * Commonly-sensitive HTTP headers that users may choose to redact from debug logging.
+ * HTTP headers that are potentially sensitive and may be redacted from debug logging.
  * This set is NOT applied by default — users must explicitly opt in via the
  * `logRedactedHeaders` client config property.
+ *
+ * Example usage:
+ * ```kotlin
+ * val client = MyServiceClient {
+ *     logRedactedHeaders += PotentiallySensitiveHeaders.Default
+ * }
+ * ```
  */
-public object SensitiveHeaders {
+public object PotentiallySensitiveHeaders {
+    /**
+     * The default set of potentially sensitive headers, including:
+     * - `Authorization`
+     * - `X-Amz-Security-Token`
+     */
     public val Default: Set<String> = setOf(
         "Authorization",
         "X-Amz-Security-Token",
     )
 }
+
+/**
+ * The string used to replace sensitive header values in debug logging output.
+ */
+internal const val SENSITIVE_DATA_REDACTED = "*** Sensitive Data Redacted ***"
+
+internal val LOG_REDACTED_HEADERS_KEY = AttributeKey<Set<String>>("aws.smithy.kotlin#LogRedactedHeaders")

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HeaderRedaction.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HeaderRedaction.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http
+
+/**
+ * Commonly-sensitive HTTP headers that users may choose to redact from debug logging.
+ * This set is NOT applied by default — users must explicitly opt in via the
+ * `logRedactedHeaders` client config property.
+ */
+public object SensitiveHeaders {
+    public val Default: Set<String> = setOf(
+        "Authorization",
+        "X-Amz-Security-Token",
+    )
+}

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt
@@ -5,9 +5,11 @@
 package aws.smithy.kotlin.runtime.http.request
 
 import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.PlannedRemoval
 import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.io.*
 import aws.smithy.kotlin.runtime.net.url.Url
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.util.CanDeepCopy
 
 /**
@@ -94,26 +96,31 @@ public fun HttpRequestBuilder.header(name: String, value: String): Unit = header
  * @param dumpBody Flag controlling whether to also dump the body out. If true the body will be consumed and
  * replaced.
  */
+@Deprecated(
+    "Use the overload that accepts context parameter",
+    ReplaceWith("dumpRequest(request, context, dumpBody)"),
+)
+@PlannedRemoval(major = 1, minor = 8)
 @InternalApi
 public suspend fun dumpRequest(
     request: HttpRequestBuilder,
     dumpBody: Boolean,
-): String = dumpRequest(request, dumpBody, emptySet())
+): String = dumpRequest(request, ExecutionContext(), dumpBody)
 
 /**
  * Dump a debug description of the request
  *
+ * @param context The execution context containing configuration such as redacted headers.
  * @param dumpBody Flag controlling whether to also dump the body out. If true the body will be consumed and
  * replaced.
- * @param redactedHeaders Set of header names whose values will be replaced with "<REDACTED>" in the output.
- * Matching is case-insensitive.
  */
 @InternalApi
 public suspend fun dumpRequest(
     request: HttpRequestBuilder,
+    context: ExecutionContext,
     dumpBody: Boolean,
-    redactedHeaders: Set<String>,
 ): String {
+    val redactedHeaders = context.getOrNull(LOG_REDACTED_HEADERS_KEY) ?: emptySet()
     val buffer = SdkBuffer()
 
     // TODO - we have no way to know the http version at this level to set HTTP/x.x
@@ -130,7 +137,7 @@ public suspend fun dumpRequest(
         .filterNot { it.key in skip }
         .forEach { (key, values) ->
             val headerValue = if (redactedHeaders.any { it.equals(key, ignoreCase = true) }) {
-                "<REDACTED>"
+                SENSITIVE_DATA_REDACTED
             } else {
                 values.joinToString(separator = ";")
             }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt
@@ -95,7 +95,25 @@ public fun HttpRequestBuilder.header(name: String, value: String): Unit = header
  * replaced.
  */
 @InternalApi
-public suspend fun dumpRequest(request: HttpRequestBuilder, dumpBody: Boolean): String {
+public suspend fun dumpRequest(
+    request: HttpRequestBuilder,
+    dumpBody: Boolean,
+): String = dumpRequest(request, dumpBody, emptySet())
+
+/**
+ * Dump a debug description of the request
+ *
+ * @param dumpBody Flag controlling whether to also dump the body out. If true the body will be consumed and
+ * replaced.
+ * @param redactedHeaders Set of header names whose values will be replaced with "<REDACTED>" in the output.
+ * Matching is case-insensitive.
+ */
+@InternalApi
+public suspend fun dumpRequest(
+    request: HttpRequestBuilder,
+    dumpBody: Boolean,
+    redactedHeaders: Set<String>,
+): String {
     val buffer = SdkBuffer()
 
     // TODO - we have no way to know the http version at this level to set HTTP/x.x
@@ -111,7 +129,12 @@ public suspend fun dumpRequest(request: HttpRequestBuilder, dumpBody: Boolean): 
     request.headers.entries()
         .filterNot { it.key in skip }
         .forEach { (key, values) ->
-            buffer.writeUtf8(values.joinToString(separator = ";", prefix = "$key: ", postfix = "\r\n"))
+            val headerValue = if (redactedHeaders.any { it.equals(key, ignoreCase = true) }) {
+                "<REDACTED>"
+            } else {
+                values.joinToString(separator = ";")
+            }
+            buffer.writeUtf8("$key: $headerValue\r\n")
         }
 
     buffer.writeUtf8("\r\n")

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpResponse.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpResponse.kt
@@ -5,13 +5,17 @@
 package aws.smithy.kotlin.runtime.http.response
 
 import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.PlannedRemoval
 import aws.smithy.kotlin.runtime.ProtocolResponse
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.LOG_REDACTED_HEADERS_KEY
+import aws.smithy.kotlin.runtime.http.SENSITIVE_DATA_REDACTED
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.readAll
 import aws.smithy.kotlin.runtime.io.*
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
 
 /**
  * Immutable container for an HTTP response
@@ -90,32 +94,37 @@ public fun ProtocolResponse.statusCode(): HttpStatusCode? {
  * @param dumpBody Flag controlling whether to also dump the body out. If true the body will be consumed and
  * replaced.
  */
+@Deprecated(
+    "Use the overload that accepts context parameter",
+    ReplaceWith("dumpResponse(response, context, dumpBody)"),
+)
+@PlannedRemoval(major = 1, minor = 8)
 @InternalApi
 public suspend fun dumpResponse(
     response: HttpResponse,
     dumpBody: Boolean,
-): Pair<HttpResponse, String> = dumpResponse(response, dumpBody, emptySet())
+): Pair<HttpResponse, String> = dumpResponse(response, ExecutionContext(), dumpBody)
 
 /**
  * Dump a debug description of the response. Either the original response or a copy will be returned to the caller
  * depending on if the body is consumed.
  *
+ * @param context The execution context containing configuration such as redacted headers.
  * @param dumpBody Flag controlling whether to also dump the body out. If true the body will be consumed and
  * replaced.
- * @param redactedHeaders Set of header names whose values will be replaced with "<REDACTED>" in the output.
- * Matching is case-insensitive.
  */
 @InternalApi
 public suspend fun dumpResponse(
     response: HttpResponse,
+    context: ExecutionContext,
     dumpBody: Boolean,
-    redactedHeaders: Set<String>,
 ): Pair<HttpResponse, String> {
+    val redactedHeaders = context.getOrNull(LOG_REDACTED_HEADERS_KEY) ?: emptySet()
     val buffer = SdkBuffer()
     buffer.writeUtf8("HTTP ${response.status}\r\n")
     response.headers.forEach { key, values ->
         val headerValue = if (redactedHeaders.any { it.equals(key, ignoreCase = true) }) {
-            "<REDACTED>"
+            SENSITIVE_DATA_REDACTED
         } else {
             values.joinToString(separator = ";")
         }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpResponse.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpResponse.kt
@@ -91,11 +91,35 @@ public fun ProtocolResponse.statusCode(): HttpStatusCode? {
  * replaced.
  */
 @InternalApi
-public suspend fun dumpResponse(response: HttpResponse, dumpBody: Boolean): Pair<HttpResponse, String> {
+public suspend fun dumpResponse(
+    response: HttpResponse,
+    dumpBody: Boolean,
+): Pair<HttpResponse, String> = dumpResponse(response, dumpBody, emptySet())
+
+/**
+ * Dump a debug description of the response. Either the original response or a copy will be returned to the caller
+ * depending on if the body is consumed.
+ *
+ * @param dumpBody Flag controlling whether to also dump the body out. If true the body will be consumed and
+ * replaced.
+ * @param redactedHeaders Set of header names whose values will be replaced with "<REDACTED>" in the output.
+ * Matching is case-insensitive.
+ */
+@InternalApi
+public suspend fun dumpResponse(
+    response: HttpResponse,
+    dumpBody: Boolean,
+    redactedHeaders: Set<String>,
+): Pair<HttpResponse, String> {
     val buffer = SdkBuffer()
     buffer.writeUtf8("HTTP ${response.status}\r\n")
     response.headers.forEach { key, values ->
-        buffer.writeUtf8(values.joinToString(separator = ";", prefix = "$key: ", postfix = "\r\n"))
+        val headerValue = if (redactedHeaders.any { it.equals(key, ignoreCase = true) }) {
+            "<REDACTED>"
+        } else {
+            values.joinToString(separator = ";")
+        }
+        buffer.writeUtf8("$key: $headerValue\r\n")
     }
     buffer.writeUtf8("\r\n")
 

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpRequestBuilderTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpRequestBuilderTest.kt
@@ -17,6 +17,7 @@ import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.net.Host
 import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.net.url.Url
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
@@ -65,12 +66,12 @@ class HttpRequestBuilderTest {
         }
 
         assertTrue(builder.body is HttpBody.ChannelContent)
-        val actualNoContent = dumpRequest(builder, false)
+        val actualNoContent = dumpRequest(builder, ExecutionContext(), false)
         val expectedNoContent = "GET /debug/test?foo=bar\r\nHost: test.amazon.com\r\nContent-Length: ${content.length}\r\nx-baz: quux;qux\r\n\r\n"
         assertTrue(builder.body is HttpBody.ChannelContent)
         assertEquals(expectedNoContent, actualNoContent)
 
-        val actualWithContent = dumpRequest(builder, true)
+        val actualWithContent = dumpRequest(builder, ExecutionContext(), true)
         assertTrue(builder.body is HttpBody.SourceContent)
         val expectedWithContent = "$expectedNoContent$content"
         assertEquals(expectedWithContent, actualWithContent)
@@ -96,7 +97,7 @@ class HttpRequestBuilderTest {
             body = ByteArrayContent("foobar".encodeToByteArray()),
         )
 
-        val actual = dumpRequest(req.toBuilder(), true)
+        val actual = dumpRequest(req.toBuilder(), ExecutionContext(), true)
         val expected = "POST /debug/test?q1=foo\r\nHost: test.amazon.com\r\nContent-Length: 6\r\nx-baz: bar\r\nx-quux: qux\r\n\r\nfoobar"
         assertEquals(expected, actual)
     }
@@ -116,9 +117,11 @@ class HttpRequestBuilderTest {
         }
 
         // Header names are normalized to lowercase by HeadersBuilder (backed by CaseInsensitiveMap)
-        val redacted = setOf("Authorization", "X-Amz-Security-Token")
-        val actual = dumpRequest(builder, false, redacted)
-        val expected = "GET /debug/test\r\nHost: test.amazon.com\r\nauthorization: <REDACTED>\r\nx-amz-security-token: <REDACTED>\r\nx-safe-header: visible-value\r\n\r\n"
+        val context = ExecutionContext().apply {
+            set(LOG_REDACTED_HEADERS_KEY, setOf("Authorization", "X-Amz-Security-Token"))
+        }
+        val actual = dumpRequest(builder, context, false)
+        val expected = "GET /debug/test\r\nHost: test.amazon.com\r\nauthorization: *** Sensitive Data Redacted ***\r\nx-amz-security-token: *** Sensitive Data Redacted ***\r\nx-safe-header: visible-value\r\n\r\n"
         assertEquals(expected, actual)
     }
 
@@ -136,9 +139,11 @@ class HttpRequestBuilderTest {
         }
 
         // Redaction set uses mixed case but still matches lowercase keys from HeadersBuilder
-        val redacted = setOf("Authorization")
-        val actual = dumpRequest(builder, false, redacted)
-        val expected = "GET /test\r\nHost: test.amazon.com\r\nauthorization: <REDACTED>\r\nx-custom: visible\r\n\r\n"
+        val context = ExecutionContext().apply {
+            set(LOG_REDACTED_HEADERS_KEY, setOf("Authorization"))
+        }
+        val actual = dumpRequest(builder, context, false)
+        val expected = "GET /test\r\nHost: test.amazon.com\r\nauthorization: *** Sensitive Data Redacted ***\r\nx-custom: visible\r\n\r\n"
         assertEquals(expected, actual)
     }
 
@@ -155,7 +160,7 @@ class HttpRequestBuilderTest {
             }
         }
 
-        val actual = dumpRequest(builder, false)
+        val actual = dumpRequest(builder, ExecutionContext(), false)
         val expected = "GET /test\r\nHost: test.amazon.com\r\nauthorization: AWS4-HMAC-SHA256 Credential=...\r\n\r\n"
         assertEquals(expected, actual)
     }

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpRequestBuilderTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpRequestBuilderTest.kt
@@ -100,4 +100,63 @@ class HttpRequestBuilderTest {
         val expected = "POST /debug/test?q1=foo\r\nHost: test.amazon.com\r\nContent-Length: 6\r\nx-baz: bar\r\nx-quux: qux\r\n\r\nfoobar"
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun testDumpRequestRedactsHeaders() = runTest {
+        val builder = HttpRequestBuilder().apply {
+            url {
+                host = Host.Domain("test.amazon.com")
+                path.encoded = "/debug/test"
+            }
+            headers {
+                append("Authorization", "AWS4-HMAC-SHA256 Credential=...")
+                append("X-Amz-Security-Token", "secret-token")
+                append("x-safe-header", "visible-value")
+            }
+        }
+
+        // Header names are normalized to lowercase by HeadersBuilder (backed by CaseInsensitiveMap)
+        val redacted = setOf("Authorization", "X-Amz-Security-Token")
+        val actual = dumpRequest(builder, false, redacted)
+        val expected = "GET /debug/test\r\nHost: test.amazon.com\r\nauthorization: <REDACTED>\r\nx-amz-security-token: <REDACTED>\r\nx-safe-header: visible-value\r\n\r\n"
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testDumpRequestRedactsCaseInsensitive() = runTest {
+        val builder = HttpRequestBuilder().apply {
+            url {
+                host = Host.Domain("test.amazon.com")
+                path.encoded = "/test"
+            }
+            headers {
+                append("authorization", "secret")
+                append("x-custom", "visible")
+            }
+        }
+
+        // Redaction set uses mixed case but still matches lowercase keys from HeadersBuilder
+        val redacted = setOf("Authorization")
+        val actual = dumpRequest(builder, false, redacted)
+        val expected = "GET /test\r\nHost: test.amazon.com\r\nauthorization: <REDACTED>\r\nx-custom: visible\r\n\r\n"
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testDumpRequestNoRedactionByDefault() = runTest {
+        val builder = HttpRequestBuilder().apply {
+            url {
+                host = Host.Domain("test.amazon.com")
+                path.encoded = "/test"
+            }
+            headers {
+                // Appended as "Authorization" but stored lowercase by HeadersBuilder
+                append("Authorization", "AWS4-HMAC-SHA256 Credential=...")
+            }
+        }
+
+        val actual = dumpRequest(builder, false)
+        val expected = "GET /test\r\nHost: test.amazon.com\r\nauthorization: AWS4-HMAC-SHA256 Credential=...\r\n\r\n"
+        assertEquals(expected, actual)
+    }
 }

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/response/HttpResponseTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/response/HttpResponseTest.kt
@@ -63,4 +63,37 @@ class HttpResponseTest {
         val expected = "HTTP 200: OK\r\nx-foo: bar\r\n\r\n$content"
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun testDumpResponseRedactsHeaders() = runTest {
+        val resp = HttpResponse(
+            HttpStatusCode.OK,
+            Headers {
+                append("x-amz-security-token", "secret-token")
+                append("x-request-id", "abc-123")
+            },
+            HttpBody.Empty,
+        )
+
+        val redacted = setOf("X-Amz-Security-Token")
+        val (_, actual) = dumpResponse(resp, false, redacted)
+        val expected = "HTTP 200: OK\r\nx-amz-security-token: <REDACTED>\r\nx-request-id: abc-123\r\n\r\n"
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testDumpResponseNoRedactionByDefault() = runTest {
+        val resp = HttpResponse(
+            HttpStatusCode.OK,
+            Headers {
+                // Appended as "Authorization" but stored lowercase by Headers (backed by CaseInsensitiveMap)
+                append("Authorization", "Bearer token123")
+            },
+            HttpBody.Empty,
+        )
+
+        val (_, actual) = dumpResponse(resp, false)
+        val expected = "HTTP 200: OK\r\nauthorization: Bearer token123\r\n\r\n"
+        assertEquals(expected, actual)
+    }
 }

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/response/HttpResponseTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/response/HttpResponseTest.kt
@@ -2,15 +2,16 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package aws.smithy.kotlin.runtime.http.response
 
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.LOG_REDACTED_HEADERS_KEY
 import aws.smithy.kotlin.runtime.http.toHttpBody
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -53,10 +54,10 @@ class HttpResponseTest {
             body = stream.toHttpBody(),
         )
 
-        val (c1, _) = dumpResponse(resp, false)
+        val (c1, _) = dumpResponse(resp, ExecutionContext(), false)
         assertSame(resp, c1)
 
-        val (c2, actual) = dumpResponse(resp, true)
+        val (c2, actual) = dumpResponse(resp, ExecutionContext(), true)
         assertTrue(c2.body is HttpBody.Bytes)
         assertNotSame(resp, c2)
 
@@ -75,9 +76,11 @@ class HttpResponseTest {
             HttpBody.Empty,
         )
 
-        val redacted = setOf("X-Amz-Security-Token")
-        val (_, actual) = dumpResponse(resp, false, redacted)
-        val expected = "HTTP 200: OK\r\nx-amz-security-token: <REDACTED>\r\nx-request-id: abc-123\r\n\r\n"
+        val context = ExecutionContext().apply {
+            set(LOG_REDACTED_HEADERS_KEY, setOf("X-Amz-Security-Token"))
+        }
+        val (_, actual) = dumpResponse(resp, context, false)
+        val expected = "HTTP 200: OK\r\nx-amz-security-token: *** Sensitive Data Redacted ***\r\nx-request-id: abc-123\r\n\r\n"
         assertEquals(expected, actual)
     }
 
@@ -92,7 +95,7 @@ class HttpResponseTest {
             HttpBody.Empty,
         )
 
-        val (_, actual) = dumpResponse(resp, false)
+        val (_, actual) = dumpResponse(resp, ExecutionContext(), false)
         val expected = "HTTP 200: OK\r\nauthorization: Bearer token123\r\n\r\n"
         assertEquals(expected, actual)
     }

--- a/runtime/smithy-client/api/smithy-client.api
+++ b/runtime/smithy-client/api/smithy-client.api
@@ -91,6 +91,15 @@ public final class aws/smithy/kotlin/runtime/client/LogMode$LogResponseWithBody 
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/client/LogRedactionConfig {
+	public abstract fun getLogRedactedHeaders ()Ljava/util/Set;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/client/LogRedactionConfig$Builder {
+	public abstract fun getLogRedactedHeaders ()Ljava/util/Set;
+	public abstract fun setLogRedactedHeaders (Ljava/util/Set;)V
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext : aws/smithy/kotlin/runtime/client/RequestInterceptorContext {
 	public abstract fun getProtocolRequest ()Ljava/lang/Object;
 }
@@ -178,6 +187,7 @@ public final class aws/smithy/kotlin/runtime/client/SdkClientOption {
 	public final fun getEndpointDiscoveryEnabled ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getIdempotencyTokenProvider ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getLogMode ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getLogRedactedHeaders ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getOperationName ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getServiceName ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 }
@@ -185,6 +195,7 @@ public final class aws/smithy/kotlin/runtime/client/SdkClientOption {
 public final class aws/smithy/kotlin/runtime/client/SdkClientOptionKt {
 	public static final fun getIdempotencyTokenProvider (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Laws/smithy/kotlin/runtime/client/IdempotencyTokenProvider;
 	public static final fun getLogMode (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Laws/smithy/kotlin/runtime/client/LogMode;
+	public static final fun getLogRedactedHeaders (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Ljava/util/Set;
 	public static final fun getOperationName (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Ljava/lang/String;
 	public static final fun getServiceName (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Ljava/lang/String;
 }

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/LogRedactionConfig.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/LogRedactionConfig.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.client
+
+/**
+ * Configuration for HTTP header redaction in debug logging.
+ */
+public interface LogRedactionConfig {
+    /**
+     * Set of HTTP header names whose values will be replaced with "<REDACTED>" in
+     * request/response debug logging. Matching is case-insensitive. Empty by default
+     * (no headers are redacted).
+     */
+    public val logRedactedHeaders: Set<String>
+
+    /**
+     * Configure header redaction for debug logging.
+     */
+    public interface Builder {
+        /**
+         * Set of HTTP header names whose values will be replaced with "<REDACTED>" in
+         * request/response debug logging. Matching is case-insensitive. Empty by default
+         * (no headers are redacted).
+         */
+        public var logRedactedHeaders: Set<String>?
+    }
+}

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/LogRedactionConfig.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/LogRedactionConfig.kt
@@ -9,9 +9,11 @@ package aws.smithy.kotlin.runtime.client
  */
 public interface LogRedactionConfig {
     /**
-     * Set of HTTP header names whose values will be replaced with "<REDACTED>" in
-     * request/response debug logging. Matching is case-insensitive. Empty by default
-     * (no headers are redacted).
+     * Set of HTTP header names whose values will be replaced with `"*** Sensitive Data Redacted ***"`
+     * in request/response debug logging. Matching is case-insensitive. This parameter is empty by
+     * default, meaning no headers are redacted. You may choose a preselected set of headers such as
+     * [PotentiallySensitiveHeaders][aws.smithy.kotlin.runtime.http.PotentiallySensitiveHeaders] or
+     * provide your own custom set.
      */
     public val logRedactedHeaders: Set<String>
 
@@ -20,10 +22,12 @@ public interface LogRedactionConfig {
      */
     public interface Builder {
         /**
-         * Set of HTTP header names whose values will be replaced with "<REDACTED>" in
-         * request/response debug logging. Matching is case-insensitive. Empty by default
-         * (no headers are redacted).
+         * Set of HTTP header names whose values will be replaced with `"*** Sensitive Data Redacted ***"`
+         * in request/response debug logging. Matching is case-insensitive. This parameter is empty by
+         * default, meaning no headers are redacted. You may choose a preselected set of headers such as
+         * [PotentiallySensitiveHeaders][aws.smithy.kotlin.runtime.http.PotentiallySensitiveHeaders] or
+         * provide your own custom set.
          */
-        public var logRedactedHeaders: Set<String>?
+        public var logRedactedHeaders: MutableSet<String>
     }
 }

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
@@ -42,6 +42,11 @@ public object SdkClientOption {
      * Whether endpoint discovery is enabled or not. Default is true
      */
     public val EndpointDiscoveryEnabled: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin#EndpointDiscoveryEnabled")
+
+    /**
+     * Set of HTTP header names whose values will be redacted from debug logging
+     */
+    public val LogRedactedHeaders: AttributeKey<Set<String>> = AttributeKey("aws.smithy.kotlin#LogRedactedHeaders")
 }
 
 /**
@@ -67,3 +72,9 @@ public val ExecutionContext.operationName: String?
  */
 public val ExecutionContext.serviceName: String?
     get() = getOrNull(SdkClientOption.ServiceName)
+
+/**
+ * Get the set of headers to redact from logging. If not set, returns an empty set.
+ */
+public val ExecutionContext.logRedactedHeaders: Set<String>
+    get() = getOrNull(SdkClientOption.LogRedactedHeaders) ?: emptySet()


### PR DESCRIPTION
## Issue \#
https://github.com/aws/aws-sdk-kotlin/issues/1460

## Description of changes
Adds a new `logRedactedHeaders` configuration property to `SdkClientConfig` that allows users to specify HTTP header names whose values should be replaced with `<REDACTED>` in request/response debug logging. Matching is case-insensitive and the set is empty by default (no headers redacted).

When `LogMode` includes request or response logging, all HTTP headers are dumped verbatim, including sensitive values like `Authorization` or custom tokens. This property gives SDK users a way to opt-in to redacting specific headers without disabling debug logging entirely. The redaction set is empty by default so there is no behavior change for existing users.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
