### PR TITLE
avoid metric interceptor when not required

### DIFF
--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/MetricsInterceptor.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/MetricsInterceptor.kt
@@ -20,6 +20,10 @@ public object MetricsInterceptor : Interceptor {
         val originalRequest = chain.request()
         val metrics = originalRequest.tag(SdkRequestTag::class.java)?.metrics ?: return chain.proceed(originalRequest)
 
+        if (metrics.bytesSent === MonotonicCounter.None && metrics.bytesReceived === MonotonicCounter.None) {
+            return chain.proceed(originalRequest)
+        }
+
         val attrs = attributesOf { "server.address" to "${originalRequest.url.host}:${originalRequest.url.port}" }
         val request = if (originalRequest.body != null) {
             originalRequest.newBuilder()


### PR DESCRIPTION
## Summary

- Short-circuit `MetricsInterceptor` when neither `bytesSent` nor `bytesReceived` counters are active, avoiding unnecessary request/response body wrapping

## Motivation

`MetricsInterceptor` wraps every request and response body with instrumented wrappers that delegate byte-counting to `MonotonicCounter`. When no metrics tracking is active (both counters are `MonotonicCounter.None`), this wrapping still runs — allocating wrapper objects and adding an extra delegation layer on every `read()`/`write()` call in the hot path.

For the common case where SDK users don't wire up byte-level transfer metrics, this overhead is pure waste. The fix checks upfront whether either counter is active and skips the wrapping entirely if not, eliminating per-request allocation and delegation overhead.

## Benchmark Results

All benchmarks run on m7i.2xlarge instances with the following configuration:
- **Operations per batch:** 100,000
- **Warmup batches:** 3
- **Measurement batches:** 5

### E2E Throughput (S3)

#### S3 Upload (base: 6 instances, target: 4 instances)
| Concurrency | Base (Gbps) | Target (Gbps) | Change |  Base CPU% | Target CPU% | Base Mem (MB) | Target Mem (MB) |
|---|---|---|---|---|---|---|---|
| 16 | 4.09 ± 0 | 4.05 ± 0 | -1.0% | 32.5 | 32.3 | 707.1 | 731.1 |
| 32 | 7.32 ± 0.20 | 7.21 ± 0.22 | -1.5% | 60.4 | 59.8 | 765.2 | 776.7 |
| 64 | 10.40 ± 0.50 | 10.32 ± 0.43 | -0.8% | 92.9 | 93.7 | 952.5 | 1008.0 |
| 128 | 10.69 ± 0.43 | 10.63 ± 0.57 | -0.6% | 94.0 | 93.6 | 961.9 | 910.5 |

#### S3 Download (base: 6 instances, target: 4 instances)
| Concurrency | Base (Gbps) | Target (Gbps) | Change | Base CPU% | Target CPU% | Base Mem (MB) | Target Mem (MB) |
|---|---|---|---|---|---|---|---|
| 16 | 5.96 ± 0.14 | 6.07 ± 0 | +1.8% | 53.8 | 52.3 | 947.7 | 963.0 |
| 32 | 9.22 ± 0.20 | 9.42 ± 0.60 | +2.2% | 85.7 | 85.2 | 1085.2 | 1105.5 |
| 64 | 10.17 ± 0.34 | 10.13 ± 0.41 | -0.4% | 88.3 | 86.0 | 1269.3 | 1307.0 |
| 128 | 9.09 ± 0.40 | 9.22 ± 0.40 | +1.4% | 88.4 | 89.7 | 1324.4 | 1228.9 |

**Throughput observations:**
- All changes fall within standard deviation overlap — no throughput regression
- This is expected: the optimization removes per-request object allocation overhead, which affects latency more than bulk transfer throughput where time is dominated by I/O
- CPU and memory usage remain effectively identical across both variants

### E2E Latency (DynamoDB)

#### DynamoDB PutItem (base: 7 instances, target: 7 instances)
| Metric | Base (ms) | Target (ms) | Change | Base CPU% | Target CPU% | Base Mem (MB) | Target Mem (MB) |
|---|---|---|---|---|---|---|---|
| Average | 3.27 ± 0.70 | 3.06 ± 0.64 | **-6.4%** | 1.1 | 1.1 | 67.9 | 67.7 |
| P50 | 3.08 ± 0.67 | 2.90 ± 0.66 | **-5.8%** | — | — | — | — |
| P90 | 3.79 ± 0.79 | 3.50 ± 0.65 | **-7.7%** | — | — | — | — |
| P99 | 5.75 ± 1.81 | 5.48 ± 1.74 | -4.7% | — | — | — | — |

#### DynamoDB GetItem (base: 7 instances, target: 7 instances)
| Metric | Base (ms) | Target (ms) | Change | Base CPU% | Target CPU% | Base Mem (MB) | Target Mem (MB) |
|---|---|---|---|---|---|---|---|
| Average | 2.03 ± 0.50 | 1.75 ± 0.24 | **-13.8%** | 1.7 | 1.8 | 68.0 | 67.8 |
| P50 | 1.86 ± 0.50 | 1.59 ± 0.28 | **-14.5%** | — | — | — | — |
| P90 | 2.38 ± 0.60 | 2.05 ± 0.31 | **-13.9%** | — | — | — | — |
| P99 | 4.34 ± 1.29 | 3.97 ± 0.42 | **-8.5%** | — | — | — | — |

**Latency observations:**
- DynamoDB GetItem P50 latency drops by **14.5%** (1.86 → 1.59 ms) — eliminating unnecessary wrapper delegation reduces per-request overhead
- DynamoDB PutItem P90 latency drops by **7.7%** (3.79 → 3.50 ms)
- Improvements are consistent across average, P50, P90, and P99 for both operations
- The larger improvement on GetItem (smaller payloads) is expected — per-request fixed overhead is a larger fraction of total request time
- No CPU or memory regression — resource usage is effectively identical
- Target variant also shows lower cross-instance standard deviation (GetItem: 0.24 vs 0.50), suggesting more stable behavior without the wrapper overhead

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
