### PR TITLE
Add sdkVersion CI check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -391,15 +391,6 @@ jobs:
     - name: Setup build
       uses: ./smithy-kotlin/.github/actions/setup-build
 
-    - name: Checkout tools
-      uses: actions/checkout@v4
-      with:
-        path: 'aws-kotlin-repo-tools'
-        repository: 'aws/aws-kotlin-repo-tools'
-        ref: '0.6.3' # FIXME: do not hardcode this, use the version set in libs.versions.toml
-        sparse-checkout: |
-          .github
-
     - name: Checkout aws-sdk-kotlin
       uses: ./aws-kotlin-repo-tools/.github/actions/checkout-head
       with:

--- a/.github/workflows/sdk-version-check.yml
+++ b/.github/workflows/sdk-version-check.yml
@@ -1,0 +1,21 @@
+name: SDK Version Check
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - main
+      - '*-main'
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  sdk-version-check:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'merge_group' }}
+    steps:
+      - name: Check sdkVersion
+        uses: aws/aws-kotlin-repo-tools/.github/actions/sdk-version-check@main


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Some fix found during minor version bump.
- Add CI for checking if sdkVersion in gradle.properties has been manually changed
- Remove Checkout tools as it is already in `setup-build`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
