### PR TITLE
Unsigned payload over HTTPS

### DIFF
--- a/.changes/1b2bc878-31c3-4e27-98f9-506d278467f3.json
+++ b/.changes/1b2bc878-31c3-4e27-98f9-506d278467f3.json
@@ -1,6 +1,6 @@
 {
   "id": "1b2bc878-31c3-4e27-98f9-506d278467f3",
   "type": "feature",
-  "description": "Add `PayloadSigningEnabled` signing attribute to allow services to skip SHA-256 payload hashing over HTTPS, reducing CPU overhead for large request bodies",
+  "description": "Add `PayloadSigningEnabled` signing attribute to allow services to skip SigV4 payload signing over HTTPS, reducing CPU overhead for large request bodies",
   "module": "aws-signing"
 }

--- a/.changes/1b2bc878-31c3-4e27-98f9-506d278467f3.json
+++ b/.changes/1b2bc878-31c3-4e27-98f9-506d278467f3.json
@@ -1,5 +1,5 @@
 {
-  "id": "b2c3d4e5-6f7a-8b9c-0d1e-unsignpayload",
+  "id": "1b2bc878-31c3-4e27-98f9-506d278467f3",
   "type": "feature",
   "description": "Add `PayloadSigningEnabled` signing attribute to allow services to skip SHA-256 payload hashing over HTTPS, reducing CPU overhead for large request bodies",
   "module": "aws-signing"

--- a/.changes/b2c3d4e5-unsigned-payload.json
+++ b/.changes/b2c3d4e5-unsigned-payload.json
@@ -1,0 +1,6 @@
+{
+  "id": "b2c3d4e5-6f7a-8b9c-0d1e-unsignpayload",
+  "type": "feature",
+  "description": "Add `PayloadSigningEnabled` signing attribute to allow services to skip SHA-256 payload hashing over HTTPS, reducing CPU overhead for large request bodies",
+  "module": "aws-signing"
+}

--- a/runtime/auth/aws-signing-common/api/aws-signing-common.api
+++ b/runtime/auth/aws-signing-common/api/aws-signing-common.api
@@ -68,6 +68,7 @@ public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttribute
 	public final fun getHashSpecification ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getNormalizeUriPath ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getOmitSessionToken ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getPayloadSigningEnabled ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getRequestSignature ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getSignedBodyHeader ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getSigner ()Laws/smithy/kotlin/runtime/collections/AttributeKey;

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
@@ -96,4 +96,11 @@ public object AwsSigningAttributes {
      * Flag indicating whether the X-Amz-Security-Token header should be omitted from the canonical request during signing.
      */
     public val OmitSessionToken: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin.signing#OmitSessionToken")
+
+    /**
+     * Flag indicating whether request payloads should be signed. When `false`, payload signing is skipped
+     * for HTTPS requests (using `UNSIGNED-PAYLOAD` instead). When `true`, payloads are always signed.
+     * Payloads are always signed for HTTP (non-TLS) requests regardless of this setting.
+     */
+    public val PayloadSigningEnabled: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin.signing#PayloadSigningEnabled")
 }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
@@ -98,9 +98,11 @@ public object AwsSigningAttributes {
     public val OmitSessionToken: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin.signing#OmitSessionToken")
 
     /**
-     * Flag indicating whether request payloads should be signed. When `false`, payload signing is skipped
-     * for HTTPS requests (using `UNSIGNED-PAYLOAD` instead). When `true`, payloads are always signed.
-     * Payloads are always signed for HTTP (non-TLS) requests regardless of this setting.
+     * Flag indicating whether request payloads should be signed. Default to `true`.
+     * When `false`, payload signing is skipped for HTTPS requests (using `UNSIGNED-PAYLOAD` instead).
+     * Note: This flag does not solely control request payload signing behavior. Other factors — such as the
+     * operation's auth scheme, the `unsignedPayload` trait, and `AwsHttpSigner.Config.isUnsignedPayload` — are
+     * also taken into account, and this flag does not override them.
      */
     public val PayloadSigningEnabled: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin.signing#PayloadSigningEnabled")
 }

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -161,9 +161,10 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
             signedBodyHeader = contextSignedBodyHeader ?: config.signedBodyHeader
             logRequest = attributes.getOrNull(SdkClientOption.LogMode)?.isEnabled(LogMode.LogRequest) == true
 
-            // SDKs are supposed to default to signed payload _always_ when possible (and when `unsignedPayload` trait
-            // isn't present). The only exception is when the customer explicitly disables signed payloads (via Config.isUnsignedPayload)
-            // or when payload signing is disabled at the client level (PayloadSigningEnabled = false) over HTTPS.
+            // SDKs are supposed to default to signed payload _always_ when possible, unless:
+            //   - the `unsignedPayload` trait is present
+            //   - the customer explicitly disables signed payloads (via Config.isUnsignedPayload)
+            //   - payload signing is disabled at the client level (PayloadSigningEnabled = false) over HTTPS
             val effectiveUnsignedPayload = config.isUnsignedPayload ||
                 (!payloadSigningEnabled && request.url.scheme == Scheme.HTTPS)
 

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -18,6 +18,7 @@ import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
@@ -129,6 +130,7 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
         val contextOmitSessionToken = attributes.getOrNull(AwsSigningAttributes.OmitSessionToken)
 
         val enableAwsChunked = attributes.getOrNull(AwsSigningAttributes.EnableAwsChunked) ?: false
+        val payloadSigningEnabled = attributes.getOrNull(AwsSigningAttributes.PayloadSigningEnabled) ?: true
 
         // operation signing config is baseConfig + operation specific config/overrides
         val signingConfig = AwsSigningConfig {
@@ -160,19 +162,22 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
             logRequest = attributes.getOrNull(SdkClientOption.LogMode)?.isEnabled(LogMode.LogRequest) == true
 
             // SDKs are supposed to default to signed payload _always_ when possible (and when `unsignedPayload` trait
-            // isn't present). The only exception is when the customer explicitly disables signed payloads (via Config.isUnsignedPayload).
+            // isn't present). The only exception is when the customer explicitly disables signed payloads (via Config.isUnsignedPayload)
+            // or when payload signing is disabled at the client level (PayloadSigningEnabled = false) over HTTPS.
+            val effectiveUnsignedPayload = config.isUnsignedPayload ||
+                (!payloadSigningEnabled && request.url.scheme == Scheme.HTTPS)
 
             hashSpecification = when {
                 contextHashSpecification != null -> contextHashSpecification
                 body is HttpBody.Empty -> HashSpecification.EmptyBody
                 body.isEligibleForAwsChunkedStreaming && enableAwsChunked -> {
                     if (request.headers.contains("x-amz-trailer")) {
-                        if (config.isUnsignedPayload) HashSpecification.StreamingUnsignedPayloadWithTrailers else HashSpecification.StreamingAws4HmacSha256PayloadWithTrailers
+                        if (effectiveUnsignedPayload) HashSpecification.StreamingUnsignedPayloadWithTrailers else HashSpecification.StreamingAws4HmacSha256PayloadWithTrailers
                     } else {
                         HashSpecification.StreamingAws4HmacSha256Payload
                     }
                 }
-                config.isUnsignedPayload -> HashSpecification.UnsignedPayload
+                effectiveUnsignedPayload -> HashSpecification.UnsignedPayload
                 // use the payload to compute the hash
                 else -> HashSpecification.CalculateFromPayload
             }

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
@@ -6,12 +6,14 @@ package aws.smithy.kotlin.runtime.http.auth
 
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
+import aws.smithy.kotlin.runtime.auth.awssigning.AwsSignedBodyHeader
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigner
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningAttributes
 import aws.smithy.kotlin.runtime.auth.awssigning.DefaultAwsSigner
 import aws.smithy.kotlin.runtime.auth.awssigning.internal.AWS_CHUNKED_THRESHOLD
 import aws.smithy.kotlin.runtime.collections.Attributes
 import aws.smithy.kotlin.runtime.collections.get
+import aws.smithy.kotlin.runtime.hashing.sha256
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpMethod
 import aws.smithy.kotlin.runtime.http.SdkHttpClient
@@ -25,6 +27,7 @@ import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.net.Host
 import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import aws.smithy.kotlin.runtime.text.encoding.encodeToHex
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
@@ -47,11 +50,14 @@ public abstract class AwsHttpSignerTestBase(
         streaming: Boolean = false,
         replayable: Boolean = true,
         unsigned: Boolean = false,
+        payloadSigningEnabled: Boolean? = null,
+        scheme: Scheme = Scheme.HTTP,
+        signedBodyHeader: AwsSignedBodyHeader = AwsSignedBodyHeader.NONE,
     ): SdkHttpOperation<Unit, HttpResponse> {
         val operation: SdkHttpOperation<Unit, HttpResponse> = SdkHttpOperation.build {
             serializeWith = when (streaming) {
-                true -> StreamingSerializer(requestBody, replayable)
-                false -> NonStreamingSerializer(requestBody)
+                true -> StreamingSerializer(requestBody, replayable, scheme)
+                false -> NonStreamingSerializer(requestBody, scheme)
             }
             deserializeWith = HttpDeserializer.Identity
             operationName = "testSigningOperation"
@@ -61,6 +67,7 @@ public abstract class AwsHttpSignerTestBase(
                 set(AwsSigningAttributes.SigningDate, Instant.fromIso8601("2020-10-16T19:56:00Z"))
                 set(AwsSigningAttributes.SigningService, "demo")
                 set(AwsSigningAttributes.EnableAwsChunked, true)
+                payloadSigningEnabled?.let { set(AwsSigningAttributes.PayloadSigningEnabled, it) }
             }
         }
 
@@ -72,6 +79,7 @@ public abstract class AwsHttpSignerTestBase(
             signer = this@AwsHttpSignerTestBase.signer
             service = "demo"
             isUnsignedPayload = unsigned
+            this.signedBodyHeader = signedBodyHeader
         }
 
         operation.execution.auth = OperationAuthConfig.from(idp.asIdentityProviderConfig(), SigV4AuthScheme(signerConfig))
@@ -111,6 +119,56 @@ public abstract class AwsHttpSignerTestBase(
         val signed = getSignedRequest(op)
         assertEquals(expectedDate, signed.headers["X-Amz-Date"])
         assertEquals(expectedSig, signed.headers["Authorization"])
+    }
+
+    @Test
+    public fun testPayloadSigningDisabledOverHttps(): TestResult = runTest {
+        // disabling payload signing over HTTPS should result in an unsigned payload. Emit the
+        // x-amz-content-sha256 header so we can directly assert the body hash is UNSIGNED-PAYLOAD.
+        val requestBody = "{\"TableName\": \"foo\"}"
+        val op = buildOperation(
+            requestBody = requestBody,
+            payloadSigningEnabled = false,
+            scheme = Scheme.HTTPS,
+            signedBodyHeader = AwsSignedBodyHeader.X_AMZ_CONTENT_SHA256,
+        )
+
+        val signed = getSignedRequest(op)
+        assertEquals("UNSIGNED-PAYLOAD", signed.headers["X-Amz-Content-Sha256"])
+    }
+
+    @Test
+    public fun testPayloadSigningDisabledOverHttp(): TestResult = runTest {
+        // disabling payload signing only takes effect over HTTPS, so over HTTP the payload is still signed:
+        // the x-amz-content-sha256 header should carry the actual SHA-256 of the body, not UNSIGNED-PAYLOAD.
+        val requestBody = "{\"TableName\": \"foo\"}"
+        val op = buildOperation(
+            requestBody = requestBody,
+            payloadSigningEnabled = false,
+            scheme = Scheme.HTTP,
+            signedBodyHeader = AwsSignedBodyHeader.X_AMZ_CONTENT_SHA256,
+        )
+
+        val signed = getSignedRequest(op)
+        val expectedHash = requestBody.encodeToByteArray().sha256().encodeToHex()
+        assertEquals(expectedHash, signed.headers["X-Amz-Content-Sha256"])
+    }
+
+    @Test
+    public fun testPayloadSigningEnabledOverHttps(): TestResult = runTest {
+        // explicitly enabling payload signing over HTTPS should sign the payload as usual:
+        // the x-amz-content-sha256 header should carry the actual SHA-256 of the body.
+        val requestBody = "{\"TableName\": \"foo\"}"
+        val op = buildOperation(
+            requestBody = requestBody,
+            payloadSigningEnabled = true,
+            scheme = Scheme.HTTPS,
+            signedBodyHeader = AwsSignedBodyHeader.X_AMZ_CONTENT_SHA256,
+        )
+
+        val signed = getSignedRequest(op)
+        val expectedHash = requestBody.encodeToByteArray().sha256().encodeToHex()
+        assertEquals(expectedHash, signed.headers["X-Amz-Content-Sha256"])
     }
 
     @Test
@@ -167,10 +225,13 @@ public abstract class AwsHttpSignerTestBase(
     }
 }
 
-private class NonStreamingSerializer(private val requestBody: String) : HttpSerializer.NonStreaming<Unit> {
+private class NonStreamingSerializer(
+    private val requestBody: String,
+    private val scheme: Scheme = Scheme.HTTP,
+) : HttpSerializer.NonStreaming<Unit> {
     override fun serialize(context: ExecutionContext, input: Unit) = HttpRequestBuilder().apply {
         method = HttpMethod.POST
-        url.scheme = Scheme.HTTP
+        url.scheme = scheme
         url.host = Host.Domain("demo.us-east-1.amazonaws.com")
         url.path.encoded = "/"
         body = HttpBody.fromBytes(requestBody.encodeToByteArray())
@@ -183,10 +244,11 @@ private class NonStreamingSerializer(private val requestBody: String) : HttpSeri
 private class StreamingSerializer(
     private val requestBody: String,
     private val replayable: Boolean,
+    private val scheme: Scheme = Scheme.HTTP,
 ) : HttpSerializer.Streaming<Unit> {
     override suspend fun serialize(context: ExecutionContext, input: Unit) = HttpRequestBuilder().apply {
         method = HttpMethod.POST
-        url.scheme = Scheme.HTTP
+        url.scheme = scheme
         url.host = Host.Domain("demo.us-east-1.amazonaws.com")
         url.path.encoded = "/"
         body = object : HttpBody.ChannelContent() {


### PR DESCRIPTION
## Summary

- Skip SHA-256 payload hashing for S3 requests over HTTPS by defaulting to `UNSIGNED-PAYLOAD`, consistent with AWS Java SDK v2 and Go SDK v2 behavior
- Add `payloadSigningEnabled` client config option for customers who need to force payload signing

## Motivation

Profiling S3 upload throughput benchmarks (256KiB objects, c256 concurrency) revealed that **SHA-256 payload hashing is the single largest CPU consumer at 11% of total samples**. For every `PutObject` request, `DefaultCanonicalizer.calculateHash()` reads and hashes the entire request body to produce the `x-amz-content-sha256` header value — even though the request is sent over HTTPS where TLS already provides transport-level integrity.

All other major AWS SDKs default to unsigned payload for S3 over HTTPS:
- **Java SDK v2**: `PAYLOAD_SIGNING_ENABLED = false` for all S3 operations ([source](https://github.com/aws/aws-sdk-java-v2/blob/master/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/plugins/S3OverrideAuthSchemePropertiesPlugin.java))
- **Go SDK v2**: `dynamicPayloadSigningMiddleware` uses `UnsignedPayload` over HTTPS for upload operations ([source](https://github.com/aws/aws-sdk-go-v2/blob/main/aws/signer/v4/middleware.go))
- **Python (botocore)**: `S3SigV4Auth` skips payload signing for streaming uploads over HTTPS ([source](https://github.com/boto/botocore/blob/develop/botocore/auth.py))

### What changed

**smithy-kotlin (runtime):**

`AwsSigningAttributes` gains a new `PayloadSigningEnabled` attribute key. `AwsHttpSigner.sign()` reads this attribute: when `false` and the request uses HTTPS, it sets `hashSpecification = HashSpecification.UnsignedPayload` instead of computing SHA-256 of the body. The default when the attribute is absent is `true` (always sign), ensuring non-S3 services are unaffected.

**aws-sdk-kotlin (S3 service codegen):**

`ClientConfigIntegration` adds a `payloadSigningEnabled: Boolean` config property (default: `false`). `S3SigningConfig` wires `config.payloadSigningEnabled` into the signing attributes via `putIfAbsent`. This means S3 operations use `UNSIGNED-PAYLOAD` over HTTPS by default, and customers can opt back into payload signing with:

```kotlin
S3Client {
    payloadSigningEnabled = true
}
```

### Cross-SDK references

| SDK | Default for S3 | Customer override | Source |
|---|---|---|---|
| Java v2 | `PAYLOAD_SIGNING_ENABLED = false` | `S3OverrideAuthSchemePropertiesPlugin.enablePayloadSigningPlugin()` | [S3OverrideAuthSchemePropertiesPlugin.java](https://github.com/aws/aws-sdk-java-v2/blob/master/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/plugins/S3OverrideAuthSchemePropertiesPlugin.java) |
| Go v2 | `UnsignedPayload` over HTTPS (automatic) | No client-level option | [v4/middleware.go](https://github.com/aws/aws-sdk-go-v2/blob/main/aws/signer/v4/middleware.go) |
| Python | Unsigned for streaming uploads over HTTPS | `Config(s3={'payload_signing_enabled': True})` | [botocore/auth.py](https://github.com/boto/botocore/blob/develop/botocore/auth.py) |

**Safety guarantees:**
- HTTP (non-TLS) requests are **always** signed regardless of this setting — the `Scheme.HTTPS` check ensures payload integrity when TLS is not protecting the transport
- Operations with explicit `@unsignedPayload` trait or `HashSpecification` set in context take precedence (no behavior change)
- The `x-amz-content-sha256: UNSIGNED-PAYLOAD` header is still emitted (required by S3) because `SignedBodyHeader = X_AMZ_CONTENT_SHA256` remains set as a service default

## Benchmark Results

All benchmarks run on m7i.2xlarge instances with the following configuration:
- **Operations per batch:** 100,000
- **Warmup batches:** 3
- **Measurement batches:** 5

### E2E Throughput (S3)

15 paired instances (base and target on same host).

#### S3 Upload
| Concurrency | Base (Gbps) | Target (Gbps) | Change | Base CPU% | Target CPU% |
|---|---|---|---|---|---|
| 16 | 4.02 | 4.25 | **+5.77%** | 26.0 | 22.1 |
| 32 | 7.13 | 7.51 | **+5.32%** | 61.4 | 57.6 |
| 64 | 8.79 | 9.37 | **+6.64%** | 94.6 | 87.8 |
| 128 | 8.53 | 8.91 | **+4.43%** | 96.5 | 90.8 |
| 256 | 8.15 | 8.57 | **+5.20%** | 97.5 | 94.3 |

#### S3 Download
| Concurrency | Base (Gbps) | Target (Gbps) | Change | Base CPU% | Target CPU% |
|---|---|---|---|---|---|
| 16 | 6.17 | 6.14 | -0.52% | 44.9 | 45.7 |
| 32 | 8.66 | 8.70 | +0.46% | 86.6 | 86.2 |
| 64 | 9.57 | 9.40 | -1.81% | 87.2 | 87.5 |
| 128 | 9.62 | 9.81 | +1.98% | 87.2 | 84.7 |
| 256 | 9.56 | 9.37 | -1.94% | 88.0 | 88.2 |

**Throughput observations:**
- S3 Upload shows statistically significant improvement at all concurrency levels (**+5-7%**, t > 3.5 at c16–c64) — directly from eliminating SHA-256 computation of the 256KiB body on every request
- S3 Download shows no meaningful change (expected — GET requests have empty bodies, so payload hashing was already trivial)
- CPU usage is lower in target for upload, consistent with eliminating the hashing work
- No memory regression

### E2E Latency (DynamoDB)

This optimization does not affect DynamoDB — DDB does not set `PayloadSigningEnabled` in its signing attributes, so payloads remain signed (the attribute defaults to `true` when absent). No latency change expected or observed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
