### PR TITLE
use stable UUID api

### DIFF
--- a/.changes/a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6.json
+++ b/.changes/a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6.json
@@ -1,0 +1,7 @@
+{
+  "id": "a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6",
+  "type": "bugfix",
+  "description": "Use `kotlin.uuid.Uuid` for UUID generation instead of `kotlin.random.Random` which is unsafe with Lambda SnapStart due to deterministic PRNG state being captured in snapshots",
+  "issues": ["https://github.com/smithy-lang/smithy-kotlin/issues/1656"],
+  "module": "runtime-core"
+}

--- a/runtime/protocol/aws-event-stream/api/aws-event-stream.api
+++ b/runtime/protocol/aws-event-stream/api/aws-event-stream.api
@@ -143,6 +143,17 @@ public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Uuid4 : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public fun <init> (Lkotlin/uuid/Uuid;)V
+	public final fun component1 ()Lkotlin/uuid/Uuid;
+	public final fun copy (Lkotlin/uuid/Uuid;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Uuid4;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Uuid4;Lkotlin/uuid/Uuid;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Uuid4;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Lkotlin/uuid/Uuid;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValueKt {
 	public static final fun expectBool (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Z
 	public static final fun expectByte (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)B
@@ -155,6 +166,7 @@ public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue
 	public static final fun expectString (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Ljava/lang/String;
 	public static final fun expectTimestamp (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Laws/smithy/kotlin/runtime/time/Instant;
 	public static final fun expectUuid (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Laws/smithy/kotlin/runtime/util/Uuid;
+	public static final fun expectUuid4 (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Lkotlin/uuid/Uuid;
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/Message {

--- a/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
+++ b/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
@@ -77,9 +77,9 @@ public sealed class HeaderValue {
     public data class Timestamp(val value: Instant) : HeaderValue()
 
     @InternalApi
-    @Suppress("DEPRECATION")
     @Deprecated("Use Uuid4 instead", ReplaceWith("Uuid4"))
     @PlannedRemoval(1, 8)
+    @Suppress("DEPRECATION")
     public data class Uuid(val value: aws.smithy.kotlin.runtime.util.Uuid) : HeaderValue()
 
     @InternalApi
@@ -202,10 +202,10 @@ public fun HeaderValue.expectByteArray(): ByteArray = checkNotNull((this as? Hea
 @InternalApi
 public fun HeaderValue.expectTimestamp(): Instant = checkNotNull((this as? HeaderValue.Timestamp)?.value) { "expected HeaderValue.Bool, found: $this" }
 
-@OptIn(PlannedRemoval::class)
 @InternalApi
-@Suppress("DEPRECATION")
 @Deprecated("Use expectUuid4 instead", ReplaceWith("expectUuid4()"))
+@PlannedRemoval(1, 8)
+@Suppress("DEPRECATION")
 public fun HeaderValue.expectUuid(): Uuid = checkNotNull((this as? HeaderValue.Uuid)?.value) { "expected HeaderValue.Uuid, found: $this" }
 
 @InternalApi

--- a/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
+++ b/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
@@ -88,8 +88,8 @@ public sealed class HeaderValue {
     /**
      * Encode a header value to [dest]
      */
+
     @OptIn(PlannedRemoval::class)
-    @Suppress("DEPRECATION")
     public fun encode(dest: SdkBufferedSink): Unit = when (this) {
         is Bool -> {
             val type = if (value) HeaderType.TRUE else HeaderType.FALSE
@@ -128,7 +128,10 @@ public sealed class HeaderValue {
             dest.writeHeader(HeaderType.TIMESTAMP)
             dest.writeLong(value.epochMilliseconds)
         }
-        is Uuid -> {
+        is
+        @Suppress("DEPRECATION")
+        Uuid,
+        -> {
             dest.writeHeader(HeaderType.UUID)
             dest.writeLong(value.high)
             dest.writeLong(value.low)

--- a/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
+++ b/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
@@ -6,6 +6,7 @@
 package aws.smithy.kotlin.runtime.awsprotocol.eventstream
 
 import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.PlannedRemoval
 import aws.smithy.kotlin.runtime.io.*
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.epochMilliseconds
@@ -78,6 +79,7 @@ public sealed class HeaderValue {
     @InternalApi
     @Suppress("DEPRECATION")
     @Deprecated("Use Uuid4 instead", ReplaceWith("Uuid4"))
+    @PlannedRemoval(1, 8)
     public data class Uuid(val value: aws.smithy.kotlin.runtime.util.Uuid) : HeaderValue()
 
     @InternalApi
@@ -86,6 +88,7 @@ public sealed class HeaderValue {
     /**
      * Encode a header value to [dest]
      */
+    @OptIn(PlannedRemoval::class)
     @Suppress("DEPRECATION")
     public fun encode(dest: SdkBufferedSink): Unit = when (this) {
         is Bool -> {
@@ -199,6 +202,7 @@ public fun HeaderValue.expectByteArray(): ByteArray = checkNotNull((this as? Hea
 @InternalApi
 public fun HeaderValue.expectTimestamp(): Instant = checkNotNull((this as? HeaderValue.Timestamp)?.value) { "expected HeaderValue.Bool, found: $this" }
 
+@OptIn(PlannedRemoval::class)
 @InternalApi
 @Suppress("DEPRECATION")
 @Deprecated("Use expectUuid4 instead", ReplaceWith("expectUuid4()"))

--- a/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
+++ b/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
@@ -10,7 +10,6 @@ import aws.smithy.kotlin.runtime.io.*
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.epochMilliseconds
 import aws.smithy.kotlin.runtime.time.fromEpochMilliseconds
-import aws.smithy.kotlin.runtime.util.Uuid
 
 internal enum class HeaderType(val value: Byte) {
     TRUE(0),
@@ -76,7 +75,7 @@ public sealed class HeaderValue {
     public data class Timestamp(val value: Instant) : HeaderValue()
 
     @InternalApi
-    public data class Uuid(val value: aws.smithy.kotlin.runtime.util.Uuid) : HeaderValue()
+    public data class Uuid(val value: kotlin.uuid.Uuid) : HeaderValue()
 
     /**
      * Encode a header value to [dest]
@@ -121,8 +120,10 @@ public sealed class HeaderValue {
         }
         is Uuid -> {
             dest.writeHeader(HeaderType.UUID)
-            dest.writeLong(value.high)
-            dest.writeLong(value.low)
+            value.toLongs { msb, lsb ->
+                dest.writeLong(msb)
+                dest.writeLong(lsb)
+            }
         }
     }
 
@@ -151,9 +152,9 @@ public sealed class HeaderValue {
                     HeaderValue.Timestamp(Instant.fromEpochMilliseconds(epochMilli))
                 }
                 HeaderType.UUID -> {
-                    val high = source.readLong()
-                    val low = source.readLong()
-                    HeaderValue.Uuid(Uuid(high, low))
+                    val msb = source.readLong()
+                    val lsb = source.readLong()
+                    HeaderValue.Uuid(kotlin.uuid.Uuid.fromLongs(msb, lsb))
                 }
             }
         }
@@ -187,7 +188,7 @@ public fun HeaderValue.expectByteArray(): ByteArray = checkNotNull((this as? Hea
 public fun HeaderValue.expectTimestamp(): Instant = checkNotNull((this as? HeaderValue.Timestamp)?.value) { "expected HeaderValue.Bool, found: $this" }
 
 @InternalApi
-public fun HeaderValue.expectUuid(): Uuid = checkNotNull((this as? HeaderValue.Uuid)?.value) { "expected HeaderValue.Bool, found: $this" }
+public fun HeaderValue.expectUuid(): kotlin.uuid.Uuid = checkNotNull((this as? HeaderValue.Uuid)?.value) { "expected HeaderValue.Uuid, found: $this" }
 
 @InternalApi
 public fun <T> HeaderValue.expectEnumValue(fromValue: (String) -> T): T = fromValue(expectString())

--- a/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
+++ b/runtime/protocol/aws-event-stream/common/src/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue.kt
@@ -10,6 +10,7 @@ import aws.smithy.kotlin.runtime.io.*
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.epochMilliseconds
 import aws.smithy.kotlin.runtime.time.fromEpochMilliseconds
+import aws.smithy.kotlin.runtime.util.Uuid
 
 internal enum class HeaderType(val value: Byte) {
     TRUE(0),
@@ -75,11 +76,17 @@ public sealed class HeaderValue {
     public data class Timestamp(val value: Instant) : HeaderValue()
 
     @InternalApi
-    public data class Uuid(val value: kotlin.uuid.Uuid) : HeaderValue()
+    @Suppress("DEPRECATION")
+    @Deprecated("Use Uuid4 instead", ReplaceWith("Uuid4"))
+    public data class Uuid(val value: aws.smithy.kotlin.runtime.util.Uuid) : HeaderValue()
+
+    @InternalApi
+    public data class Uuid4(val value: kotlin.uuid.Uuid) : HeaderValue()
 
     /**
      * Encode a header value to [dest]
      */
+    @Suppress("DEPRECATION")
     public fun encode(dest: SdkBufferedSink): Unit = when (this) {
         is Bool -> {
             val type = if (value) HeaderType.TRUE else HeaderType.FALSE
@@ -120,6 +127,11 @@ public sealed class HeaderValue {
         }
         is Uuid -> {
             dest.writeHeader(HeaderType.UUID)
+            dest.writeLong(value.high)
+            dest.writeLong(value.low)
+        }
+        is Uuid4 -> {
+            dest.writeHeader(HeaderType.UUID)
             value.toLongs { msb, lsb ->
                 dest.writeLong(msb)
                 dest.writeLong(lsb)
@@ -154,7 +166,7 @@ public sealed class HeaderValue {
                 HeaderType.UUID -> {
                     val msb = source.readLong()
                     val lsb = source.readLong()
-                    HeaderValue.Uuid(kotlin.uuid.Uuid.fromLongs(msb, lsb))
+                    HeaderValue.Uuid4(kotlin.uuid.Uuid.fromLongs(msb, lsb))
                 }
             }
         }
@@ -188,7 +200,12 @@ public fun HeaderValue.expectByteArray(): ByteArray = checkNotNull((this as? Hea
 public fun HeaderValue.expectTimestamp(): Instant = checkNotNull((this as? HeaderValue.Timestamp)?.value) { "expected HeaderValue.Bool, found: $this" }
 
 @InternalApi
-public fun HeaderValue.expectUuid(): kotlin.uuid.Uuid = checkNotNull((this as? HeaderValue.Uuid)?.value) { "expected HeaderValue.Uuid, found: $this" }
+@Suppress("DEPRECATION")
+@Deprecated("Use expectUuid4 instead", ReplaceWith("expectUuid4()"))
+public fun HeaderValue.expectUuid(): Uuid = checkNotNull((this as? HeaderValue.Uuid)?.value) { "expected HeaderValue.Uuid, found: $this" }
+
+@InternalApi
+public fun HeaderValue.expectUuid4(): kotlin.uuid.Uuid = checkNotNull((this as? HeaderValue.Uuid4)?.value) { "expected HeaderValue.Uuid4, found: $this" }
 
 @InternalApi
 public fun <T> HeaderValue.expectEnumValue(fromValue: (String) -> T): T = fromValue(expectString())

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValueTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValueTest.kt
@@ -6,12 +6,13 @@
 package aws.smithy.kotlin.runtime.awsprotocol.eventstream
 
 import aws.smithy.kotlin.runtime.time.Instant
-import kotlin.uuid.Uuid
+import aws.smithy.kotlin.runtime.util.Uuid
 import io.kotest.matchers.string.shouldContain
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.uuid.Uuid as KotlinUuid
 
 class HeaderValueTest {
 
@@ -26,8 +27,12 @@ class HeaderValueTest {
         assertContentEquals("foo".encodeToByteArray(), HeaderValue.ByteArray("foo".encodeToByteArray()).expectByteArray())
         val ts = Instant.now()
         assertEquals(ts, HeaderValue.Timestamp(ts).expectTimestamp())
+        @Suppress("DEPRECATION")
         val uuid = Uuid.random()
+        @Suppress("DEPRECATION")
         assertEquals(uuid, HeaderValue.Uuid(uuid).expectUuid())
+        val uuid4 = KotlinUuid.random()
+        assertEquals(uuid4, HeaderValue.Uuid4(uuid4).expectUuid4())
 
         assertFails {
             HeaderValue.Int32(12).expectString()

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValueTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValueTest.kt
@@ -6,7 +6,7 @@
 package aws.smithy.kotlin.runtime.awsprotocol.eventstream
 
 import aws.smithy.kotlin.runtime.time.Instant
-import aws.smithy.kotlin.runtime.util.Uuid
+import kotlin.uuid.Uuid
 import io.kotest.matchers.string.shouldContain
 import kotlin.test.Test
 import kotlin.test.assertContentEquals

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValueTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValueTest.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.awsprotocol.eventstream
 
+import aws.smithy.kotlin.runtime.PlannedRemoval
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.Uuid
 import io.kotest.matchers.string.shouldContain
@@ -28,8 +29,10 @@ class HeaderValueTest {
         val ts = Instant.now()
         assertEquals(ts, HeaderValue.Timestamp(ts).expectTimestamp())
         @Suppress("DEPRECATION")
+        @OptIn(PlannedRemoval::class)
         val uuid = Uuid.random()
         @Suppress("DEPRECATION")
+        @OptIn(PlannedRemoval::class)
         assertEquals(uuid, HeaderValue.Uuid(uuid).expectUuid())
         val uuid4 = KotlinUuid.random()
         assertEquals(uuid4, HeaderValue.Uuid4(uuid4).expectUuid4())

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageTest.kt
@@ -8,10 +8,9 @@ package aws.smithy.kotlin.runtime.awsprotocol.eventstream
 import aws.smithy.kotlin.runtime.io.EOFException
 import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.time.Instant
-import kotlin.uuid.Uuid
-
 import io.kotest.matchers.string.shouldContain
 import kotlin.test.*
+import kotlin.uuid.Uuid
 
 fun sdkBufferOf(b: ByteArray): SdkBuffer = SdkBuffer().apply { write(b) }
 
@@ -105,7 +104,7 @@ class MessageTest {
             addHeader("bytes", HeaderValue.ByteArray("some bytes".encodeToByteArray()))
             addHeader("str", HeaderValue.String("some str"))
             addHeader("time", HeaderValue.Timestamp(Instant.fromEpochSeconds(5_000_000, 0)))
-            addHeader("uuid", HeaderValue.Uuid(Uuid.fromLongs(0xb79bc914de214e13u.toLong(), 0xb8b2bc47e85b7f0bu.toLong())))
+            addHeader("uuid", HeaderValue.Uuid4(Uuid.fromLongs(0xb79bc914de214e13u.toLong(), 0xb8b2bc47e85b7f0bu.toLong())))
         }
 
         val dest = SdkBuffer()

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageTest.kt
@@ -8,7 +8,8 @@ package aws.smithy.kotlin.runtime.awsprotocol.eventstream
 import aws.smithy.kotlin.runtime.io.EOFException
 import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.time.Instant
-import aws.smithy.kotlin.runtime.util.Uuid
+import kotlin.uuid.Uuid
+
 import io.kotest.matchers.string.shouldContain
 import kotlin.test.*
 
@@ -104,7 +105,7 @@ class MessageTest {
             addHeader("bytes", HeaderValue.ByteArray("some bytes".encodeToByteArray()))
             addHeader("str", HeaderValue.String("some str"))
             addHeader("time", HeaderValue.Timestamp(Instant.fromEpochSeconds(5_000_000, 0)))
-            addHeader("uuid", HeaderValue.Uuid(Uuid(0xb79bc914de214e13u.toLong(), 0xb8b2bc47e85b7f0bu.toLong())))
+            addHeader("uuid", HeaderValue.Uuid(Uuid.fromLongs(0xb79bc914de214e13u.toLong(), 0xb8b2bc47e85b7f0bu.toLong())))
         }
 
         val dest = SdkBuffer()

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
@@ -13,10 +13,10 @@ import aws.smithy.kotlin.runtime.http.complete
 import aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.telemetry.trace.withSpan
-import kotlin.uuid.Uuid
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.job
 import kotlin.reflect.KClass
+import kotlin.uuid.Uuid
 
 /**
  * A (Smithy) HTTP based operation.

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
@@ -13,7 +13,7 @@ import aws.smithy.kotlin.runtime.http.complete
 import aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.telemetry.trace.withSpan
-import aws.smithy.kotlin.runtime.util.Uuid
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.job
 import kotlin.reflect.KClass

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
@@ -17,8 +17,7 @@ public data class Uuid(val high: Long, val low: Long) {
     @InternalApi
     public companion object {
         @Suppress("DEPRECATION")
-        public fun random(): Uuid =
-            KotlinUuid.random().toLongs { high, low -> Uuid(high, low) }
+        public fun random(): Uuid = KotlinUuid.random().toLongs { high, low -> Uuid(high, low) }
     }
 
     override fun toString(): String = KotlinUuid.fromLongs(high, low).toString()

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
@@ -5,7 +5,7 @@
 package aws.smithy.kotlin.runtime.util
 
 import aws.smithy.kotlin.runtime.InternalApi
-import kotlin.random.Random
+import kotlin.uuid.Uuid as KotlinUuid
 
 /**
  * A KMP-compatible implementation of UUID, necessary because no cross-platform implementation exists yet.
@@ -15,24 +15,14 @@ public data class Uuid(val high: Long, val low: Long) {
     @InternalApi
     public companion object {
         private val nibbleChars = "0123456789abcdef".toCharArray()
-        private val random = Random
-
-        private val v4Mask = 0x00000000_0000_f000U.toLong()
-        private val v4Set = 0x00000000_0000_4000U.toLong()
-
-        private val type2Mask = 0xc000_000000000000U.toLong()
-        private val type2Set = 0x8000_000000000000U.toLong()
 
         /**
          * Generates a random [Uuid], specifically a
          * [UUID v4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29).
-         * UUIDs are not generated with a cryptographically-strong random number generator.
+         * Delegates to [kotlin.uuid.Uuid.random] which uses platform-appropriate secure randomness
          */
-        public fun random(): Uuid {
-            val high = random.nextLong() and v4Mask.inv() or v4Set
-            val low = random.nextLong() and type2Mask.inv() or type2Set
-            return Uuid(high, low)
-        }
+        public fun random(): Uuid =
+            KotlinUuid.random().toLongs { high, low -> Uuid(high, low) }
 
         /**
          * Generates a string representation of a UUID in the form of `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`, where `x`

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
@@ -8,66 +8,18 @@ import aws.smithy.kotlin.runtime.InternalApi
 import kotlin.uuid.Uuid as KotlinUuid
 
 /**
- * A KMP-compatible implementation of UUID, necessary because no cross-platform implementation exists yet.
+ * Internal UUID representation using raw high/low longs for wire-format serialization (e.g., event-stream headers).
+ * Random generation delegates to [kotlin.uuid.Uuid] for platform-appropriate secure randomness.
  */
+@Deprecated("Use kotlin.uuid.Uuid directly", ReplaceWith("kotlin.uuid.Uuid"))
 @InternalApi
 public data class Uuid(val high: Long, val low: Long) {
     @InternalApi
     public companion object {
-        private val nibbleChars = "0123456789abcdef".toCharArray()
-
-        /**
-         * Generates a random [Uuid], specifically a
-         * [UUID v4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29).
-         * Delegates to [kotlin.uuid.Uuid.random] which uses platform-appropriate secure randomness
-         */
+        @Suppress("DEPRECATION")
         public fun random(): Uuid =
             KotlinUuid.random().toLongs { high, low -> Uuid(high, low) }
-
-        /**
-         * Generates a string representation of a UUID in the form of `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`, where `x`
-         * is a hexadecimal digit from 0-f.
-         */
-        private fun toString(high: Long, low: Long): String {
-            val chars = CharArray(36) // 32 hex digits plus 4 hyphens
-
-            writeDigits(high, 0, chars, 0, 4)
-            chars[8] = '-'
-            writeDigits(high, 4, chars, 9, 2)
-            chars[13] = '-'
-            writeDigits(high, 6, chars, 14, 2)
-            chars[18] = '-'
-            writeDigits(low, 0, chars, 19, 2)
-            chars[23] = '-'
-            writeDigits(low, 2, chars, 24, 6)
-
-            return chars.concatToString()
-        }
-
-        /**
-         * Write hexadecimal digits to a character array from a source [Long].
-         * @param src The source bits as a [Long].
-         * @param srcOffset The offset (in bytes, from the left) within [src]. This offset should be between 0 and 8
-         * exclusive (since that's how many bytes are in a [Long]).
-         * @param dest The character array to receive the digits.
-         * @param destOffset The offset (in characters) within [dest]. This offset should generally be double the source
-         * offset (because each byte of source becomes two hex digits) plus however many interceding hyphens have been
-         * added to the array.
-         * @param length The length (in bytes) to write. (Twice this number of characters will be written.)
-         */
-        private fun writeDigits(src: Long, srcOffset: Int, dest: CharArray, destOffset: Int, length: Int) {
-            var shiftBits = 64 - srcOffset * 8
-            var destIndex = destOffset
-
-            repeat(length * 2) {
-                shiftBits -= 4
-                val nibble = src shr shiftBits and 0xf
-                dest[destIndex++] = nibbleChars[nibble.toInt()]
-            }
-        }
     }
 
-    private val stringRep = toString(high, low)
-
-    override fun toString(): String = stringRep
+    override fun toString(): String = KotlinUuid.fromLongs(high, low).toString()
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
@@ -5,6 +5,7 @@
 package aws.smithy.kotlin.runtime.util
 
 import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.PlannedRemoval
 import kotlin.uuid.Uuid as KotlinUuid
 
 /**
@@ -12,6 +13,7 @@ import kotlin.uuid.Uuid as KotlinUuid
  * Random generation delegates to [kotlin.uuid.Uuid] for platform-appropriate secure randomness.
  */
 @Deprecated("Use kotlin.uuid.Uuid directly", ReplaceWith("kotlin.uuid.Uuid"))
+@PlannedRemoval(1, 8)
 @InternalApi
 public data class Uuid(val high: Long, val low: Long) {
     @InternalApi

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/SystemPlatformProviderTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/SystemPlatformProviderTest.kt
@@ -6,6 +6,7 @@ package aws.smithy.kotlin.runtime.util
 
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.uuid.Uuid
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFails

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/SystemPlatformProviderTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/SystemPlatformProviderTest.kt
@@ -6,7 +6,6 @@ package aws.smithy.kotlin.runtime.util
 
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.uuid.Uuid
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -15,6 +14,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 class SystemPlatformProviderTest {
     @Test

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/UuidTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/UuidTest.kt
@@ -5,32 +5,20 @@
 package aws.smithy.kotlin.runtime.util
 
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 class UuidTest {
     @Test
-    fun `it should generate random UUIDs`() {
-        var seenUuids = mutableSetOf<Uuid>()
+    fun `it should generate a valid V4 UUID`() {
+        val uuid = Uuid.random()
 
-        repeat(100) {
-            // randomness is unpredictable so do this a bunch to lower risk of false positive
-            val uuid = Uuid.random()
+        uuid.toLongs { msb, lsb ->
+            val version = (msb ushr 12) and 0xF
+            assertTrue(version == 4L, "Expected UUID v4, got version $version")
 
-            // Check that v4 flag is set
-            assertEquals(0x00000000_0000_4000U.toLong(), uuid.high and 0x00000000_0000_f000U.toLong())
-
-            // Check that type 2 is set
-            assertEquals(0x8000_000000000000U.toLong(), uuid.low and 0xc000_000000000000U.toLong())
-
-            // Check that the UUID is truly random
-            assertTrue(seenUuids.add(uuid), """Generated UUID "$uuid" is not unique""")
+            val variant = (lsb ushr 62) and 0x3
+            assertTrue(variant == 2L, "Expected variant 2 (RFC 9562), got variant $variant")
         }
-    }
-
-    @Test
-    fun `it should yield valid UUID strings`() {
-        val uuid = Uuid(0x12345678_90ab_cdef, 0x2143_658709badcfe)
-        assertEquals("12345678-90ab-cdef-2143-658709badcfe", uuid.toString())
     }
 }

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/util/WritePermissionsJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/util/WritePermissionsJVMTest.kt
@@ -8,6 +8,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.attribute.PosixFilePermissions
 import kotlin.test.*
+import kotlin.uuid.Uuid
 
 class WritePermissionsJVMTest {
 

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/IdempotencyTokenProvider.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/IdempotencyTokenProvider.kt
@@ -4,7 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.client
 
-import aws.smithy.kotlin.runtime.util.Uuid
+import kotlin.uuid.Uuid
 
 /**
  * User-accessible configuration for client-side token generation.

--- a/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/RandomTempFile.kt
+++ b/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/RandomTempFile.kt
@@ -5,7 +5,7 @@
 package aws.smithy.kotlin.runtime.testing
 
 import aws.smithy.kotlin.runtime.InternalApi
-import aws.smithy.kotlin.runtime.util.Uuid
+import kotlin.uuid.Uuid
 
 /**
  * Creates a temporary file with random data

--- a/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
+++ b/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
@@ -5,10 +5,10 @@
 package aws.smithy.kotlin.runtime.testing
 
 import aws.smithy.kotlin.runtime.InternalApi
-import kotlin.uuid.Uuid
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.SystemTemporaryDirectory
+import kotlin.uuid.Uuid
 
 /**
  * Cleanup behavior for temporary directories created by [withTempDir].

--- a/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
+++ b/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
@@ -5,7 +5,7 @@
 package aws.smithy.kotlin.runtime.testing
 
 import aws.smithy.kotlin.runtime.InternalApi
-import aws.smithy.kotlin.runtime.util.Uuid
+import kotlin.uuid.Uuid
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.SystemTemporaryDirectory


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
[Uuid.random() uses non-cryptographic kotlin.random.Random; duplicate UUIDs (idempotency tokens, invocation IDs) under Lambda SnapStart](https://github.com/smithy-lang/smithy-kotlin/issues/1656)

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Previosly, we use `kotlin.random.Random` to generate UUID, this is a bug because whenever they use it in SnapStart, the same random UUID will be generated.

Since from Kotlin 2.4.0, UUID standard library api is stabilized, we should use it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
