### PR TITLE
optimize signing canonical path

### DIFF
--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
@@ -217,6 +217,9 @@ internal fun Url.Builder.canonicalPath(config: AwsSigningConfig): String {
     val srcPath = path
     val srcSegments = srcPath.segments
 
+    // Fast path: "/" has no segments to encode or normalize
+    if (srcSegments.isEmpty()) return "/"
+
     val mapper: (Encodable) -> Encodable = when (config.useDoubleUriEncode) {
         true -> { existing ->
             // This is _double_ encoding so treat the existing encoded output as "decoded" for the purposes re-encoding
@@ -239,20 +242,24 @@ internal fun Url.Builder.canonicalPath(config: AwsSigningConfig): String {
  * Canonicalizes the query parameters from this [Url.Builder].
  * @return The canonicalized query parameters
  */
-internal fun Url.Builder.canonicalQueryParams(): String = QueryParameters {
-    parameters
-        .entries
-        .associate { (key, values) ->
-            val reencodedKey = key.reencode(PercentEncoding.SigV4)
-            val reencodedValues = values.map { it.reencode(PercentEncoding.SigV4) }
-            reencodedKey to reencodedValues
-        }
-        .entries
-        .sortedWith(compareBy { it.key.encoded }) // Sort keys
-        .associateTo(this) { (key, values) ->
-            key to values.sortedWith(compareBy { it.encoded }).toMutableList() // Sort values
-        }
-}.toString().removePrefix("?")
+internal fun Url.Builder.canonicalQueryParams(): String {
+    if (parameters.isEmpty()) return ""
+
+    return QueryParameters {
+        parameters
+            .entries
+            .associate { (key, values) ->
+                val reencodedKey = key.reencode(PercentEncoding.SigV4)
+                val reencodedValues = values.map { it.reencode(PercentEncoding.SigV4) }
+                reencodedKey to reencodedValues
+            }
+            .entries
+            .sortedWith(compareBy { it.key.encoded }) // Sort keys
+            .associateTo(this) { (key, values) ->
+                key to values.sortedWith(compareBy { it.encoded }).toMutableList() // Sort values
+            }
+    }.toString().removePrefix("?")
+}
 
 private fun Pair<String, List<String>>.canonicalLine(): String {
     val valuesString = second.joinToString(separator = ",") { it.trimAll() }


### PR DESCRIPTION
## Summary

- Short-circuit canonical path and query parameter processing in SigV4 signing for the common RPC case (path = "/", no query params)

## Motivation

For JSON-RPC services (DynamoDB, Lambda, STS, etc.), every request is a POST to `/` with no query parameters. Despite this, the SigV4 canonicalizer performed full path encoding and query parameter processing on every request — allocating intermediate builders, lists, and maps that are immediately discarded.

Profiling shows endpoint resolution and canonicalization together account for ~5% of SDK CPU on DynamoDB latency benchmarks. The Java SDK v2 implemented the same short-circuit in [PR #6383](https://github.com/aws/aws-sdk-java-v2/pull/6383), reporting a 25% reduction in signing latency.

### What changed

**`Canonicalizer.kt`:**

`canonicalPath()` — when `segments.isEmpty()` (the request path is `/`), returns the literal string `"/"` immediately. This skips:
- Allocating a `UrlPath.Builder` + intermediate `MutableList<Encodable>`
- Creating the double-encoding mapper lambda
- Calling `mapTo`, `normalize()`, and `joinToString`
- Building and stringifying a new `UrlPath` instance

`canonicalQueryParams()` — when `parameters.isEmpty()`, returns `""` immediately. This skips:
- Allocating a `QueryParameters.Builder`
- Calling `associate`, `sortedWith`, `associateTo` on empty collections
- Building and stringifying a new `QueryParameters` instance
- The `removePrefix("?")` call

For S3 (which uses path-style URLs like `/bucket/key`), the fast paths do not trigger — behavior is unchanged.

## Benchmark Results

All benchmarks run on m7i.2xlarge instances with the following configuration:
- **Operations per batch:** 100,000
- **Warmup batches:** 3
- **Measurement batches:** 5

### E2E Latency (DynamoDB)

15 paired instances (base and target on same host). Target includes this optimization combined with the date formatting/parsing optimization.

#### DynamoDB PutItem
| Metric | Base (ms) | Target (ms) | Change |
|---|---|---|---|
| Average | 4.19 | 4.03 | **-3.67%** |
| P50 | 3.98 | 3.86 | **-3.18%** |
| P90 | 4.75 | 4.57 | **-3.84%** |
| P99 | 7.83 | 7.17 | **-8.42%** |

#### DynamoDB GetItem
| Metric | Base (ms) | Target (ms) | Change |
|---|---|---|---|
| Average | 3.30 | 3.04 | **-7.87%** |
| P50 | 3.08 | 2.89 | **-6.10%** |
| P90 | 3.97 | 3.57 | **-10.15%** |
| P99 | 7.30 | 6.07 | **-16.82%** |

**Latency observations:**
- GetItem shows strong improvement across all percentiles (**-6% to -17%**) — the combined savings from skipping path/query processing, date formatting, and stack trace capture represent a meaningful fraction of the ~1ms SDK overhead
- P99 improves disproportionately (**-8% to -17%**) — fewer allocations reduce GC pressure, leading to fewer tail-latency spikes
- Cross-instance standard deviation is lower in target (0.42 vs 0.67 for GetItem), indicating more consistent performance
- No CPU or memory regression

### E2E Throughput (S3)

This optimization targets the RPC canonical path case (path = "/", no query params). S3 uses path-style URLs (`/bucket/key`) with non-empty segments, so the fast path does not trigger. No throughput change expected or observed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
