### PR TITLE
date optimization

### DIFF
--- a/runtime/auth/aws-signing-common/api/aws-signing-common.api
+++ b/runtime/auth/aws-signing-common/api/aws-signing-common.api
@@ -84,6 +84,8 @@ public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig {
 	public final fun getAlgorithm ()Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAlgorithm;
 	public final fun getCredentials ()Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
 	public final fun getExpiresAfter-FghU774 ()Lkotlin/time/Duration;
+	public final fun getFormattedSigningDate ()Ljava/lang/String;
+	public final fun getFormattedSigningDateShort ()Ljava/lang/String;
 	public final fun getHashSpecification ()Laws/smithy/kotlin/runtime/auth/awssigning/HashSpecification;
 	public final fun getLogRequest ()Z
 	public final fun getNormalizeUriPath ()Z

--- a/runtime/auth/aws-signing-common/api/aws-signing-common.api
+++ b/runtime/auth/aws-signing-common/api/aws-signing-common.api
@@ -85,7 +85,7 @@ public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig {
 	public final fun getCredentials ()Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
 	public final fun getExpiresAfter-FghU774 ()Lkotlin/time/Duration;
 	public final fun getFormattedSigningDate ()Ljava/lang/String;
-	public final fun getFormattedSigningDateShort ()Ljava/lang/String;
+	public final fun getFormattedSigningDateOnly ()Ljava/lang/String;
 	public final fun getHashSpecification ()Laws/smithy/kotlin/runtime/auth/awssigning/HashSpecification;
 	public final fun getLogRequest ()Z
 	public final fun getNormalizeUriPath ()Z

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig.kt
@@ -6,6 +6,7 @@ package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.TimestampFormat
 import kotlin.time.Duration
 
 public typealias ShouldSignHeaderPredicate = (String) -> Boolean
@@ -92,6 +93,18 @@ public class AwsSigningConfig(builder: Builder) {
      * construction time.
      */
     public val signingDate: Instant = builder.signingDate ?: Instant.now()
+
+    /**
+     * The signing date formatted as a condensed ISO-8601 timestamp (e.g., "20260714T163045Z").
+     * Pre-computed to avoid repeated formatting.
+     */
+    public val formattedSigningDate: String = signingDate.format(TimestampFormat.ISO_8601_CONDENSED)
+
+    /**
+     * The signing date formatted as a condensed ISO-8601 date only (e.g., "20260714").
+     * Pre-computed to avoid repeated formatting.
+     */
+    public val formattedSigningDateShort: String = signingDate.format(TimestampFormat.ISO_8601_CONDENSED_DATE)
 
     /**
      * A predicate to control which headers are a part of the canonical request. Note that skipping auth-required

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig.kt
@@ -104,7 +104,7 @@ public class AwsSigningConfig(builder: Builder) {
      * The signing date formatted as a condensed ISO-8601 date only (e.g., "20260714").
      * Pre-computed to avoid repeated formatting.
      */
-    public val formattedSigningDateShort: String = signingDate.format(TimestampFormat.ISO_8601_CONDENSED_DATE)
+    public val formattedSigningDateOnly: String = signingDate.format(TimestampFormat.ISO_8601_CONDENSED_DATE)
 
     /**
      * A predicate to control which headers are a part of the canonical request. Note that skipping auth-required

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/BaseSigV4SignatureCalculator.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/BaseSigV4SignatureCalculator.kt
@@ -10,7 +10,6 @@ import aws.smithy.kotlin.runtime.hashing.hash
 import aws.smithy.kotlin.runtime.hashing.sha256
 import aws.smithy.kotlin.runtime.text.encoding.encodeToHex
 import aws.smithy.kotlin.runtime.time.Instant
-import aws.smithy.kotlin.runtime.time.TimestampFormat
 import aws.smithy.kotlin.runtime.time.epochMilliseconds
 
 /**
@@ -31,14 +30,14 @@ internal abstract class BaseSigV4SignatureCalculator(
 
     override fun stringToSign(canonicalRequest: String, config: AwsSigningConfig): String = buildString {
         appendLine(algorithm.signingName)
-        appendLine(config.signingDate.format(TimestampFormat.ISO_8601_CONDENSED))
+        appendLine(config.formattedSigningDate)
         appendLine(config.credentialScope)
         append(canonicalRequest.encodeToByteArray().hash(sha256Provider).encodeToHex())
     }
 
     override fun chunkStringToSign(chunkBody: ByteArray, prevSignature: ByteArray, config: AwsSigningConfig): String = buildString {
         appendLine("${algorithm.signingName}-PAYLOAD")
-        appendLine(config.signingDate.format(TimestampFormat.ISO_8601_CONDENSED))
+        appendLine(config.formattedSigningDate)
         appendLine(config.credentialScope)
         appendLine(prevSignature.decodeToString()) // Should already be a byte array of ASCII hex chars
 
@@ -53,7 +52,7 @@ internal abstract class BaseSigV4SignatureCalculator(
 
     override fun chunkTrailerStringToSign(trailingHeaders: ByteArray, prevSignature: ByteArray, config: AwsSigningConfig): String = buildString {
         appendLine("${algorithm.signingName}-TRAILER")
-        appendLine(config.signingDate.format(TimestampFormat.ISO_8601_CONDENSED))
+        appendLine(config.formattedSigningDate)
         appendLine(config.credentialScope)
         appendLine(prevSignature.decodeToString())
         append(trailingHeaders.hash(sha256Provider).encodeToHex())

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
@@ -19,7 +19,6 @@ import aws.smithy.kotlin.runtime.net.url.UrlPath
 import aws.smithy.kotlin.runtime.text.encoding.Encodable
 import aws.smithy.kotlin.runtime.text.encoding.PercentEncoding
 import aws.smithy.kotlin.runtime.text.encoding.encodeToHex
-import aws.smithy.kotlin.runtime.time.TimestampFormat
 import kotlinx.coroutines.withContext
 
 /**
@@ -127,7 +126,7 @@ internal class DefaultCanonicalizer(private val sha256Supplier: HashSupplier = :
         param("X-Amz-Algorithm", config.algorithm.signingName, signViaQueryParams)
         param("X-Amz-Credential", credentialValue(config), signViaQueryParams)
         param("X-Amz-Content-Sha256", hash, addHashHeader)
-        param("X-Amz-Date", config.signingDate.format(TimestampFormat.ISO_8601_CONDENSED))
+        param("X-Amz-Date", config.formattedSigningDate)
         param("X-Amz-Expires", config.expiresAfter?.inWholeSeconds?.toString(), signViaQueryParams)
         param("X-Amz-Security-Token", sessionToken, !config.omitSessionToken) // Add pre-sig if omitSessionToken=false
         param("X-Amz-Region-Set", config.region, config.algorithm == AwsSigningAlgorithm.SIGV4_ASYMMETRIC)

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/RequestMutator.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/RequestMutator.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
-import aws.smithy.kotlin.runtime.time.TimestampFormat
 
 /**
  * An object that can mutate requests to include signing attributes.
@@ -61,12 +60,9 @@ internal class DefaultRequestMutator : RequestMutator {
  * Formats a credential scope consisting of a signing date, region (SigV4 only), service, and a signature type
  */
 internal val AwsSigningConfig.credentialScope: String
-    get() {
-        val signingDate = signingDate.format(TimestampFormat.ISO_8601_CONDENSED_DATE)
-        return when (algorithm) {
-            AwsSigningAlgorithm.SIGV4 -> "$signingDate/$region/$service/aws4_request"
-            AwsSigningAlgorithm.SIGV4_ASYMMETRIC -> "$signingDate/$service/aws4_request"
-        }
+    get() = when (algorithm) {
+        AwsSigningAlgorithm.SIGV4 -> "$formattedSigningDateShort/$region/$service/aws4_request"
+        AwsSigningAlgorithm.SIGV4_ASYMMETRIC -> "$formattedSigningDateShort/$service/aws4_request"
     }
 
 /**

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/RequestMutator.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/RequestMutator.kt
@@ -61,8 +61,8 @@ internal class DefaultRequestMutator : RequestMutator {
  */
 internal val AwsSigningConfig.credentialScope: String
     get() = when (algorithm) {
-        AwsSigningAlgorithm.SIGV4 -> "$formattedSigningDateShort/$region/$service/aws4_request"
-        AwsSigningAlgorithm.SIGV4_ASYMMETRIC -> "$formattedSigningDateShort/$service/aws4_request"
+        AwsSigningAlgorithm.SIGV4 -> "$formattedSigningDateOnly/$region/$service/aws4_request"
+        AwsSigningAlgorithm.SIGV4_ASYMMETRIC -> "$formattedSigningDateOnly/$service/aws4_request"
     }
 
 /**

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/SigV4SignatureCalculator.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/SigV4SignatureCalculator.kt
@@ -8,7 +8,6 @@ import aws.smithy.kotlin.runtime.hashing.HashSupplier
 import aws.smithy.kotlin.runtime.hashing.Sha256
 import aws.smithy.kotlin.runtime.hashing.hmac
 import aws.smithy.kotlin.runtime.text.encoding.encodeToHex
-import aws.smithy.kotlin.runtime.time.TimestampFormat
 
 /**
  * [SignatureCalculator] for the SigV4 ("AWS4-HMAC-SHA256") algorithm
@@ -21,7 +20,7 @@ internal class SigV4SignatureCalculator(override val sha256Provider: HashSupplie
         fun hmac(key: ByteArray, message: String) = hmac(key, message.encodeToByteArray(), sha256Provider)
 
         val initialKey = ("AWS4" + config.credentials.secretAccessKey).encodeToByteArray()
-        val kDate = hmac(initialKey, config.signingDate.format(TimestampFormat.ISO_8601_CONDENSED_DATE))
+        val kDate = hmac(initialKey, config.formattedSigningDateShort)
         val kRegion = hmac(kDate, config.region)
         val kService = hmac(kRegion, config.service)
         return hmac(kService, "aws4_request")

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/SigV4SignatureCalculator.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/SigV4SignatureCalculator.kt
@@ -20,7 +20,7 @@ internal class SigV4SignatureCalculator(override val sha256Provider: HashSupplie
         fun hmac(key: ByteArray, message: String) = hmac(key, message.encodeToByteArray(), sha256Provider)
 
         val initialKey = ("AWS4" + config.credentials.secretAccessKey).encodeToByteArray()
-        val kDate = hmac(initialKey, config.formattedSigningDateShort)
+        val kDate = hmac(initialKey, config.formattedSigningDateOnly)
         val kRegion = hmac(kDate, config.region)
         val kService = hmac(kRegion, config.service)
         return hmac(kService, "aws4_request")

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/NoTraceParseException.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/NoTraceParseException.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.time
+
+/**
+ * A lightweight [ParseException] that suppresses stack trace capture on JVM.
+ * Used internally by parser combinators (e.g., [alt]) where exceptions are used for control flow
+ * and the stack trace is never inspected.
+ */
+internal expect class NoTraceParseException(input: String, message: String, position: Int) : ParseException

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/ParserCombinators.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/ParserCombinators.kt
@@ -81,7 +81,7 @@ internal fun isDigit(chr: Char): Boolean = chr in '0'..'9'
 internal fun char(chr: Char): Parser<Char> = { str, pos ->
     precond(str, pos, 1)
     val c = str[pos]
-    if (c != chr) throw ParseException(str, "expected `$chr` found `$c`", pos)
+    if (c != chr) throw NoTraceParseException(str, "expected `$chr` found `$c`", pos)
     ParseResult(pos + 1, c)
 }
 
@@ -98,7 +98,7 @@ internal fun oneOf(chars: String): Parser<Char> = { str, pos ->
             break
         }
     }
-    result ?: throw ParseException(str, "expected one of `$chars` found $c", pos)
+    result ?: throw NoTraceParseException(str, "expected one of `$chars` found $c", pos)
 }
 
 /**
@@ -110,7 +110,7 @@ internal fun tag(match: String): Parser<String> = { str, pos ->
     for ((idx, chr) in match.withIndex()) {
         val i = pos + idx
         if (str[i] != chr) {
-            throw ParseException(str, "expected `$match` found `${str.substring(pos, pos + match.length)}`", pos)
+            throw NoTraceParseException(str, "expected `$match` found `${str.substring(pos, pos + match.length)}`", pos)
         }
     }
 
@@ -173,17 +173,17 @@ internal fun <T : Number> takeMNDigitsT(m: Int, n: Int, transform: (String, IntR
     try {
         val (pos1, range) = takeWhileMN(m, n, ::isDigit)(str, pos)
         if (range.isEmpty()) {
-            throw ParseException(str, "expected integer", pos)
+            throw NoTraceParseException(str, "expected integer", pos)
         }
 
         val res = transform(str, range)
         ParseResult(pos1, res)
     } catch (ex: TakeWhileMNException) {
         val msg = fmtTakeWhileErrorMsg(m, n, ex.expected, "found ${ex.matched}")
-        throw ParseException(str, msg, pos)
+        throw NoTraceParseException(str, msg, pos)
     } catch (ex: IncompleteException) {
         val msg = fmtTakeWhileErrorMsg(m, n, m, "${ex.needed}")
-        throw ParseException(str, msg, pos)
+        throw NoTraceParseException(str, msg, pos)
     }
 }
 
@@ -218,7 +218,7 @@ internal fun mnDigitsInRange(m: Int, n: Int, range: IntRange): Parser<Int> = { s
     precond(str, pos)
     val (pos0, result) = takeMNDigitsInt(m, n)(str, pos)
     if (!range.contains(result)) {
-        throw ParseException(str, "$result not in range $range", pos)
+        throw NoTraceParseException(str, "$result not in range $range", pos)
     }
 
     ParseResult(pos0, result)
@@ -239,7 +239,7 @@ internal fun fraction(m: Int, n: Int, denomDigits: Int): Parser<Int> = { str, po
 
     val (pos0, range) = takeWhileMN(m, n, ::isDigit)(str, pos)
     if (range.isEmpty()) {
-        throw ParseException(str, "expected integer", pos)
+        throw NoTraceParseException(str, "expected integer", pos)
     }
 
     var result = str.substring(range).toInt()

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/NoTraceParseException.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/NoTraceParseException.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.time
+
+internal actual class NoTraceParseException actual constructor(
+    input: String,
+    message: String,
+    position: Int,
+) : ParseException(input, message, position) {
+    override fun fillInStackTrace(): Throwable = this
+}

--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/time/NoTraceParseException.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/time/NoTraceParseException.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.time
+
+internal actual class NoTraceParseException actual constructor(
+    input: String,
+    message: String,
+    position: Int,
+) : ParseException(input, message, position)


### PR DESCRIPTION
## Summary

- Pre-compute formatted signing dates in `AwsSigningConfig` to avoid repeated `Instant.format()` calls during SigV4 signing
- Suppress `fillInStackTrace` on internal parser exceptions to eliminate expensive JVM stack walks during RFC-5322 date parsing

## Motivation

Profiling sequential DynamoDB latency benchmarks revealed two date-related hotspots in the per-request signing and response handling paths:

1. **Repeated date formatting**: `Instant.format(TimestampFormat.ISO_8601_CONDENSED)` was called 6 times per signing operation (in `stringToSign`, `credentialScope`, `signingKey`, and `canonicalRequest`), each time producing the same string from the same `Instant`.

2. **Exception-driven date parsing**: The `ClockSkewInterceptor` parses the response `Date` header on every request via `Instant.fromRfc5322()`. The parser combinator's `alt` function uses exceptions for backtracking — matching the day name "Thu" requires throwing and catching 3 `ParseException` instances (for "Mon", "Tue", "Wed"). Each exception triggers `Throwable.fillInStackTrace()`, a native JNI call that walks the entire thread stack (~50+ frames deep in coroutine + middleware context), costing ~5-15µs per exception.

### What changed

**Date formatting (signing path):**
`AwsSigningConfig` now exposes `formattedSigningDate` and `formattedSigningDateShort` properties, computed once at construction. All 6 call sites in `BaseSigV4SignatureCalculator`, `Canonicalizer`, `RequestMutator`, and `SigV4SignatureCalculator` use the pre-computed values.

**Date parsing (response path):**
Introduced `NoTraceParseException` as an `expect/actual` class:
- JVM actual: overrides `fillInStackTrace()` to return `this` (no-op)
- Native actual: plain subclass (stack traces are not expensive on Native)

All internal parser combinator throw sites (`char()`, `tag()`, `oneOf()`, `takeMNDigitsT()`, `mnDigitsInRange()`, `fraction()`) now throw `NoTraceParseException`. The final `alt` failure that may escape to user code retains the full `ParseException` with stack trace for diagnosability.

## Benchmark Results

All benchmarks run on m7i.2xlarge instances with the following configuration:
- **Operations per batch:** 100,000
- **Warmup batches:** 3
- **Measurement batches:** 5

### E2E Latency (DynamoDB)

14 paired instances (base and target on same host).

#### DynamoDB PutItem
| Metric | Base (ms) | Target (ms) | Change |
|---|---|---|---|
| Average | 4.36 | 4.34 | -0.50% |
| P50 | 4.20 | 4.19 | -0.27% |
| P90 | 4.93 | 4.88 | -1.02% |
| P99 | 7.23 | 7.01 | **-3.01%** |

#### DynamoDB GetItem
| Metric | Base (ms) | Target (ms) | Change |
|---|---|---|---|
| Average | 3.35 | 3.18 | **-4.92%** |
| P50 | 3.20 | 3.05 | **-4.53%** |
| P90 | 3.84 | 3.69 | **-3.90%** |
| P99 | 6.40 | 5.98 | **-6.50%** |

**Latency observations:**
- GetItem shows consistent improvement across all percentiles (**-4.5% to -6.5%**) — the date parsing optimization is directly visible since response handling (where `ClockSkewInterceptor` parses the `Date` header) represents a larger fraction of the shorter GET latency
- PutItem shows modest tail-latency improvement (**-3% at P99**) — the signing date formatting optimization benefits both operations equally, but PUT latency is dominated by network round-trip for the larger request body
- No CPU or memory regression — resource usage is effectively identical

### E2E Throughput (S3)

This optimization targets per-request fixed costs (date format/parse), which are negligible relative to the I/O and crypto costs that dominate high-concurrency throughput workloads. No meaningful throughput change expected or observed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
