### PR TITLE
Optimize CRT response handler: eliminate writer coroutine + intermediate channel

### DIFF
--- a/.changes/c5bee5f8-7554-42c5-b695-214c7f5e3c32.json
+++ b/.changes/c5bee5f8-7554-42c5-b695-214c7f5e3c32.json
@@ -1,0 +1,6 @@
+{
+  "id": "c5bee5f8-7554-42c5-b695-214c7f5e3c32",
+  "type": "misc",
+  "description": "Reduce CPU and memory overhead of the CRT HTTP engine's response body handling by writing received bytes directly into a window-sized channel, eliminating the intermediate unbounded channel and per-response writer coroutine",
+  "module": "http-client-engine-crt"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 
-internal const val DEFAULT_WINDOW_SIZE_BYTES: Int = 64 * 1024
+internal const val DEFAULT_WINDOW_SIZE_BYTES: Int = 16 * 1024
 internal const val CHUNK_BUFFER_SIZE: Long = 64 * 1024
 
 /**
@@ -64,7 +64,7 @@ public class CrtHttpEngine(public override val config: CrtHttpEngineConfig) : Ht
         val conn = connectionManager.acquire(request)
         logger.trace { "Acquired connection ${conn.id} (${conn.version})" }
 
-        val respHandler = SdkStreamResponseHandler(conn, callContext)
+        val respHandler = SdkStreamResponseHandler(conn, callContext, config.initialWindowSizeBytes)
         callContext.job.invokeOnCompletion {
             logger.trace { "completing handler; cause=$it" }
             // ensures the stream is driven to completion regardless of what the downstream consumer does

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 
-internal const val DEFAULT_WINDOW_SIZE_BYTES: Int = 16 * 1024
+internal const val DEFAULT_WINDOW_SIZE_BYTES: Int = 64 * 1024
 internal const val CHUNK_BUFFER_SIZE: Long = 64 * 1024
 
 /**

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 
-internal const val DEFAULT_WINDOW_SIZE_BYTES: Int = 64 * 1024
+internal const val DEFAULT_WINDOW_SIZE_BYTES: Int = 16 * 1024
 internal const val CHUNK_BUFFER_SIZE: Long = 64 * 1024
 
 /**

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -38,9 +38,8 @@ internal class SdkStreamResponseHandler(
     // exception from a callback such that AWS_OP_ERROR is returned. Wait for HttpStream to have explicit cancellation
 
     init {
-        // The non-suspending write path in onResponseBody is only safe if the channel buffer is at least as large as
-        // the CRT flow-control window (the two are sized from the same windowSizeBytes below). Guard the precondition
-        // at construction so a misconfiguration fails fast here rather than as a mid-stream body failure.
+        // Channel buffer and CRT window are both sized from windowSizeBytes; fail fast on a bad value here rather
+        // than as a mid-stream body failure.
         require(windowSizeBytes > 0) { "windowSizeBytes must be > 0, was $windowSizeBytes" }
     }
 
@@ -69,9 +68,9 @@ internal class SdkStreamResponseHandler(
     private var streamCompleted = false
     private var receivedBodyData = false
 
-    // set true once a consumable body channel has been handed to the caller (see createHttpResponseBody). When the
-    // response was signalled with no body (HttpBody.Empty) nothing ever drains bodyChan, so any body bytes that still
-    // arrive must be discarded rather than written — otherwise the bounded buffer fills and the stream stalls.
+    // set true once a consumable body channel has been handed to the caller . When the response was signalled
+    // with no body (HttpBody.Empty) nothing ever drains bodyChan, so any body bytes that still arrive must be
+    // discarded rather than written — otherwise the bounded buffer fills and the stream stalls.
     private var bodyConsumable = false
 
     /**
@@ -99,8 +98,7 @@ internal class SdkStreamResponseHandler(
 
     private fun createHttpResponseBody(contentLength: Long?): HttpBody {
         // Reads from [bodyChan] drive CRT window replenishment: as the downstream consumer drains bytes we hand the
-        // same number of bytes back to the flow-control window. This ties backpressure to actual consumption without
-        // an intermediate writer coroutine — body bytes are written straight into the channel from onResponseBody.
+        // same number of bytes back to the flow-control window.
         val ch = WindowManagedReadChannel(bodyChan, ::onDataConsumed)
         bodyConsumable = true
         return object : HttpBody.ChannelContent() {
@@ -178,9 +176,7 @@ internal class SdkStreamResponseHandler(
         }
 
         // short circuit, stop buffering data and discard remaining incoming bytes. This also covers the case where
-        // the downstream consumer closed/cancelled the body channel early: writing to it would throw, so instead we
-        // discard the remaining bytes (returning them as "consumed" to CRT) rather than surfacing an exception from
-        // this native callback.
+        // the downstream consumer closed/cancelled the body channel early.
         if (isCancelled || bodyChan.isClosedForWrite) {
             return abortStream(stream, bodyBytesIn.len)
         }
@@ -202,36 +198,22 @@ internal class SdkStreamResponseHandler(
             write(bytes)
         }
 
-        // Write directly into the channel buffer without suspending. CRT never has more than the flow-control
-        // window of un-acked bytes outstanding and the channel buffer is sized to that window, so there is always
-        // room. Window credit is returned on the read side as the consumer drains the channel (see onDataConsumed).
-        //
-        // PRECONDITION (single writer): this is the only writer to bodyChan and CRT delivers body callbacks
-        // sequentially per stream, so tryWrite is never called concurrently with itself. onResponseComplete/complete
-        // only ever close the channel (never write), which tryWrite tolerates.
+        // Write directly into the channel buffer without suspending.
         val wc = buffer.size
         val written = try {
             bodyChan.tryWrite(buffer, wc)
         } catch (e: Throwable) {
-            // The consumer may have closed/cancelled the body channel between the isClosedForWrite check above and
-            // here (they run on different threads). A write to a closed channel throws either
-            // ClosedWriteChannelException or the consumer's close cause (an arbitrary Throwable, e.g. the
-            // CancellationException from cancel(null) or a caller-supplied cause). We therefore classify by channel
-            // state, not exception type: if the channel is now closed, this is the expected consumer-went-away race,
-            // so discard the bytes rather than letting the exception escape into the CRT native callback. If the
-            // channel is still open the throwable is a genuine bug and is rethrown.
+            // The consumer may have closed the channel between the isClosedForWrite check above and here, in which
+            // case tryWrite throws the (arbitrary) close cause. If now closed, discard the bytes rather than letting
+            // it escape the CRT native callback; otherwise it's a genuine bug, so rethrow.
             if (bodyChan.isClosedForWrite) {
                 return abortStream(stream, bodyBytesIn.len)
             }
             throw e
         }
 
-        // INVARIANT: written == wc, because the channel buffer is sized to the CRT flow-control window and window
-        // credit is only returned after buffer space is freed (see WindowManagedReadChannel), so outstanding bytes
-        // never exceed capacity. If this is ever violated (e.g. buffer size and window size were decoupled) we would
-        // otherwise silently drop body bytes CRT considers delivered. Rather than throw out of this native callback,
-        // fail the stream deterministically: close the channel with a diagnostic cause so the consumer observes a
-        // clean error, and abort the stream so CRT stops delivering.
+        // INVARIANT: written == wc (buffer sized to the CRT window, credit returned only after space frees). If ever
+        // violated, fail deterministically instead of silently dropping bytes or throwing out of the native callback.
         if (written != wc) {
             val cause = IllegalStateException(
                 "response body channel accepted only $written of $wc bytes; the channel buffer " +
@@ -311,10 +293,8 @@ private class WindowManagedReadChannel(
     private val onConsumed: (Int) -> Unit,
 ) : SdkByteReadChannel by delegate {
     override suspend fun read(sink: SdkBuffer, limit: Long): Long {
-        // INVARIANT (ordering): buffer space MUST be freed before window credit is returned. delegate.read
-        // completes the read (freeing availableForWrite) before we call onConsumed, which increments the CRT window
-        // and lets CRT deliver more. Returning credit first would let CRT write into a still-full buffer, breaking
-        // the "channel capacity == window" guarantee that onResponseBody's non-suspending tryWrite relies on.
+        // ORDERING: free buffer space (delegate.read) before returning window credit (onConsumed). Crediting first
+        // would let CRT deliver into a still-full buffer, breaking the "channel capacity == window" guarantee.
         val rc = delegate.read(sink, limit)
         if (rc > 0) onConsumed(rc.toInt())
         return rc

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -50,9 +50,7 @@ internal class SdkStreamResponseHandler(
 
     // Body bytes are written directly into this channel from onResponseBody (a non-suspending CRT callback).
     // The channel buffer is sized to the CRT flow-control window, so no more than [windowSizeBytes] un-acked bytes
-    // are ever in-flight and the synchronous write always has room. The CRT window is replenished on the read side
-    // (see WindowManagedReadChannel) as the downstream consumer drains bytes, preserving consumption-driven
-    // backpressure without an intermediate writer coroutine.
+    // are ever in-flight and the synchronous write always has room.
     private val bodyChan = SdkByteChannel(true, windowSizeBytes)
 
     private val lock = reentrantLock() // protects crtStream and cancelled state

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -15,7 +15,6 @@ import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.io.SdkByteChannel
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
-import aws.smithy.kotlin.runtime.io.tryWrite
 import aws.smithy.kotlin.runtime.telemetry.logging.logger
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
@@ -37,6 +36,13 @@ internal class SdkStreamResponseHandler(
     // TODO - need to cancel the stream when the body is closed from the caller side early.
     // There is no great way to do that currently without either (1) closing the connection or (2) throwing an
     // exception from a callback such that AWS_OP_ERROR is returned. Wait for HttpStream to have explicit cancellation
+
+    init {
+        // The non-suspending write path in onResponseBody is only safe if the channel buffer is at least as large as
+        // the CRT flow-control window (the two are sized from the same windowSizeBytes below). Guard the precondition
+        // at construction so a misconfiguration fails fast here rather than as a mid-stream body failure.
+        require(windowSizeBytes > 0) { "windowSizeBytes must be > 0, was $windowSizeBytes" }
+    }
 
     private val logger = callContext.logger<SdkStreamResponseHandler>()
     private val responseReady = Channel<HttpResponse>(1)
@@ -177,8 +183,26 @@ internal class SdkStreamResponseHandler(
         // room. Window credit is returned on the read side as the consumer drains the channel (see onDataConsumed).
         val wc = buffer.size
         val written = bodyChan.tryWrite(buffer, wc)
-        check(written == wc) {
-            "response body channel rejected $wc bytes (only accepted $written); CRT window exceeded channel capacity"
+
+        // INVARIANT: written == wc, because the channel buffer is sized to the CRT flow-control window and window
+        // credit is only returned after buffer space is freed (see WindowManagedReadChannel), so outstanding bytes
+        // never exceed capacity. If this is ever violated (e.g. buffer size and window size were decoupled) we would
+        // otherwise silently drop body bytes CRT considers delivered. Rather than throw out of this native callback,
+        // fail the stream deterministically: close the channel with a diagnostic cause so the consumer observes a
+        // clean error, and abort the stream so CRT stops delivering.
+        if (written != wc) {
+            val cause = IllegalStateException(
+                "response body channel accepted only $written of $wc bytes; the channel buffer " +
+                    "($windowSizeBytes) is smaller than the CRT flow-control window and body bytes would be lost",
+            )
+            logger.error(cause) { "flow-control invariant violated; failing response stream" }
+            bodyChan.close(cause)
+            lock.withLock {
+                crtStream?.close()
+                crtStream = null
+            }
+            stream.close()
+            return bodyBytesIn.len
         }
 
         // explicit window management is handled by `onDataConsumed` as data is read from the channel

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -15,15 +15,14 @@ import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.io.SdkByteChannel
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.io.tryWrite
 import aws.smithy.kotlin.runtime.telemetry.logging.logger
-import aws.smithy.kotlin.runtime.util.derivedName
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Implements the CRT stream response interface which proxies the response from the CRT to the SDK
@@ -43,8 +42,12 @@ internal class SdkStreamResponseHandler(
     private val responseReady = Channel<HttpResponse>(1)
     private val headers = HeadersBuilder()
 
-    // in practice only WINDOW_SIZE bytes will ever be in-flight
-    private val bodyChan = Channel<SdkBuffer>(Channel.UNLIMITED)
+    // Body bytes are written directly into this channel from onResponseBody (a non-suspending CRT callback).
+    // The channel buffer is sized to the CRT flow-control window, so no more than [windowSizeBytes] un-acked bytes
+    // are ever in-flight and the synchronous write always has room. The CRT window is replenished on the read side
+    // (see WindowManagedReadChannel) as the downstream consumer drains bytes, preserving consumption-driven
+    // backpressure without an intermediate writer coroutine.
+    private val bodyChan = SdkByteChannel(true, windowSizeBytes)
 
     private val lock = reentrantLock() // protects crtStream and cancelled state
     private var crtStream: HttpStream? = null
@@ -86,26 +89,10 @@ internal class SdkStreamResponseHandler(
     }
 
     private fun createHttpResponseBody(contentLength: Long?): HttpBody {
-        val ch = SdkByteChannel(true, windowSizeBytes)
-        val writerContext = callContext + callContext.derivedName("response-body-writer")
-        val job = GlobalScope.launch(writerContext) {
-            val result = runCatching {
-                for (buffer in bodyChan) {
-                    val wc = buffer.size.toInt()
-                    ch.write(buffer)
-                    // increment window
-                    onDataConsumed(wc)
-                }
-            }
-
-            // immediately close when done to signal end of body stream
-            ch.close(result.exceptionOrNull())
-        }
-
-        job.invokeOnCompletion { cause ->
-            // close is idempotent, if not previously closed then close with cause
-            ch.close(cause)
-        }
+        // Reads from [bodyChan] drive CRT window replenishment: as the downstream consumer drains bytes we hand the
+        // same number of bytes back to the flow-control window. This ties backpressure to actual consumption without
+        // an intermediate writer coroutine — body bytes are written straight into the channel from onResponseBody.
+        val ch = WindowManagedReadChannel(bodyChan, ::onDataConsumed)
         return object : HttpBody.ChannelContent() {
             override val contentLength: Long? = contentLength
             override fun readFrom(): SdkByteReadChannel = ch
@@ -165,8 +152,11 @@ internal class SdkStreamResponseHandler(
             cancelled
         }
 
-        // short circuit, stop buffering data and discard remaining incoming bytes
-        if (isCancelled) {
+        // short circuit, stop buffering data and discard remaining incoming bytes. This also covers the case where
+        // the downstream consumer closed/cancelled the body channel early: writing to it would throw, so instead we
+        // discard the remaining bytes (returning them as "consumed" to CRT) rather than surfacing an exception from
+        // this native callback.
+        if (isCancelled || bodyChan.isClosedForWrite) {
             crtStream?.close()
             stream.close()
             return bodyBytesIn.len
@@ -182,7 +172,14 @@ internal class SdkStreamResponseHandler(
             write(bytes)
         }
 
-        bodyChan.trySend(buffer).getOrThrow()
+        // Write directly into the channel buffer without suspending. CRT never has more than the flow-control
+        // window of un-acked bytes outstanding and the channel buffer is sized to that window, so there is always
+        // room. Window credit is returned on the read side as the consumer drains the channel (see onDataConsumed).
+        val wc = buffer.size
+        val written = bodyChan.tryWrite(buffer, wc)
+        check(written == wc) {
+            "response body channel rejected $wc bytes (only accepted $written); CRT window exceeded channel capacity"
+        }
 
         // explicit window management is handled by `onDataConsumed` as data is read from the channel
         return 0
@@ -231,11 +228,31 @@ internal class SdkStreamResponseHandler(
                 logger.debug { "stream did not complete before job, forcing connection shutdown! handler=$this; conn=$conn; conn.id=${conn.id}; stream=$crtStream" }
                 conn.shutdown()
                 cancelled = true
+                // wake any consumer suspended reading the body; onResponseComplete may never fire once we've
+                // force-shutdown the connection. close is idempotent so this is a no-op if already closed.
+                bodyChan.close(CancellationException("response stream did not complete before the call was finished"))
             }
 
             logger.trace { "Closing connection ${conn.id}" }
             // return to pool
             conn.close()
         }
+    }
+}
+
+/**
+ * Read-side decorator over [delegate] that returns CRT flow-control window credit as bytes are consumed.
+ * Every successful [read] hands the number of bytes read back to [onConsumed], which increments the CRT stream
+ * window. This ties backpressure to actual downstream consumption: CRT will not deliver more data until the
+ * consumer has drained (and thereby acknowledged) previously delivered bytes.
+ */
+private class WindowManagedReadChannel(
+    private val delegate: SdkByteChannel,
+    private val onConsumed: (Int) -> Unit,
+) : SdkByteReadChannel by delegate {
+    override suspend fun read(sink: SdkBuffer, limit: Long): Long {
+        val rc = delegate.read(sink, limit)
+        if (rc > 0) onConsumed(rc.toInt())
+        return rc
     }
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -33,6 +33,7 @@ import kotlin.coroutines.CoroutineContext
 internal class SdkStreamResponseHandler(
     private val conn: HttpClientConnection,
     private val callContext: CoroutineContext,
+    private val windowSizeBytes: Int,
 ) : HttpStreamResponseHandler {
     // TODO - need to cancel the stream when the body is closed from the caller side early.
     // There is no great way to do that currently without either (1) closing the connection or (2) throwing an
@@ -85,7 +86,7 @@ internal class SdkStreamResponseHandler(
     }
 
     private fun createHttpResponseBody(contentLength: Long?): HttpBody {
-        val ch = SdkByteChannel(true, DEFAULT_WINDOW_SIZE_BYTES)
+        val ch = SdkByteChannel(true, windowSizeBytes)
         val writerContext = callContext + callContext.derivedName("response-body-writer")
         val job = GlobalScope.launch(writerContext) {
             val result = runCatching {

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -85,7 +85,7 @@ internal class SdkStreamResponseHandler(
     }
 
     private fun createHttpResponseBody(contentLength: Long?): HttpBody {
-        val ch = SdkByteChannel(true)
+        val ch = SdkByteChannel(true, DEFAULT_WINDOW_SIZE_BYTES)
         val writerContext = callContext + callContext.derivedName("response-body-writer")
         val job = GlobalScope.launch(writerContext) {
             val result = runCatching {

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -71,6 +71,11 @@ internal class SdkStreamResponseHandler(
     private var streamCompleted = false
     private var receivedBodyData = false
 
+    // set true once a consumable body channel has been handed to the caller (see createHttpResponseBody). When the
+    // response was signalled with no body (HttpBody.Empty) nothing ever drains bodyChan, so any body bytes that still
+    // arrive must be discarded rather than written — otherwise the bounded buffer fills and the stream stalls.
+    private var bodyConsumable = false
+
     /**
      * Called by the response read channel as data is consumed
      * @param size the number of bytes consumed
@@ -99,6 +104,7 @@ internal class SdkStreamResponseHandler(
         // same number of bytes back to the flow-control window. This ties backpressure to actual consumption without
         // an intermediate writer coroutine — body bytes are written straight into the channel from onResponseBody.
         val ch = WindowManagedReadChannel(bodyChan, ::onDataConsumed)
+        bodyConsumable = true
         return object : HttpBody.ChannelContent() {
             override val contentLength: Long? = contentLength
             override fun readFrom(): SdkByteReadChannel = ch
@@ -152,6 +158,21 @@ internal class SdkStreamResponseHandler(
         signalResponse(stream)
     }
 
+    /**
+     * Abort the response stream and stop CRT delivering more body data. Optionally fails the body channel with
+     * [cause] so a downstream reader observes it. Returns [discardedLen] so the caller can report the incoming bytes
+     * as consumed to CRT (the sliding window advances but the bytes are dropped).
+     */
+    private fun abortStream(stream: HttpStream, discardedLen: Int, cause: Throwable? = null): Int {
+        if (cause != null) bodyChan.close(cause)
+        lock.withLock {
+            crtStream?.close()
+            crtStream = null
+        }
+        stream.close()
+        return discardedLen
+    }
+
     override fun onResponseBody(stream: HttpStream, bodyBytesIn: Buffer): Int {
         val isCancelled = lock.withLock {
             crtStream = stream
@@ -163,14 +184,19 @@ internal class SdkStreamResponseHandler(
         // discard the remaining bytes (returning them as "consumed" to CRT) rather than surfacing an exception from
         // this native callback.
         if (isCancelled || bodyChan.isClosedForWrite) {
-            crtStream?.close()
-            stream.close()
-            return bodyBytesIn.len
+            return abortStream(stream, bodyBytesIn.len)
         }
 
         if (!receivedBodyData) {
             receivedBodyData = true
             signalResponse(stream)
+        }
+
+        // The response was signalled with no consumable body (e.g. Content-Length: 0, 204/304, or an informational
+        // status) yet the server sent body bytes anyway. Nothing will ever drain bodyChan, so writing here would fill
+        // the bounded buffer and stall the stream. Discard the bytes and report them consumed so the window advances.
+        if (!bodyConsumable) {
+            return bodyBytesIn.len
         }
 
         val buffer = SdkBuffer().apply {
@@ -181,8 +207,26 @@ internal class SdkStreamResponseHandler(
         // Write directly into the channel buffer without suspending. CRT never has more than the flow-control
         // window of un-acked bytes outstanding and the channel buffer is sized to that window, so there is always
         // room. Window credit is returned on the read side as the consumer drains the channel (see onDataConsumed).
+        //
+        // PRECONDITION (single writer): this is the only writer to bodyChan and CRT delivers body callbacks
+        // sequentially per stream, so tryWrite is never called concurrently with itself. onResponseComplete/complete
+        // only ever close the channel (never write), which tryWrite tolerates.
         val wc = buffer.size
-        val written = bodyChan.tryWrite(buffer, wc)
+        val written = try {
+            bodyChan.tryWrite(buffer, wc)
+        } catch (e: Throwable) {
+            // The consumer may have closed/cancelled the body channel between the isClosedForWrite check above and
+            // here (they run on different threads). A write to a closed channel throws either
+            // ClosedWriteChannelException or the consumer's close cause (an arbitrary Throwable, e.g. the
+            // CancellationException from cancel(null) or a caller-supplied cause). We therefore classify by channel
+            // state, not exception type: if the channel is now closed, this is the expected consumer-went-away race,
+            // so discard the bytes rather than letting the exception escape into the CRT native callback. If the
+            // channel is still open the throwable is a genuine bug and is rethrown.
+            if (bodyChan.isClosedForWrite) {
+                return abortStream(stream, bodyBytesIn.len)
+            }
+            throw e
+        }
 
         // INVARIANT: written == wc, because the channel buffer is sized to the CRT flow-control window and window
         // credit is only returned after buffer space is freed (see WindowManagedReadChannel), so outstanding bytes
@@ -196,13 +240,7 @@ internal class SdkStreamResponseHandler(
                     "($windowSizeBytes) is smaller than the CRT flow-control window and body bytes would be lost",
             )
             logger.error(cause) { "flow-control invariant violated; failing response stream" }
-            bodyChan.close(cause)
-            lock.withLock {
-                crtStream?.close()
-                crtStream = null
-            }
-            stream.close()
-            return bodyBytesIn.len
+            return abortStream(stream, bodyBytesIn.len, cause)
         }
 
         // explicit window management is handled by `onDataConsumed` as data is read from the channel
@@ -275,6 +313,10 @@ private class WindowManagedReadChannel(
     private val onConsumed: (Int) -> Unit,
 ) : SdkByteReadChannel by delegate {
     override suspend fun read(sink: SdkBuffer, limit: Long): Long {
+        // INVARIANT (ordering): buffer space MUST be freed before window credit is returned. delegate.read
+        // completes the read (freeing availableForWrite) before we call onConsumed, which increments the CRT window
+        // and lets CRT deliver more. Returning credit first would let CRT write into a still-full buffer, breaking
+        // the "channel capacity == window" guarantee that onResponseBody's non-suspending tryWrite relies on.
         val rc = delegate.read(sink, limit)
         if (rc > 0) onConsumed(rc.toInt())
         return rc

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
@@ -58,7 +58,7 @@ class SdkStreamResponseHandlerTest {
 
     @Test
     fun testWaitSuccessResponse() = runTest {
-        val handler = SdkStreamResponseHandler(mockConn, coroutineContext)
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
         val stream = MockHttpStream(200)
         launch {
             val headers = listOf(
@@ -83,7 +83,7 @@ class SdkStreamResponseHandlerTest {
 
     @Test
     fun testWaitNoHeaders() = runTest {
-        val handler = SdkStreamResponseHandler(mockConn, coroutineContext)
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
         val stream = MockHttpStream(200)
         launch {
             handler.onResponseComplete(stream, 0)
@@ -95,7 +95,7 @@ class SdkStreamResponseHandlerTest {
 
     @Test
     fun testResponseSignalledBeforeStreamClosed() = runTest {
-        val handler = SdkStreamResponseHandler(mockConn, coroutineContext)
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
         val stream = MockHttpStream(204)
         launch {
             handler.onResponseComplete(stream, 0)
@@ -111,7 +111,7 @@ class SdkStreamResponseHandlerTest {
 
     @Test
     fun testWaitAbortedResponse() = runTest {
-        val handler = SdkStreamResponseHandler(mockConn, coroutineContext)
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
         val stream = MockHttpStream(200)
         launch {
             handler.onResponseComplete(stream, -1)
@@ -125,7 +125,7 @@ class SdkStreamResponseHandlerTest {
 
     @Test
     fun testRespBodyCreated() = runTest {
-        val handler = SdkStreamResponseHandler(mockConn, coroutineContext)
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
         val stream = MockHttpStream(200)
         launch {
             val headers = listOf(
@@ -152,7 +152,7 @@ class SdkStreamResponseHandlerTest {
 
     @Test
     fun testRespBody() = runTest {
-        val handler = SdkStreamResponseHandler(mockConn, coroutineContext)
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
         val stream = MockHttpStream(200)
         val data = "Fool of a Took! Throw yourself in next time and rid us of your stupidity!"
         launch {
@@ -181,7 +181,7 @@ class SdkStreamResponseHandlerTest {
     @Test
     fun testStreamError() = runTest {
         CRT.initRuntime() // CRT needs to be initialized for human-readable error codes
-        val handler = SdkStreamResponseHandler(mockConn, coroutineContext)
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
         val stream = MockHttpStream(200)
         val data = "foo bar"
         val socketClosedEc = 1051

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.*
 
 class SdkStreamResponseHandlerTest {
@@ -339,5 +340,92 @@ class SdkStreamResponseHandlerTest {
         val discarded = handler.onResponseBody(stream, byteArrayBuffer("more data".encodeToByteArray()))
         assertEquals("more data".length, discarded)
         assertTrue(stream.closed)
+    }
+
+    @Test
+    fun testConsumerCancellingWithCauseDoesNotThrowFromCallback() = runTest {
+        // Consumer cancels the body with a specific cause. In a single-threaded test the isClosedForWrite guard
+        // handles this before the write is attempted; the write-path try/catch is the defensive backstop for the
+        // cross-thread race where the close lands between the guard and tryWrite (not deterministically reproducible
+        // here). Either way the callback must not throw out of the CRT native callback and must discard the bytes.
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
+        val stream = MockHttpStream(200)
+
+        val headers = listOf(HttpHeader("Content-Length", "1024"))
+        handler.onResponseHeaders(stream, 200, HttpHeaderBlock.MAIN.blockType, headers)
+        handler.onResponseHeadersDone(stream, HttpHeaderBlock.MAIN.blockType)
+        handler.onResponseBody(stream, byteArrayBuffer("first".encodeToByteArray()))
+
+        val resp = handler.waitForResponse()
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
+
+        // consumer cancels with a specific cause -> the channel's closedCause is that exception
+        respChan.cancel(RuntimeException("consumer went away"))
+
+        val discarded = handler.onResponseBody(stream, byteArrayBuffer("more data".encodeToByteArray()))
+        assertEquals("more data".length, discarded)
+        assertTrue(stream.closed)
+    }
+
+    @Test
+    fun testWindowSmallerThanDeliveryFailsStreamDeterministically() = runTest {
+        // Exercises the written != wc safety net (:onResponseBody). The channel buffer is sized to windowSizeBytes;
+        // if CRT ever delivers more un-acked bytes than the window (i.e. buffer size and window size were decoupled),
+        // tryWrite can only accept `window` bytes and the rest would be silently lost. The handler must instead fail
+        // the stream deterministically: report the bytes consumed, close the stream, and fail the body channel with a
+        // diagnostic cause the consumer can observe.
+        val window = 8
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, window)
+        val stream = MockHttpStream(200)
+
+        val body = ByteArray(20) { it.toByte() } // larger than the window, delivered before any read
+        val headers = listOf(HttpHeader("Content-Length", "${body.size}"))
+        handler.onResponseHeaders(stream, 200, HttpHeaderBlock.MAIN.blockType, headers)
+        handler.onResponseHeadersDone(stream, HttpHeaderBlock.MAIN.blockType)
+
+        val resp = handler.waitForResponse()
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
+
+        // callback must not throw out of the native callback; it reports all incoming bytes as consumed
+        val consumed = handler.onResponseBody(stream, byteArrayBuffer(body))
+        assertEquals(body.size, consumed)
+        assertTrue(stream.closed, "stream should be torn down when the invariant is violated")
+
+        // the consumer observes the diagnostic failure rather than silently truncated data
+        val ex = assertFailsWith<IllegalStateException> {
+            respChan.readAll(SdkSink.blackhole())
+        }
+        ex.message.shouldContain("smaller than the CRT flow-control window")
+    }
+
+    @Test
+    fun testBodyBytesDiscardedWhenResponseSignalledWithNoBody() = runTest {
+        // A 204 No Content response is signalled with HttpBody.Empty, so nothing ever drains bodyChan. If the server
+        // nonetheless sends body bytes, the handler must discard them (reporting them consumed so the window advances)
+        // rather than writing into the bounded buffer, which would stall the stream once the window filled.
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
+        val stream = MockHttpStream(204)
+
+        launch {
+            handler.onResponseHeaders(stream, 204, HttpHeaderBlock.MAIN.blockType, emptyList())
+            handler.onResponseHeadersDone(stream, HttpHeaderBlock.MAIN.blockType)
+        }
+
+        val resp = handler.waitForResponse()
+        assertTrue(resp.body is HttpBody.Empty)
+
+        // unexpected body bytes must be discarded, not buffered
+        val consumed = handler.onResponseBody(stream, byteArrayBuffer("unexpected".encodeToByteArray()))
+        assertEquals("unexpected".length, consumed)
+    }
+
+    @Test
+    fun testNonPositiveWindowSizeIsRejected() {
+        assertFailsWith<IllegalArgumentException> {
+            SdkStreamResponseHandler(mockConn, EmptyCoroutineContext, 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            SdkStreamResponseHandler(mockConn, EmptyCoroutineContext, -1)
+        }
     }
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvmAndNative/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
@@ -12,12 +12,15 @@ import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpErrorCode
 import aws.smithy.kotlin.runtime.http.HttpException
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.io.SdkSink
 import aws.smithy.kotlin.runtime.io.readAll
 import aws.smithy.kotlin.runtime.io.readToBuffer
 import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
 import kotlin.test.*
 
@@ -25,6 +28,10 @@ class SdkStreamResponseHandlerTest {
     private class MockHttpStream(private val statusCode: Int) : HttpStream {
         var closed: Boolean = false
         var statusReadAfterClose: Boolean = false
+
+        // records every incrementWindow(size) call so tests can assert window replenishment
+        val windowIncrements = mutableListOf<Int>()
+        val totalWindowIncremented: Int get() = windowIncrements.sum()
 
         override val responseStatusCode: Int
             get() {
@@ -40,7 +47,9 @@ class SdkStreamResponseHandlerTest {
         override fun close() {
             closed = true
         }
-        override fun incrementWindow(size: Int) {}
+        override fun incrementWindow(size: Int) {
+            windowIncrements.add(size)
+        }
     }
 
     private class MockHttpClientConnection : HttpClientConnection {
@@ -208,5 +217,127 @@ class SdkStreamResponseHandlerTest {
 
         ex.message.shouldContain("socket is closed.; crtErrorCode=$socketClosedEc")
         assertEquals(HttpErrorCode.CONNECTION_CLOSED, ex.errorCode)
+    }
+
+    @Test
+    fun testRespBodyMultipleChunksReassembledInOrder() = runTest {
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
+        val stream = MockHttpStream(200)
+        val chunks = listOf("Frodo ", "Sam ", "Merry ", "Pippin")
+        val full = chunks.joinToString("")
+        launch {
+            val headers = listOf(HttpHeader("Content-Length", "${full.length}"))
+            handler.onResponseHeaders(stream, 200, HttpHeaderBlock.MAIN.blockType, headers)
+            handler.onResponseHeadersDone(stream, HttpHeaderBlock.MAIN.blockType)
+            chunks.forEach { handler.onResponseBody(stream, byteArrayBuffer(it.encodeToByteArray())) }
+            handler.onResponseComplete(stream, 0)
+        }
+
+        val resp = handler.waitForResponse()
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
+        assertEquals(full, respChan.readToBuffer().readUtf8())
+    }
+
+    @Test
+    fun testWindowIsReplenishedAsBodyIsConsumed() = runTest {
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
+        val stream = MockHttpStream(200)
+        val data = "Fool of a Took!".encodeToByteArray()
+        // deliver headers + a body chunk but leave the stream active (not yet complete) so the window is live
+        val headers = listOf(HttpHeader("Content-Length", "${data.size}"))
+        handler.onResponseHeaders(stream, 200, HttpHeaderBlock.MAIN.blockType, headers)
+        handler.onResponseHeadersDone(stream, HttpHeaderBlock.MAIN.blockType)
+        handler.onResponseBody(stream, byteArrayBuffer(data))
+
+        val resp = handler.waitForResponse()
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
+
+        // no window credit should be returned until bytes are actually consumed
+        assertEquals(0, stream.totalWindowIncremented)
+
+        // consume the buffered chunk while the stream is still active; window must be returned for the bytes read
+        val sink = SdkBuffer()
+        val rc = respChan.read(sink, data.size.toLong())
+        assertContentEquals(data, sink.readByteArray())
+        assertEquals(rc.toInt(), stream.totalWindowIncremented)
+        assertEquals(data.size, stream.totalWindowIncremented)
+    }
+
+    @Test
+    fun testWindowReplenishedIncrementallyOnPartialReads() = runTest {
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
+        val stream = MockHttpStream(200)
+        val data = ByteArray(32) { it.toByte() }
+        // leave the stream active so window increments are delivered to it as the consumer reads
+        val headers = listOf(HttpHeader("Content-Length", "${data.size}"))
+        handler.onResponseHeaders(stream, 200, HttpHeaderBlock.MAIN.blockType, headers)
+        handler.onResponseHeadersDone(stream, HttpHeaderBlock.MAIN.blockType)
+        handler.onResponseBody(stream, byteArrayBuffer(data))
+
+        val resp = handler.waitForResponse()
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
+
+        val sink = SdkBuffer()
+        val firstRead = respChan.read(sink, 10)
+        assertTrue(firstRead > 0, "expected to read some bytes")
+        // window returned so far must equal exactly what was read (no more, no less)
+        assertEquals(firstRead.toInt(), stream.totalWindowIncremented)
+
+        // read the remainder; total window returned must equal total bytes read back
+        var total = firstRead
+        while (total < data.size) {
+            val rc = respChan.read(sink, data.size - total)
+            if (rc <= 0) break
+            total += rc
+        }
+        assertEquals(data.size.toLong(), total)
+        assertEquals(data.size, stream.totalWindowIncremented)
+    }
+
+    @Test
+    fun testForceCloseMidBodyWakesSuspendedReader() = runTest {
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
+        val stream = MockHttpStream(200)
+        launch {
+            val headers = listOf(HttpHeader("Content-Length", "1024"))
+            handler.onResponseHeaders(stream, 200, HttpHeaderBlock.MAIN.blockType, headers)
+            handler.onResponseHeadersDone(stream, HttpHeaderBlock.MAIN.blockType)
+            handler.onResponseBody(stream, byteArrayBuffer("partial".encodeToByteArray()))
+            // stream never completes: simulate the request job finishing early (e.g. cancellation)
+            handler.complete()
+        }
+
+        val resp = handler.waitForResponse()
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
+
+        // reading past the buffered data must not hang; force-close wakes the reader with a failure
+        val ex = assertFails {
+            withTimeout(5000) {
+                respChan.readAll(SdkSink.blackhole())
+            }
+        }
+        assertTrue(ex is CancellationException, "expected reader to be woken with a CancellationException, got $ex")
+    }
+
+    @Test
+    fun testConsumerClosingBodyEarlyDoesNotThrowFromCallback() = runTest {
+        val handler = SdkStreamResponseHandler(mockConn, coroutineContext, DEFAULT_WINDOW_SIZE_BYTES)
+        val stream = MockHttpStream(200)
+
+        val headers = listOf(HttpHeader("Content-Length", "1024"))
+        handler.onResponseHeaders(stream, 200, HttpHeaderBlock.MAIN.blockType, headers)
+        handler.onResponseHeadersDone(stream, HttpHeaderBlock.MAIN.blockType)
+        handler.onResponseBody(stream, byteArrayBuffer("first".encodeToByteArray()))
+
+        val resp = handler.waitForResponse()
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
+
+        // consumer abandons the body early
+        respChan.cancel(null)
+
+        // subsequent body callbacks must not throw out of the CRT native callback; bytes are discarded
+        val discarded = handler.onResponseBody(stream, byteArrayBuffer("more data".encodeToByteArray()))
+        assertEquals("more data".length, discarded)
+        assertTrue(stream.closed)
     }
 }

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1059,6 +1059,8 @@ public final class aws/smithy/kotlin/runtime/io/SdkByteChannelKt {
 	public static synthetic fun SdkByteChannel$default (ZIILjava/lang/Object;)Laws/smithy/kotlin/runtime/io/SdkByteChannel;
 	public static final fun SdkByteReadChannel ([BII)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
 	public static synthetic fun SdkByteReadChannel$default ([BIIILjava/lang/Object;)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
+	public static final fun tryWrite (Laws/smithy/kotlin/runtime/io/SdkByteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;J)J
+	public static synthetic fun tryWrite$default (Laws/smithy/kotlin/runtime/io/SdkByteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;JILjava/lang/Object;)J
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteReadChannel {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1051,6 +1051,7 @@ public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteChannel : aw
 
 public final class aws/smithy/kotlin/runtime/io/SdkByteChannel$DefaultImpls {
 	public static fun close (Laws/smithy/kotlin/runtime/io/SdkByteChannel;)V
+	public static fun tryWrite (Laws/smithy/kotlin/runtime/io/SdkByteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;J)J
 }
 
 public final class aws/smithy/kotlin/runtime/io/SdkByteChannelKt {
@@ -1059,8 +1060,6 @@ public final class aws/smithy/kotlin/runtime/io/SdkByteChannelKt {
 	public static synthetic fun SdkByteChannel$default (ZIILjava/lang/Object;)Laws/smithy/kotlin/runtime/io/SdkByteChannel;
 	public static final fun SdkByteReadChannel ([BII)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
 	public static synthetic fun SdkByteReadChannel$default ([BIIILjava/lang/Object;)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
-	public static final fun tryWrite (Laws/smithy/kotlin/runtime/io/SdkByteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;J)J
-	public static synthetic fun tryWrite$default (Laws/smithy/kotlin/runtime/io/SdkByteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;JILjava/lang/Object;)J
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteReadChannel {
@@ -1094,11 +1093,15 @@ public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteWriteChannel
 	public abstract fun getClosedCause ()Ljava/lang/Throwable;
 	public abstract fun getTotalBytesWritten ()J
 	public abstract fun isClosedForWrite ()Z
+	public fun tryWrite (Laws/smithy/kotlin/runtime/io/SdkBuffer;J)J
+	public static synthetic fun tryWrite$default (Laws/smithy/kotlin/runtime/io/SdkByteWriteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;JILjava/lang/Object;)J
 	public abstract fun write (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun write$default (Laws/smithy/kotlin/runtime/io/SdkByteWriteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class aws/smithy/kotlin/runtime/io/SdkByteWriteChannel$DefaultImpls {
+	public static fun tryWrite (Laws/smithy/kotlin/runtime/io/SdkByteWriteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;J)J
+	public static synthetic fun tryWrite$default (Laws/smithy/kotlin/runtime/io/SdkByteWriteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;JILjava/lang/Object;)J
 	public static synthetic fun write$default (Laws/smithy/kotlin/runtime/io/SdkByteWriteChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -1192,6 +1195,7 @@ public final class aws/smithy/kotlin/runtime/io/internal/JobChannel : aws/smithy
 	public fun isClosedForRead ()Z
 	public fun isClosedForWrite ()Z
 	public fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun tryWrite (Laws/smithy/kotlin/runtime/io/SdkBuffer;J)J
 	public fun write (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/RealSdkByteChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/RealSdkByteChannel.kt
@@ -120,18 +120,16 @@ internal class RealSdkByteChannel(
         ensureNotClosed()
         if (byteCount == 0L) return 0L
 
-        check(_writeInProgress.compareAndSet(false, true)) { "Write operation already in progress" }
-        try {
+        return writing {
             val wc = minOf(availableForWrite.toLong(), byteCount)
-            if (wc == 0L) return 0L
 
-            synchronized(lock) {
-                buffer.write(source, wc)
+            if (wc > 0L) {
+                synchronized(lock) {
+                    buffer.write(source, wc)
+                }
             }
-            afterWrite(wc.toInt())
-            return wc
-        } finally {
-            _writeInProgress.compareAndSet(true, false)
+
+            wc
         }
     }
 
@@ -160,10 +158,11 @@ internal class RealSdkByteChannel(
         }
     }
 
-    private inline fun writing(block: () -> Long) = try {
+    private inline fun writing(block: () -> Long): Long = try {
         check(_writeInProgress.compareAndSet(false, true)) { "Write operation already in progress" }
         val wc = block()
         afterWrite(wc.toInt())
+        wc
     } finally {
         _writeInProgress.compareAndSet(true, false)
     }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/RealSdkByteChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/RealSdkByteChannel.kt
@@ -116,16 +116,7 @@ internal class RealSdkByteChannel(
         _readInProgress.compareAndSet(true, false)
     }
 
-    /**
-     * Attempts to append up to [byteCount] bytes from [source] **without suspending**, writing only as many bytes
-     * as currently fit within [availableForWrite]. Returns the number of bytes actually written.
-     *
-     * This is intended for producers that manage their own external flow control / backpressure and can therefore
-     * guarantee buffer capacity ahead of the write (e.g. a native reader gated by a flow-control window sized no
-     * larger than this channel's buffer). Like [write] this is a single-writer operation and must not be invoked
-     * concurrently with [write] or itself.
-     */
-    fun tryWrite(source: SdkBuffer, byteCount: Long): Long {
+    override fun tryWrite(source: SdkBuffer, byteCount: Long): Long {
         ensureNotClosed()
         if (byteCount == 0L) return 0L
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/RealSdkByteChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/RealSdkByteChannel.kt
@@ -116,6 +116,34 @@ internal class RealSdkByteChannel(
         _readInProgress.compareAndSet(true, false)
     }
 
+    /**
+     * Attempts to append up to [byteCount] bytes from [source] **without suspending**, writing only as many bytes
+     * as currently fit within [availableForWrite]. Returns the number of bytes actually written.
+     *
+     * This is intended for producers that manage their own external flow control / backpressure and can therefore
+     * guarantee buffer capacity ahead of the write (e.g. a native reader gated by a flow-control window sized no
+     * larger than this channel's buffer). Like [write] this is a single-writer operation and must not be invoked
+     * concurrently with [write] or itself.
+     */
+    fun tryWrite(source: SdkBuffer, byteCount: Long): Long {
+        ensureNotClosed()
+        if (byteCount == 0L) return 0L
+
+        check(_writeInProgress.compareAndSet(false, true)) { "Write operation already in progress" }
+        try {
+            val wc = minOf(availableForWrite.toLong(), byteCount)
+            if (wc == 0L) return 0L
+
+            synchronized(lock) {
+                buffer.write(source, wc)
+            }
+            afterWrite(wc.toInt())
+            return wc
+        } finally {
+            _writeInProgress.compareAndSet(true, false)
+        }
+    }
+
     override suspend fun write(source: SdkBuffer, byteCount: Long) {
         ensureNotClosed()
         if (byteCount == 0L) return

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteChannel.kt
@@ -41,6 +41,25 @@ public fun SdkByteChannel(
 ): SdkByteChannel = RealSdkByteChannel(autoFlush, maxBufferSize)
 
 /**
+ * Appends up to [byteCount] bytes from [source] to this channel **without suspending**, writing only as many bytes
+ * as currently fit in the channel's buffer ([SdkByteWriteChannel.availableForWrite]). Returns the number of bytes
+ * actually written (which may be less than [byteCount], including `0` if the buffer is full).
+ *
+ * This is intended for producers that enforce their own external backpressure (e.g. a native reader bounded by a
+ * flow-control window no larger than the channel's buffer) and therefore do not need the suspending semantics of
+ * [SdkByteWriteChannel.write]. It is a single-writer operation and must not be invoked concurrently with
+ * [SdkByteWriteChannel.write] or itself.
+ *
+ * @throws IllegalStateException if invoked on a channel implementation that does not support non-suspending writes
+ */
+@InternalApi
+public fun SdkByteChannel.tryWrite(source: SdkBuffer, byteCount: Long = source.size): Long {
+    val real = this as? RealSdkByteChannel
+        ?: error("tryWrite is only supported on the default SdkByteChannel implementation, got ${this::class}")
+    return real.tryWrite(source, byteCount)
+}
+
+/**
  * Creates a channel for reading with the contents of the given byte array.
  *
  * NOTE: The returned channel will be closed.

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteChannel.kt
@@ -41,25 +41,6 @@ public fun SdkByteChannel(
 ): SdkByteChannel = RealSdkByteChannel(autoFlush, maxBufferSize)
 
 /**
- * Appends up to [byteCount] bytes from [source] to this channel **without suspending**, writing only as many bytes
- * as currently fit in the channel's buffer ([SdkByteWriteChannel.availableForWrite]). Returns the number of bytes
- * actually written (which may be less than [byteCount], including `0` if the buffer is full).
- *
- * This is intended for producers that enforce their own external backpressure (e.g. a native reader bounded by a
- * flow-control window no larger than the channel's buffer) and therefore do not need the suspending semantics of
- * [SdkByteWriteChannel.write]. It is a single-writer operation and must not be invoked concurrently with
- * [SdkByteWriteChannel.write] or itself.
- *
- * @throws IllegalStateException if invoked on a channel implementation that does not support non-suspending writes
- */
-@InternalApi
-public fun SdkByteChannel.tryWrite(source: SdkBuffer, byteCount: Long = source.size): Long {
-    val real = this as? RealSdkByteChannel
-        ?: error("tryWrite is only supported on the default SdkByteChannel implementation, got ${this::class}")
-    return real.tryWrite(source, byteCount)
-}
-
-/**
  * Creates a channel for reading with the contents of the given byte array.
  *
  * NOTE: The returned channel will be closed.

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
@@ -5,8 +5,6 @@
 
 package aws.smithy.kotlin.runtime.io
 
-import aws.smithy.kotlin.runtime.InternalApi
-
 /**
  * A channel for writing a sequence of bytes asynchronously. This is a **single writer channel**.
  */
@@ -71,7 +69,6 @@ public interface SdkByteWriteChannel : Closeable {
      * @param byteCount the number of bytes to read from source
      * @return the number of bytes actually written
      */
-    @InternalApi
     public fun tryWrite(source: SdkBuffer, byteCount: Long = source.size): Long = throw UnsupportedOperationException("${this::class.simpleName} does not support non-suspending writes")
 
     /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
@@ -5,6 +5,8 @@
 
 package aws.smithy.kotlin.runtime.io
 
+import aws.smithy.kotlin.runtime.InternalApi
+
 /**
  * A channel for writing a sequence of bytes asynchronously. This is a **single writer channel**.
  */
@@ -59,16 +61,21 @@ public interface SdkByteWriteChannel : Closeable {
      * This is intended for producers that enforce their own external backpressure (for example a native reader
      * bounded by a flow-control window no larger than this channel's buffer) and therefore do not need the suspending
      * semantics of [write]. Like [write], this is a single-writer operation and must not be invoked concurrently with
-     * [write] or itself. Throws [ClosedWriteChannelException] if this channel was already closed.
+     * [write] or itself; doing so may throw [IllegalStateException] ("Write operation already in progress").
+     * Throws [ClosedWriteChannelException] if this channel was closed successfully, or the close cause if it was
+     * closed with one.
      *
      * The default implementation throws [UnsupportedOperationException]; implementations that can service a
      * non-suspending write override it. Because it is a regular interface member, delegating wrappers
      * (e.g. `SdkByteChannel by delegate`) forward it to their delegate automatically.
      *
+     * This is a low-level flow-control primitive intended for engine internals and is not part of the stable API.
+     *
      * @param source the buffer data will be read from and written to this channel
      * @param byteCount the number of bytes to read from source
      * @return the number of bytes actually written
      */
+    @InternalApi
     public fun tryWrite(source: SdkBuffer, byteCount: Long = source.size): Long = throw UnsupportedOperationException("${this::class.simpleName} does not support non-suspending writes")
 
     /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
@@ -54,22 +54,18 @@ public interface SdkByteWriteChannel : Closeable {
     public suspend fun write(source: SdkBuffer, byteCount: Long = source.size)
 
     /**
-     * Attempts to append up to [byteCount] bytes from [source] to this channel **without suspending**, writing only
-     * as many bytes as currently fit within [availableForWrite]. Returns the number of bytes actually written, which
-     * may be less than [byteCount] (including `0` when the buffer is full).
+     * Appends up to [byteCount] bytes from [source] **without suspending**, writing only as many as currently fit
+     * within [availableForWrite]. Returns the number of bytes actually written, which may be less than [byteCount]
+     * (including `0` when the buffer is full).
      *
-     * This is intended for producers that enforce their own external backpressure (for example a native reader
-     * bounded by a flow-control window no larger than this channel's buffer) and therefore do not need the suspending
-     * semantics of [write]. Like [write], this is a single-writer operation and must not be invoked concurrently with
-     * [write] or itself; doing so may throw [IllegalStateException] ("Write operation already in progress").
-     * Throws [ClosedWriteChannelException] if this channel was closed successfully, or the close cause if it was
-     * closed with one.
+     * Intended for producers that enforce their own external backpressure and so don't need the suspending semantics
+     * of [write]. Like [write], this is single-writer: concurrent use with [write] or itself may throw
+     * [IllegalStateException]. Throws [ClosedWriteChannelException] if the channel was closed successfully, or the
+     * close cause if it was closed with one.
      *
      * The default implementation throws [UnsupportedOperationException]; implementations that can service a
-     * non-suspending write override it. Because it is a regular interface member, delegating wrappers
-     * (e.g. `SdkByteChannel by delegate`) forward it to their delegate automatically.
-     *
-     * This is a low-level flow-control primitive intended for engine internals and is not part of the stable API.
+     * non-suspending write override it (delegating wrappers forward it automatically). Low-level flow-control
+     * primitive for engine internals; not part of the stable API.
      *
      * @param source the buffer data will be read from and written to this channel
      * @param byteCount the number of bytes to read from source

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
@@ -52,6 +52,26 @@ public interface SdkByteWriteChannel : Closeable {
     public suspend fun write(source: SdkBuffer, byteCount: Long = source.size)
 
     /**
+     * Attempts to append up to [byteCount] bytes from [source] to this channel **without suspending**, writing only
+     * as many bytes as currently fit within [availableForWrite]. Returns the number of bytes actually written, which
+     * may be less than [byteCount] (including `0` when the buffer is full).
+     *
+     * This is intended for producers that enforce their own external backpressure (for example a native reader
+     * bounded by a flow-control window no larger than this channel's buffer) and therefore do not need the suspending
+     * semantics of [write]. Like [write], this is a single-writer operation and must not be invoked concurrently with
+     * [write] or itself. Throws [ClosedWriteChannelException] if this channel was already closed.
+     *
+     * The default implementation throws [UnsupportedOperationException]; implementations that can service a
+     * non-suspending write override it. Because it is a regular interface member, delegating wrappers
+     * (e.g. `SdkByteChannel by delegate`) forward it to their delegate automatically.
+     *
+     * @param source the buffer data will be read from and written to this channel
+     * @param byteCount the number of bytes to read from source
+     * @return the number of bytes actually written
+     */
+    public fun tryWrite(source: SdkBuffer, byteCount: Long = source.size): Long = throw UnsupportedOperationException("${this::class.simpleName} does not support non-suspending writes")
+
+    /**
      * Closes this channel with an optional exceptional [cause]. All pending bytes are flushed.
      * This is an idempotent operation — subsequent invocations of this function have no effect and return false
      *

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelTest.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.io
 
+import aws.smithy.kotlin.runtime.io.internal.JobChannel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
@@ -15,6 +16,98 @@ class SdkByteChannelTest {
     fun testCreateAndClose() {
         val chan = SdkByteChannel(false)
         chan.close()
+    }
+
+    @Test
+    fun testTryWriteWithinCapacity() = runTest {
+        SdkByteChannel(true, maxBufferSize = 16).use { chan ->
+            val source = SdkBuffer().apply { write(byteArrayOf(1, 2, 3, 4)) }
+            val written = chan.tryWrite(source)
+            assertEquals(4L, written)
+            assertEquals(4L, chan.totalBytesWritten)
+            assertEquals(4, chan.availableForRead)
+            assertEquals(0L, source.size)
+        }
+    }
+
+    @Test
+    fun testTryWritePartialWhenBufferNearlyFull() = runTest {
+        SdkByteChannel(true, maxBufferSize = 8).use { chan ->
+            // fill 6 of 8 bytes
+            chan.tryWrite(SdkBuffer().apply { write(ByteArray(6)) })
+            assertEquals(2, chan.availableForWrite)
+
+            // only 2 bytes fit without suspending; tryWrite writes what it can
+            val source = SdkBuffer().apply { write(ByteArray(5)) }
+            val written = chan.tryWrite(source)
+            assertEquals(2L, written)
+            assertEquals(0, chan.availableForWrite)
+            assertEquals(3L, source.size) // remaining bytes left in source
+        }
+    }
+
+    @Test
+    fun testTryWriteReturnsZeroWhenFull() = runTest {
+        SdkByteChannel(true, maxBufferSize = 4).use { chan ->
+            chan.tryWrite(SdkBuffer().apply { write(ByteArray(4)) })
+            assertEquals(0, chan.availableForWrite)
+
+            val written = chan.tryWrite(SdkBuffer().apply { write(ByteArray(4)) })
+            assertEquals(0L, written)
+        }
+    }
+
+    @Test
+    fun testTryWriteRoundTrip() = runTest {
+        SdkByteChannel(true, maxBufferSize = 64).use { chan ->
+            val data = "hello flow control".encodeToByteArray()
+            val written = chan.tryWrite(SdkBuffer().apply { write(data) })
+            assertEquals(data.size.toLong(), written)
+
+            val sink = SdkBuffer()
+            chan.read(sink, data.size.toLong())
+            assertContentEquals(data, sink.readByteArray())
+        }
+    }
+
+    @Test
+    fun testTryWriteReadFreesCapacityForSubsequentWrite() = runTest {
+        SdkByteChannel(true, maxBufferSize = 8).use { chan ->
+            assertEquals(8L, chan.tryWrite(SdkBuffer().apply { write(ByteArray(8)) }))
+            assertEquals(0, chan.availableForWrite)
+
+            // draining bytes must free capacity so the next tryWrite succeeds (models flow-control window replenish)
+            val sink = SdkBuffer()
+            chan.read(sink, 5)
+            assertEquals(5, chan.availableForWrite)
+            assertEquals(5L, chan.tryWrite(SdkBuffer().apply { write(ByteArray(5)) }))
+        }
+    }
+
+    @Test
+    fun testTryWriteOnClosedChannelThrows() = runTest {
+        val chan = SdkByteChannel(true, maxBufferSize = 8)
+        chan.close()
+        assertFailsWith<ClosedWriteChannelException> {
+            chan.tryWrite(SdkBuffer().apply { write(byteArrayOf(1)) })
+        }
+    }
+
+    @Test
+    fun testTryWriteZeroByteCountIsNoOp() = runTest {
+        SdkByteChannel(true, maxBufferSize = 8).use { chan ->
+            assertEquals(0L, chan.tryWrite(SdkBuffer(), 0))
+            assertEquals(0L, chan.totalBytesWritten)
+        }
+    }
+
+    @Test
+    fun testTryWriteUnsupportedOnNonDefaultImpl() = runTest {
+        // tryWrite is only supported on the concrete RealSdkByteChannel; delegating wrappers hit the error path.
+        val chan = JobChannel()
+        assertFailsWith<IllegalStateException> {
+            chan.tryWrite(SdkBuffer().apply { write(byteArrayOf(1)) })
+        }
     }
 
     @Test

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelTest.kt
@@ -102,10 +102,31 @@ class SdkByteChannelTest {
     }
 
     @Test
-    fun testTryWriteUnsupportedOnNonDefaultImpl() = runTest {
-        // tryWrite is only supported on the concrete RealSdkByteChannel; delegating wrappers hit the error path.
-        val chan = JobChannel()
-        assertFailsWith<IllegalStateException> {
+    fun testTryWriteForwardsThroughDelegatingWrapper() = runTest {
+        // tryWrite is an interface member, so a delegating wrapper (SdkByteChannel by delegate) forwards it to its
+        // RealSdkByteChannel delegate rather than hitting the unsupported default.
+        JobChannel().use { chan ->
+            val written = chan.tryWrite(SdkBuffer().apply { write(byteArrayOf(1, 2, 3)) })
+            assertEquals(3L, written)
+            assertEquals(3, chan.availableForRead)
+        }
+    }
+
+    @Test
+    fun testTryWriteDefaultIsUnsupported() {
+        // an implementation that does not override tryWrite falls back to the throwing default
+        val chan = object : SdkByteWriteChannel {
+            override val availableForWrite: Int = 0
+            override val isClosedForWrite: Boolean = false
+            override val closedCause: Throwable? = null
+            override val totalBytesWritten: Long = 0
+            override val autoFlush: Boolean = true
+            override suspend fun write(source: SdkBuffer, byteCount: Long) {}
+            override fun close(cause: Throwable?): Boolean = true
+            override fun close() {}
+            override fun flush() {}
+        }
+        assertFailsWith<UnsupportedOperationException> {
             chan.tryWrite(SdkBuffer().apply { write(byteArrayOf(1)) })
         }
     }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelTest.kt
@@ -94,6 +94,20 @@ class SdkByteChannelTest {
     }
 
     @Test
+    fun testTryWriteOnChannelClosedWithCauseThrowsThatCause() = runTest {
+        // When a channel is closed with a cause, tryWrite rethrows that exact cause (not ClosedWriteChannelException).
+        // The CRT response handler relies on this: its write-path catch classifies by channel state rather than
+        // exception type precisely because the thrown type is arbitrary.
+        val chan = SdkByteChannel(true, maxBufferSize = 8)
+        val cause = RuntimeException("consumer went away")
+        chan.close(cause)
+        val thrown = assertFailsWith<RuntimeException> {
+            chan.tryWrite(SdkBuffer().apply { write(byteArrayOf(1)) })
+        }
+        assertEquals(cause, thrown)
+    }
+
+    @Test
     fun testTryWriteZeroByteCountIsNoOp() = runTest {
         SdkByteChannel(true, maxBufferSize = 8).use { chan ->
             assertEquals(0L, chan.tryWrite(SdkBuffer(), 0))


### PR DESCRIPTION
# Optimize CRT response handler: eliminate writer coroutine + intermediate channel

## Summary

Rewrites how the CRT HTTP engine moves response body bytes from the native CRT callback to the SDK consumer. The previous design buffered body chunks into an unbounded `Channel<SdkBuffer>` and drained it with a dedicated `GlobalScope` writer coroutine. This PR removes both the intermediate channel and the coroutine, writing body bytes **directly** into a single window-sized `SdkByteChannel` from the CRT callback and driving flow-control window replenishment from the read side as the consumer drains bytes.

Net effect: fewer allocations, one fewer thread hop per body chunk, no per-response coroutine, and a hard cap on body-buffer memory — while preserving consumption-driven backpressure.

## Before vs After

| Aspect | Before (`main`) | After (this PR) |
|---|---|---|
| Body buffering | Unbounded `Channel<SdkBuffer>(UNLIMITED)` **+** a second `SdkByteChannel` | Single `SdkByteChannel(true, windowSizeBytes)` sized to the CRT window |
| Writer path | `GlobalScope.launch` coroutine loops the channel, copies each buffer into the `SdkByteChannel`, calls `incrementWindow` per buffer | `onResponseBody` writes directly via non-suspending `tryWrite`; no coroutine, no second channel |
| Window replenishment | Write-side, per buffer received, on the writer's dispatcher thread | Read-side, per actual `read()`, on the consumer thread via `WindowManagedReadChannel` → `onDataConsumed` → `incrementWindow` |
| Coroutines / response | 1 `GlobalScope` Job + completion handler | 0 |
| Extra channel / response | 2nd `SdkByteChannel` | 0 |
| Thread hops (native → consumer) | event-loop → channel → writer coroutine (dispatcher) → channel | event-loop writes directly into the channel the consumer reads |
| Steady-state body memory | ≈ `window + 16 KiB` (≈2× window at defaults) | 1 × `windowSizeBytes` (16 KiB default) |

### Before

```
onResponseBody (event-loop thread)
   └─ bodyChan.trySend(buffer)         // unbounded Channel<SdkBuffer>
                                        // ── thread hop ──
writer coroutine (GlobalScope, dispatcher thread)
   └─ for (buffer in bodyChan) { ch.write(buffer); onDataConsumed(wc) }
consumer
   └─ reads `ch`
```

### After

```
onResponseBody (event-loop thread)
   └─ bodyChan.tryWrite(buffer)         // window-sized SdkByteChannel, non-suspending
consumer
   └─ WindowManagedReadChannel.read → onDataConsumed(bytesRead) → crtStream.incrementWindow
```

## The core invariant (why this is safe)

The whole design rests on one coupling: **`bodyChan` capacity == CRT `initialWindowSize`** (both derive from
`config.initialWindowSizeBytes`; wired at `CrtHttpEngine.kt:67` and `ConnectionManager.kt:62`).

CRT's flow-control contract (`aws-crt-kotlin` `HttpStream.incrementWindow`) guarantees the stream window shrinks as body data arrives and **halts delivery when it reaches 0**. Window credit is only returned *after* the consumer
drains bytes (freeing buffer space). Therefore CRT never has more than `windowSizeBytes` un-acked bytes outstanding, so the non-suspending `tryWrite` always has room and `written == wc` provably holds.

Two ordering rules protect this and are commented in the code:

1. **Read side:** free buffer space *before* returning window credit (`WindowManagedReadChannel.read`). Returning credit first would let CRT deliver into a still-full buffer.
2. **Write side:** single-writer — CRT delivers body callbacks sequentially per stream, and `onResponseComplete`/`complete()` only ever *close* the channel, never write.

## HTTP/2 behavior

This change is fully applicable to HTTP/2 — it is not an HTTP/1.1-only optimization.

The one HTTP/2-specific consideration is the `written != wc` fail-fast. However, aws-c-http decrements the per-stream flow-control window (`window_size_self`) and rejects any DATA frame that would exceed it before invoking our body callback, so CRT can never hand us more un-acked bytes than thewindow we sized the channel buffer to — making the non-suspending tryWrite always fit.

## Why this approach was chosen (alternatives considered)

**Alternative A — keep the writer coroutine, just bound the channel.**
Rejected. Bounding the intermediate `Channel` addresses memory but keeps the per-response coroutine, the second
channel, and the extra thread hop — i.e. it fixes the smallest of the costs and none of the CPU/allocation overhead.

**Alternative B — make `onResponseBody` suspend and call the existing suspending `write`.**
Not possible. `onResponseBody` is a **non-suspending native CRT callback** — it cannot suspend to await buffer
space. That's precisely why a new non-suspending `tryWrite` primitive is introduced instead of reusing `write`.

**Alternative C — block the event-loop thread in the callback until space frees.**
Rejected. Blocking a CRT event-loop thread risks stalling all streams multiplexed on that loop and can deadlock against the consumer. The window-sizing invariant makes blocking unnecessary: there is always room by construction.

**Chosen — direct non-suspending write + read-driven window replenishment.**
This is the only option that (a) respects the non-suspending native callback, (b) removes the coroutine/channel/thread-hop overhead, and (c) preserves consumption-driven backpressure. The `tryWrite` primitive is the minimal addition needed to make it work, and the "buffer sized == window" invariant is what lets it be
non-suspending safely.

## Tradeoffs

- **(−) New assumption:** correctness now *requires* buffer size to equal the CRT window and CRT to honor its window. The old unbounded channel tolerated any window. This is guarded by `require(windowSizeBytes > 0)` and a deterministic fail-fast if the invariant is ever violated (see Robustness below).

## New public API

Adds `SdkByteWriteChannel.tryWrite(source, byteCount): Long` — a non-suspending, single-writer, partial-write
primitive:

- Default implementation throws `UnsupportedOperationException`; `RealSdkByteChannel` overrides it; delegating
  wrappers (`SdkByteChannel by delegate`, e.g. `JobChannel`) forward it automatically.
- Marked **`@InternalApi`** — it's a sharp-edged flow-control primitive (silent partial writes, caller-enforced
  backpressure) with a single engine-internal caller, consistent with the sibling `@InternalApi`
  `SdkByteChannel(...)` / `SdkByteReadChannel(content)` factories. No `.api` diff; binary-compatible.

## Robustness / safety nets

- **Invariant violation is fail-fast, not silent.** If `written != wc` ever occurs (e.g. buffer size and window were
  decoupled), the stream is torn down and the consumer observes a diagnostic `IllegalStateException` rather than
  silently truncated data.
- **Consumer-closes-early race** (consumer cancels the body between the `isClosedForWrite` guard and `tryWrite`, on different threads): the write is wrapped in a try/catch that classifies by **channel state** (not exception type,
  since a close-with-cause rethrows an arbitrary throwable) and discards the bytes instead of letting the exception
  escape the native callback.
- **Unexpected body on a bodyless response** (body bytes after a 204/304/`Content-Length: 0`): discarded and reported consumed, so the bounded buffer can't fill and stall the stream.
- **Force-close mid-body** wakes any suspended reader with a `CancellationException`.

## Tests

`SdkByteChannelTest` (common — runs on JVM + native):

- `tryWrite` within/partial/full capacity, returns-zero-when-full, round-trip, read-frees-capacity, zero-byte no-op,
  closed-throws, **closed-with-cause rethrows that cause**, delegation forwarding, unsupported default.

`SdkStreamResponseHandlerTest` (jvmAndNative):

- window replenishment on read (full + incremental partial reads), multi-chunk reassembly, force-close wakes reader,
  consumer-closes-early discards, consumer-cancels-with-cause discards, **`written != wc` fails deterministically**,
  **unexpected body on bodyless response discarded**, **non-positive window rejected**.

## Benchmark results

E2E S3 throughput benchmark, paired base-vs-target, 14 instances per point (mean values shown).
`base` = `main`, `target` = this PR. CPU% and Mem(MB) are per-variant process-level means. Only the **download** path
exercises this change; upload is included as a control.

### Download (affected path)

| Concurrency | Base (Gbps) | Target (Gbps) | Δ Throughput | Base CPU% | Target CPU% | Base Mem (MB) | Target Mem (MB) |
|---|---|---|---|---|---|---|---|
| crt-16  | 2.68 | 3.33 | **+24.2%** | 55.1 | 34.7 | 312 | 328 |
| crt-32  | 3.07 | 3.73 | **+21.4%** | 67.7 | 46.5 | 342 | 362 |
| crt-64  | 3.03 | 3.40 | **+12.1%** | 71.9 | 56.3 | 349 | 378 |
| crt-128 | 2.87 | 3.16 | **+10.2%** | 73.5 | 58.5 | 390 | 443 |
| crt-256 | 2.97 | 2.84 | −4.2%      | 72.8 | 62.5 | 513 | 498 |

### Upload (control — not on this path)

| Concurrency | Base (Gbps) | Target (Gbps) | Δ Throughput | Base CPU% | Target CPU% | Base Mem (MB) | Target Mem (MB) |
|---|---|---|---|---|---|---|---|
| crt-16  | 3.91 | 3.91 | −0.0% | 20.3 | 20.5 | 189 | 191 |
| crt-32  | 6.05 | 6.09 | +0.4% | 37.2 | 38.1 | 190 | 191 |
| crt-64  | 5.56 | 5.55 | −0.3% | 38.7 | 39.5 | 198 | 197 |
| crt-128 | 5.58 | 5.56 | −0.5% | 40.3 | 40.5 | 202 | 200 |
| crt-256 | 5.44 | 5.44 | +0.2% | 43.4 | 41.8 | 209 | 212 |

### Reading the results

- **Throughput (download):** clear win from crt-16 through crt-128 (+24% → +10%), converging to roughly break-even at crt-256 (−4.2%).
- **CPU (download):** target uses **materially less CPU at every concurrency** (e.g. 34.7 vs 55.1 at crt-16;
  62.5 vs 72.8 at crt-256) — removing the per-response writer coroutine, per-chunk channel-node allocations, and a
  cross-thread dispatch hop lowers per-byte cost across the board.
- **Memory:** roughly a wash at process RSS (small deltas, mixed sign). The theoretical per-stream body-buffer
  saving (one window-sized buffer instead of two staged buffers) is real but swamped by total process allocation at
  this scale.
- **Upload:** flat on every metric, confirming the change is isolated to the response path.

**Why crt-256 doesn't win:** target has spare CPU there (62.5% vs 72.8%) yet doesn't gain throughput, so the limiter is not CPU — it's reduced pipelining depth. The old design returned CRT window credit when bytes moved into the downstream channel (decoupled from the consumer, ~2× read-ahead per stream); the new design returns credit only when the consumer reads, with a single window-sized buffer. Under ~256 concurrent streams competing for coroutine scheduling, the per-stream window reaches 0 and delivery briefly stalls waiting for a read — visible as *both* lower CPU and slightly lower throughput.

### Small-request latency (control)

E2E latency benchmark, paired base-vs-target, 15 instances per point (mean values shown). DynamoDB `PutItem`/`GetItem`
are small single-shot request/response operations — included to confirm the change does not regress the common
small-payload API path (their tiny bodies barely exercise the response-streaming path this PR touches).

| Op | Metric | Base (ms) | Target (ms) | Δ | Base CPU% | Target CPU% | Base Mem (MB) | Target Mem (MB) |
|---|---|---|---|---|---|---|---|---|
| PutItem | Avg | 3.56 | 3.67 | +3.1% | 4.9 | 4.9 | 180 | 179 |
| PutItem | P50 | 3.39 | 3.51 | +3.5% | 4.9 | 4.9 | 180 | 179 |
| PutItem | P90 | 4.02 | 4.18 | +4.0% | 4.9 | 4.9 | 180 | 179 |
| PutItem | P99 | 6.38 | 6.50 | +1.8% | 4.9 | 4.9 | 180 | 179 |
| GetItem | Avg | 2.85 | 2.79 | −1.8% | 6.4 | 6.2 | 176 | 174 |
| GetItem | P50 | 2.63 | 2.58 | −2.0% | 6.4 | 6.2 | 176 | 174 |
| GetItem | P90 | 3.40 | 3.37 | −0.9% | 6.4 | 6.2 | 176 | 174 |
| GetItem | P99 | 6.37 | 6.16 | −3.2% | 6.4 | 6.2 | 176 | 174 |

All deltas are within run-to-run noise (cross-instance variance exceeds the deltas). As expected, small API calls are
a wash — latency there is dominated by network round-trip and service time, not the intra-process buffering this PR
changes, so there is no per-chunk overhead to amortize. The throughput/CPU wins above materialize on large streaming
downloads (many body chunks), not single-shot small responses. Note this benchmark does not measure inter-chunk
delivery latency on a large download, which is the latency dimension the change actually affects.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
