### PR TITLE
Fix jackson dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,12 +18,6 @@ buildscript {
         classpath(libs.kotlinx.atomicfu.plugin)
         // Add our custom gradle build logic to buildscript classpath
         classpath(libs.aws.kotlin.repo.tools.build.support)
-        /*
-        Enforce jackson to a version supported both by dokka and jreleaser:
-        https://github.com/Kotlin/dokka/issues/3472#issuecomment-1929712374
-        https://github.com/Kotlin/dokka/issues/3194#issuecomment-1929382630
-         */
-        classpath(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.22.1"))
     }
 
     configurations.classpath {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,4 +15,7 @@ repositories {
 dependencies {
     implementation(libs.dokka.gradle.plugin)
     implementation(libs.kotlin.gradle.plugin)
+    implementation(platform(libs.jackson.bom))
+    // https://github.com/gradle/gradle/issues/15383 — expose generated catalog accessors to precompiled plugins
+    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
@@ -2,10 +2,14 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+// https://github.com/gradle/gradle/issues/15383
+import org.gradle.accessors.dm.LibrariesForLibs
 
 plugins {
     id("org.jetbrains.dokka")
 }
+
+val libs = rootProject.the<LibrariesForLibs>()
 
 dokka {
     val sdkVersion: String by project
@@ -30,6 +34,16 @@ dokka {
 
         footerMessage.set("© ${java.time.LocalDate.now().year}, Amazon Web Services, Inc. or its affiliates. All rights reserved.")
         separateInheritedMembers.set(true)
+    }
+}
+
+val jacksonVersion = libs.jackson.bom.get().version!!
+
+configurations.matching { it.name.startsWith("dokka") }.configureEach {
+    resolutionStrategy.eachDependency {
+        if (requested.group.startsWith("com.fasterxml.jackson")) {
+            useVersion(jacksonVersion)
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
@@ -42,7 +42,13 @@ val jacksonVersion = libs.jackson.bom.get().version!!
 configurations.matching { it.name.startsWith("dokka") }.configureEach {
     resolutionStrategy.eachDependency {
         if (requested.group.startsWith("com.fasterxml.jackson")) {
-            useVersion(jacksonVersion)
+            if (requested.name == "jackson-annotations") {
+                // jackson-annotations dropped patch version from 2.20 onwards
+                // https://github.com/FasterXML/jackson-annotations/issues/294
+                useVersion(jacksonVersion.substringBeforeLast('.'))
+            } else {
+                useVersion(jacksonVersion)
+            }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
@@ -2,13 +2,13 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-// https://github.com/gradle/gradle/issues/15383
 import org.gradle.accessors.dm.LibrariesForLibs
 
 plugins {
     id("org.jetbrains.dokka")
 }
 
+// https://github.com/gradle/gradle/issues/15383
 val libs = rootProject.the<LibrariesForLibs>()
 
 dokka {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-version = "2.4.0"
 dokka-version = "2.2.0"
-jackson-bom-version = "2.18.9"
+jackson-bom-version = "2.22.1"
 
 aws-kotlin-repo-tools-version = "0.6.3"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin-version = "2.4.0"
 dokka-version = "2.2.0"
+jackson-bom-version = "2.18.9"
 
 aws-kotlin-repo-tools-version = "0.6.3"
 
@@ -37,6 +38,7 @@ kaml-version = "0.55.0"
 jsoup-version = "1.22.2"
 
 [libraries]
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson-bom-version" }
 aws-kotlin-repo-tools-build-support = { module="aws.sdk.kotlin.gradle:build-support", version.ref = "aws-kotlin-repo-tools-version" }
 
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-version = "2.4.0"
 dokka-version = "2.2.0"
-jackson-bom-version = "2.22.1"
+jackson-bom-version = "2.21.5"
 
 aws-kotlin-repo-tools-version = "0.6.3"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Dokka 2.2.0 bundles jackson-databind 2.15.3 contains vulnerabilities. This PR upgrades Jackson to 2.22.1 across both the buildSrc classpath and Dokka's isolated generator runtime.

The previous workaround (`enforcedPlatform` on the root buildscript classpath) was a no-op — nothing on that classpath actually depended on Jackson, and it didn't propagate to Dokka's generator process. This replaces it with a fix that targets the actual affected classpaths:

  1. `buildSrc/build.gradle.kts` — `platform(libs.jackson.bom)` overrides Jackson on the buildSrc classpath where dokka-gradle-plugin pulls it in transitively.
  2. `dokka-convention.gradle.kts` — `resolutionStrategy.eachDependency` overrides Jackson on all Dokka configurations (including the isolated generator process). A `platform()`/`enforcedPlatform()` BOM doesn't work here because Dokka 2.x uses custom Gradle attributes on its configurations that prevent BOM constraints from applying.

  The version catalog accessor is made available in the precompiled script plugin via the [gradle/gradle#15383](https://github.com/gradle/gradle/issues/15383) workaround, using `rootProject.the<LibrariesForLibs>()` since the extension isn't registered on subprojects at the time the convention plugin is applied cross-project.

  This is safe per the [Dokka maintainer's confirmation](https://github.com/Kotlin/dokka/issues/3472#issuecomment-3179718926) that Dokka 2.1.0+ supports updated Jackson versions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
