### PR TITLE
make CI to use up-to-dated aws-kotlin-repo-tools

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -177,6 +177,12 @@ jobs:
         with:
           path: 'smithy-kotlin'
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: us-west-2
+
       - name: Configure Gradle
         uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
         with:
@@ -186,8 +192,17 @@ jobs:
         uses: ./smithy-kotlin/.github/actions/setup-build
 
       - name: Configure CRT Docker Images
-        run: |
-          ./aws-crt-kotlin/docker-images/build-all.sh
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 30
+          command: |
+            ./aws-crt-kotlin/docker-images/build-all.sh
+          on_retry_command: |
+            echo "Docker image build failed. Waiting for 10s before trying again..."
+            sleep 10        
+
 
       - name: Build and Test on Linux with Cross-Compile
         working-directory: ./smithy-kotlin

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -381,7 +381,7 @@ jobs:
       with:
         path: 'aws-kotlin-repo-tools'
         repository: 'aws/aws-kotlin-repo-tools'
-        ref: '0.6.1'
+        ref: '0.6.2' # FIXME: do not hardcode this, use the version set in libs.versions.toml
         sparse-checkout: |
           .github
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
version bump for aws-kotlin-repo-tools


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
