### PR TITLE
fix: correctly generate default values for floating point numbers given in scientific notation

### DIFF
--- a/.changes/64b59434-cc49-4499-b458-b5481b89458e.json
+++ b/.changes/64b59434-cc49-4499-b458-b5481b89458e.json
@@ -1,0 +1,5 @@
+{
+    "id": "64b59434-cc49-4499-b458-b5481b89458e",
+    "type": "bugfix",
+    "description": "Correctly generate default values for floating point numbers given in scientific notation"
+}

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -361,7 +361,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
     private fun getDefaultValueForNumber(type: ShapeType, value: String) = when (type) {
         ShapeType.LONG -> "${value}L"
         ShapeType.FLOAT -> "${value}f"
-        ShapeType.DOUBLE -> if (value.matches("-?[0-9]*\\.[0-9]+".toRegex())) value else "$value.0"
+        ShapeType.DOUBLE -> (value.toDoubleOrNull() ?: error("""Cannot parse "$value" to double""")).toString()
         ShapeType.SHORT -> "$value.toShort()"
         ShapeType.BYTE -> "$value.toByte()"
         else -> value

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -152,6 +152,23 @@ class SymbolProviderTest {
     }
 
     @Test
+    fun `scientific double default value does not get extra decimal appended`() {
+        val model = """
+        structure MyStruct {
+           @default(1.0e-8)
+           foo: MyFoo
+        }
+        
+        double MyFoo
+        """.prependNamespaceAndService().toSmithyModel()
+
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
+        val member = model.expectShape<MemberShape>("com.test#MyStruct\$foo")
+        val memberSymbol = provider.toSymbol(member)
+        assertEquals("1.0E-8", memberSymbol.defaultValue())
+    }
+
+    @Test
     fun `can read default trait from target`() {
         val modeledDefault = "2500"
         val expectedDefault = "2500L"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change refactors parsing of defaults for double values in Smithy models to correctly extract numbers given in scientific notation. Previously, a Smithy model default such as `"smithy.api#default": 1.0E-8` would be codegenned as `1.0E-8.0`, which is invalid because Kotlin double literals may not contain decimals in the exponent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
