### PR TITLE
fix: update operation metrics to properly include RPC attributes and telemetry context

### DIFF
--- a/.changes/6081d67c-ca52-4cc2-b583-72cf076be7bc.json
+++ b/.changes/6081d67c-ca52-4cc2-b583-72cf076be7bc.json
@@ -1,0 +1,8 @@
+{
+    "id": "6081d67c-ca52-4cc2-b583-72cf076be7bc",
+    "type": "bugfix",
+    "description": "Update operation metrics to properly include RPC attributes and telemetry context",
+    "issues": [
+        "https://github.com/smithy-lang/smithy-kotlin/issues/1667"
+    ]
+}

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
@@ -17,6 +17,7 @@ import aws.smithy.kotlin.runtime.http.engine.EngineAttributes
 import aws.smithy.kotlin.runtime.http.operation.OperationMetrics
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.telemetry.metrics.recordPayloadSize
 import aws.smithy.kotlin.runtime.telemetry.metrics.recordSeconds
 import kotlin.time.TimeMark
@@ -49,13 +50,14 @@ internal class OperationTelemetryInterceptor(
         "rpc.method" to operation
     }
 
+    private val currentCtx: Context
+        get() = metrics.provider.contextManager.current()
+
     override fun readBeforeExecution(context: RequestInterceptorContext<Any>) {
         callStart = timeSource.markNow()
     }
 
     override fun readAfterExecution(context: ResponseInterceptorContext<Any, Any, HttpRequest?, HttpResponse?>) {
-        val currentCtx = metrics.provider.contextManager.current()
-
         callStart?.elapsedNow()?.let { callDuration ->
             metrics.rpcCallDuration.recordSeconds(callDuration, perRpcAttributes, currentCtx)
         }
@@ -79,18 +81,18 @@ internal class OperationTelemetryInterceptor(
 
     override fun readAfterSerialization(context: ProtocolRequestInterceptorContext<Any, HttpRequest>) {
         val serializeDuration = serializeStart?.elapsedNow() ?: return
-        metrics.serializationDuration.recordSeconds(serializeDuration, perRpcAttributes, metrics.provider.contextManager.current())
+        metrics.serializationDuration.recordSeconds(serializeDuration, perRpcAttributes, currentCtx)
     }
 
     override fun readAfterAttempt(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse?>) {
-        metrics.rpcAttempts.add(1L, perRpcAttributes, metrics.provider.contextManager.current())
+        metrics.rpcAttempts.add(1L, perRpcAttributes, currentCtx)
         attempts++
 
         val attemptDuration = attemptStart?.elapsedNow() ?: return
-        metrics.rpcAttemptDuration.recordSeconds(attemptDuration, perRpcAttributes, metrics.provider.contextManager.current())
+        metrics.rpcAttemptDuration.recordSeconds(attemptDuration, perRpcAttributes, currentCtx)
 
         context.executionContext.takeOrNull(EngineAttributes.TimeToFirstByte)?.let { ttfb ->
-            metrics.rpcAttemptOverheadDuration.recordSeconds(attemptDuration - ttfb, perRpcAttributes)
+            metrics.rpcAttemptOverheadDuration.recordSeconds(attemptDuration - ttfb, perRpcAttributes, currentCtx)
         }
     }
 
@@ -100,7 +102,7 @@ internal class OperationTelemetryInterceptor(
 
     override fun readAfterDeserialization(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse>) {
         val deserializeDuration = deserializeStart?.elapsedNow() ?: return
-        metrics.deserializationDuration.recordSeconds(deserializeDuration, perRpcAttributes, metrics.provider.contextManager.current())
+        metrics.deserializationDuration.recordSeconds(deserializeDuration, perRpcAttributes, currentCtx)
     }
 
     override fun readBeforeAttempt(context: ProtocolRequestInterceptorContext<Any, HttpRequest>) {
@@ -108,10 +110,10 @@ internal class OperationTelemetryInterceptor(
     }
 
     override fun readBeforeTransmit(context: ProtocolRequestInterceptorContext<Any, HttpRequest>) {
-        metrics.requestPayloadSize.recordPayloadSize(context.protocolRequest.body.contentLength)
+        metrics.requestPayloadSize.recordPayloadSize(context.protocolRequest.body.contentLength, perRpcAttributes, currentCtx)
     }
 
     override fun readAfterTransmit(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>) {
-        metrics.responsePayloadSize.recordPayloadSize(context.protocolResponse.body.contentLength)
+        metrics.responsePayloadSize.recordPayloadSize(context.protocolResponse.body.contentLength, perRpcAttributes, currentCtx)
     }
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -177,7 +177,7 @@ internal fun <Request, Response> SdkOperationExecution<Request, Response>.decora
     val receiveHandler = decorateHandler(handler, receive)
     val deserializeHandler = op.deserializer.decorate(receiveHandler, interceptors)
 
-    val authHandler = AuthHandler(deserializeHandler, interceptors, auth, op.context, endpointResolver)
+    val authHandler = AuthHandler(deserializeHandler, interceptors, auth, endpointResolver)
     val onEachAttemptHandler = decorateHandler(authHandler, onEachAttempt)
     val retryHandler = decorateHandler(onEachAttemptHandler, RetryMiddleware(retryStrategy, retryPolicy, interceptors))
 
@@ -270,7 +270,6 @@ internal class AuthHandler<Input, Output>(
     private val inner: Handler<SdkHttpRequest, Output>,
     private val interceptors: InterceptorExecutor<Input, Output>,
     private val authConfig: OperationAuthConfig,
-    private val opContext: ExecutionContext,
     private val endpointResolver: EndpointResolver? = null,
 ) : Handler<SdkHttpRequest, Output> {
 
@@ -283,8 +282,8 @@ internal class AuthHandler<Input, Output>(
 
         val schemeAttr = attributesOf {
             "auth.scheme_id" to authScheme.schemeId.id
-            opContext.getOrNull(SdkClientOption.ServiceName)?.let { "rpc.service" to it }
-            opContext.getOrNull(SdkClientOption.OperationName)?.let { "rpc.method" to it }
+            request.context.getOrNull(SdkClientOption.ServiceName)?.let { "rpc.service" to it }
+            request.context.getOrNull(SdkClientOption.OperationName)?.let { "rpc.method" to it }
         }
 
         // properties need to propagate from AuthOption to signer and identity provider

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.http.operation
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.businessmetrics.BusinessMetrics
 import aws.smithy.kotlin.runtime.businessmetrics.SmithyBusinessMetric
@@ -286,12 +287,15 @@ internal class AuthHandler<Input, Output>(
             request.context.getOrNull(SdkClientOption.OperationName)?.let { "rpc.method" to it }
         }
 
+        @OptIn(ExperimentalApi::class)
+        val telemetryCtx = request.context.operationMetrics.provider.contextManager.current()
+
         // properties need to propagate from AuthOption to signer and identity provider
         request.context.merge(authOption.attributes)
 
         // resolve identity from the selected auth scheme
         val identityProvider = authScheme.identityProvider(authConfig.identityProviderConfig)
-        val identity = request.context.operationMetrics.resolveIdentityDuration.measureSeconds(schemeAttr) {
+        val identity = request.context.operationMetrics.resolveIdentityDuration.measureSeconds(schemeAttr, telemetryCtx) {
             identityProvider.resolve(request.context)
         }
 
@@ -301,7 +305,7 @@ internal class AuthHandler<Input, Output>(
         val resolveEndpointReq = ResolveEndpointRequest(request.context, request.subject.immutableView(), identity)
 
         if (endpointResolver != null) {
-            val endpoint = request.context.operationMetrics.resolveEndpointDuration.measureSeconds(request.context.operationAttributes) {
+            val endpoint = request.context.operationMetrics.resolveEndpointDuration.measureSeconds(schemeAttr, telemetryCtx) {
                 endpointResolver.resolve(resolveEndpointReq)
             }
             coroutineContext.debug<AuthHandler<*, *>> { "resolved endpoint: $endpoint" }
@@ -321,7 +325,7 @@ internal class AuthHandler<Input, Output>(
 
         val signingRequest = SignHttpRequest(modified.subject, identity, modified.context)
 
-        request.context.operationMetrics.signingDuration.measureSeconds(schemeAttr) {
+        request.context.operationMetrics.signingDuration.measureSeconds(schemeAttr, telemetryCtx) {
             authScheme.signer.sign(signingRequest)
         }
 

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -10,6 +10,7 @@ import aws.smithy.kotlin.runtime.businessmetrics.BusinessMetrics
 import aws.smithy.kotlin.runtime.businessmetrics.SmithyBusinessMetric
 import aws.smithy.kotlin.runtime.businessmetrics.emitBusinessMetric
 import aws.smithy.kotlin.runtime.client.LogMode
+import aws.smithy.kotlin.runtime.client.SdkClientOption
 import aws.smithy.kotlin.runtime.client.endpoints.authOptions
 import aws.smithy.kotlin.runtime.client.logMode
 import aws.smithy.kotlin.runtime.collections.attributesOf
@@ -176,7 +177,7 @@ internal fun <Request, Response> SdkOperationExecution<Request, Response>.decora
     val receiveHandler = decorateHandler(handler, receive)
     val deserializeHandler = op.deserializer.decorate(receiveHandler, interceptors)
 
-    val authHandler = AuthHandler(deserializeHandler, interceptors, auth, endpointResolver)
+    val authHandler = AuthHandler(deserializeHandler, interceptors, auth, op.context, endpointResolver)
     val onEachAttemptHandler = decorateHandler(authHandler, onEachAttempt)
     val retryHandler = decorateHandler(onEachAttemptHandler, RetryMiddleware(retryStrategy, retryPolicy, interceptors))
 
@@ -269,6 +270,7 @@ internal class AuthHandler<Input, Output>(
     private val inner: Handler<SdkHttpRequest, Output>,
     private val interceptors: InterceptorExecutor<Input, Output>,
     private val authConfig: OperationAuthConfig,
+    private val opContext: ExecutionContext,
     private val endpointResolver: EndpointResolver? = null,
 ) : Handler<SdkHttpRequest, Output> {
 
@@ -281,6 +283,8 @@ internal class AuthHandler<Input, Output>(
 
         val schemeAttr = attributesOf {
             "auth.scheme_id" to authScheme.schemeId.id
+            opContext.getOrNull(SdkClientOption.ServiceName)?.let { "rpc.service" to it }
+            opContext.getOrNull(SdkClientOption.OperationName)?.let { "rpc.method" to it }
         }
 
         // properties need to propagate from AuthOption to signer and identity provider

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptorTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.ExperimentalApi
+import aws.smithy.kotlin.runtime.collections.AttributeKey
+import aws.smithy.kotlin.runtime.collections.get
+import aws.smithy.kotlin.runtime.http.Headers
+import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.HttpCall
+import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.SdkHttpClient
+import aws.smithy.kotlin.runtime.http.engine.EngineAttributes
+import aws.smithy.kotlin.runtime.http.operation.HttpDeserializer
+import aws.smithy.kotlin.runtime.http.operation.HttpSerializer
+import aws.smithy.kotlin.runtime.http.operation.OperationMetrics
+import aws.smithy.kotlin.runtime.http.operation.SdkHttpOperation
+import aws.smithy.kotlin.runtime.http.operation.roundTrip
+import aws.smithy.kotlin.runtime.http.operation.telemetry
+import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import aws.smithy.kotlin.runtime.http.util.MetricRecord
+import aws.smithy.kotlin.runtime.http.util.RecordingTelemetryProvider
+import aws.smithy.kotlin.runtime.httptest.TestEngine
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import aws.smithy.kotlin.runtime.telemetry.context.Context
+import aws.smithy.kotlin.runtime.time.Instant
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+private const val SERVICE_NAME = "TestService"
+private const val OPERATION_NAME = "TestOperation"
+
+private val RPC_SERVICE_KEY = AttributeKey<String>("rpc.service")
+private val RPC_METHOD_KEY = AttributeKey<String>("rpc.method")
+
+private val REQUEST_BODY = "request-payload".encodeToByteArray()
+private val RESPONSE_BODY = "response-payload-that-is-longer".encodeToByteArray()
+
+private object TelemetryTestInput
+private data class TelemetryTestOutput(val body: HttpBody)
+
+@OptIn(ExperimentalApi::class)
+class OperationTelemetryInterceptorTest {
+    private fun runOperation(provider: RecordingTelemetryProvider, withTimeToFirstByte: Boolean) = runTest {
+        val op = SdkHttpOperation.build<TelemetryTestInput, TelemetryTestOutput> {
+            serializeWith = object : HttpSerializer.NonStreaming<TelemetryTestInput> {
+                override fun serialize(
+                    context: ExecutionContext,
+                    input: TelemetryTestInput,
+                ): HttpRequestBuilder = HttpRequestBuilder().apply {
+                    body = HttpBody.fromBytes(REQUEST_BODY)
+                }
+            }
+
+            deserializeWith = object : HttpDeserializer.NonStreaming<TelemetryTestOutput> {
+                override fun deserialize(
+                    context: ExecutionContext,
+                    call: HttpCall,
+                    payload: ByteArray?,
+                ): TelemetryTestOutput = TelemetryTestOutput(call.response.body)
+            }
+
+            operationName = OPERATION_NAME
+            serviceName = SERVICE_NAME
+
+            telemetry {
+                this.provider = provider
+                metrics = OperationMetrics(SERVICE_NAME, provider)
+            }
+        }
+
+        if (withTimeToFirstByte) {
+            // simulate the engine reporting time-to-first-byte so the attempt-overhead metric is emitted
+            op.context[EngineAttributes.TimeToFirstByte] = 1.milliseconds
+        }
+
+        val engine = TestEngine { _, request ->
+            val resp = HttpResponse(HttpStatusCode.OK, Headers.Empty, HttpBody.fromBytes(RESPONSE_BODY))
+            HttpCall(request, resp, Instant.now(), Instant.now())
+        }
+
+        op.roundTrip(SdkHttpClient(engine), TelemetryTestInput)
+    }
+
+    private fun assertHasRpcAttributesAndContext(record: MetricRecord, expectedContext: Context) {
+        assertEquals(SERVICE_NAME, record.attributes.getOrNull(RPC_SERVICE_KEY), "${record.name} missing rpc.service")
+        assertEquals(OPERATION_NAME, record.attributes.getOrNull(RPC_METHOD_KEY), "${record.name} missing rpc.method")
+        assertNotNull(record.context, "${record.name} missing telemetry context")
+        assertSame(expectedContext, record.context, "${record.name} did not carry the current telemetry context")
+    }
+
+    @Test
+    fun testRequestPayloadSizeCarriesAttributesAndContext() {
+        val provider = RecordingTelemetryProvider()
+        runOperation(provider, withTimeToFirstByte = false)
+
+        val records = provider.recordsFor("smithy.client.call.request_payload_size")
+        assertEquals(1, records.size, "expected exactly one request payload size measurement")
+        val record = records.single()
+        assertHasRpcAttributesAndContext(record, provider.activeContext)
+        assertEquals(REQUEST_BODY.size.toDouble(), record.value)
+    }
+
+    @Test
+    fun testResponsePayloadSizeCarriesAttributesAndContext() {
+        val provider = RecordingTelemetryProvider()
+        runOperation(provider, withTimeToFirstByte = false)
+
+        val records = provider.recordsFor("smithy.client.call.response_payload_size")
+        assertEquals(1, records.size, "expected exactly one response payload size measurement")
+        val record = records.single()
+        assertHasRpcAttributesAndContext(record, provider.activeContext)
+        assertEquals(RESPONSE_BODY.size.toDouble(), record.value)
+    }
+
+    @Test
+    fun testAttemptOverheadDurationCarriesAttributesAndContext() {
+        val provider = RecordingTelemetryProvider()
+        runOperation(provider, withTimeToFirstByte = true)
+
+        val records = provider.recordsFor("smithy.client.call.attempt_overhead_duration")
+        assertEquals(1, records.size, "expected exactly one attempt overhead measurement")
+        assertHasRpcAttributesAndContext(records.single(), provider.activeContext)
+    }
+
+    @Test
+    fun testAttemptOverheadDurationNotEmittedWithoutTimeToFirstByte() {
+        val provider = RecordingTelemetryProvider()
+        runOperation(provider, withTimeToFirstByte = false)
+
+        assertTrue(
+            provider.recordsFor("smithy.client.call.attempt_overhead_duration").isEmpty(),
+            "attempt overhead metric should not be emitted without a time-to-first-byte measurement",
+        )
+    }
+
+    @Test
+    fun testAllEmittedMetricsCarryRpcAttributes() {
+        // regression guard for the bug: every operation metric should carry rpc.service/rpc.method
+        val provider = RecordingTelemetryProvider()
+        runOperation(provider, withTimeToFirstByte = true)
+
+        assertTrue(provider.records.isNotEmpty(), "expected the operation to emit metrics")
+        provider.records.forEach { record ->
+            assertEquals(SERVICE_NAME, record.attributes.get(RPC_SERVICE_KEY), "${record.name} missing rpc.service")
+            assertEquals(OPERATION_NAME, record.attributes.get(RPC_METHOD_KEY), "${record.name} missing rpc.method")
+        }
+    }
+}

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
@@ -72,7 +72,7 @@ class HttpAuthHandlerTest {
 
         val schemes = listOf(scheme).associateBy(AuthScheme::schemeId)
         val authConfig = OperationAuthConfig(resolver, schemes, idpConfig)
-        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, authConfig, ctx)
+        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, authConfig)
         val request = SdkHttpRequest(ctx, HttpRequestBuilder())
         op.call(request)
 
@@ -95,7 +95,7 @@ class HttpAuthHandlerTest {
             Endpoint("https://localhost")
         }
 
-        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, OperationAuthConfig.Anonymous, ctx, endpointResolver)
+        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, OperationAuthConfig.Anonymous, endpointResolver)
         val request = SdkHttpRequest(ctx, HttpRequestBuilder())
         op.call(request)
 
@@ -124,7 +124,7 @@ class HttpAuthHandlerTest {
         // seed internal state required
         interceptorExec.readBeforeExecution(Unit)
 
-        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, OperationAuthConfig.Anonymous, ctx)
+        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, OperationAuthConfig.Anonymous)
         val request = SdkHttpRequest(ctx, HttpRequestBuilder())
         op.call(request)
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
@@ -5,8 +5,10 @@
 
 package aws.smithy.kotlin.runtime.http.operation
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
+import aws.smithy.kotlin.runtime.client.SdkClientOption
 import aws.smithy.kotlin.runtime.client.endpoints.Endpoint
 import aws.smithy.kotlin.runtime.collections.AttributeKey
 import aws.smithy.kotlin.runtime.collections.Attributes
@@ -15,6 +17,7 @@ import aws.smithy.kotlin.runtime.collections.get
 import aws.smithy.kotlin.runtime.http.auth.*
 import aws.smithy.kotlin.runtime.http.interceptors.InterceptorExecutor
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.http.util.RecordingTelemetryProvider
 import aws.smithy.kotlin.runtime.identity.Identity
 import aws.smithy.kotlin.runtime.identity.IdentityProvider
 import aws.smithy.kotlin.runtime.identity.IdentityProviderConfig
@@ -69,7 +72,7 @@ class HttpAuthHandlerTest {
 
         val schemes = listOf(scheme).associateBy(AuthScheme::schemeId)
         val authConfig = OperationAuthConfig(resolver, schemes, idpConfig)
-        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, authConfig)
+        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, authConfig, ctx)
         val request = SdkHttpRequest(ctx, HttpRequestBuilder())
         op.call(request)
 
@@ -92,11 +95,48 @@ class HttpAuthHandlerTest {
             Endpoint("https://localhost")
         }
 
-        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, OperationAuthConfig.Anonymous, endpointResolver)
+        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, OperationAuthConfig.Anonymous, ctx, endpointResolver)
         val request = SdkHttpRequest(ctx, HttpRequestBuilder())
         op.call(request)
 
         assertEquals(Scheme.HTTPS, request.subject.url.scheme)
         assertEquals(Host.Domain("localhost"), request.subject.url.host)
+    }
+
+    @OptIn(ExperimentalApi::class)
+    @Test
+    fun testAuthMetricsCarryRpcAttributes() = runTest {
+        // verify identity-resolution and signing metrics are tagged with rpc.service/rpc.method
+        val rpcServiceKey = AttributeKey<String>("rpc.service")
+        val rpcMethodKey = AttributeKey<String>("rpc.method")
+
+        val inner = object : Handler<SdkHttpRequest, Unit> {
+            override suspend fun call(request: SdkHttpRequest) = Unit
+        }
+
+        val provider = RecordingTelemetryProvider()
+        val ctx = ExecutionContext()
+        ctx[SdkClientOption.ServiceName] = "TestService"
+        ctx[SdkClientOption.OperationName] = "TestOperation"
+        ctx[HttpOperationContext.OperationMetrics] = OperationMetrics("TestService", provider)
+
+        val interceptorExec = InterceptorExecutor<Unit, Unit>(ctx, emptyList(), OperationTypeInfo(Unit::class, Unit::class))
+        // seed internal state required
+        interceptorExec.readBeforeExecution(Unit)
+
+        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, OperationAuthConfig.Anonymous, ctx)
+        val request = SdkHttpRequest(ctx, HttpRequestBuilder())
+        op.call(request)
+
+        listOf(
+            "smithy.client.call.auth.resolve_identity_duration",
+            "smithy.client.call.auth.signing_duration",
+        ).forEach { name ->
+            val records = provider.recordsFor(name)
+            assertEquals(1, records.size, "expected exactly one $name measurement")
+            val attrs = records.single().attributes
+            assertEquals("TestService", attrs.getOrNull(rpcServiceKey), "$name missing rpc.service attribute")
+            assertEquals("TestOperation", attrs.getOrNull(rpcMethodKey), "$name missing rpc.method attribute")
+        }
     }
 }

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
@@ -29,6 +29,8 @@ import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class HttpAuthHandlerTest {
@@ -105,11 +107,9 @@ class HttpAuthHandlerTest {
 
     @OptIn(ExperimentalApi::class)
     @Test
-    fun testAuthMetricsCarryRpcAttributes() = runTest {
-        // verify identity-resolution and signing metrics are tagged with rpc.service/rpc.method
-        val rpcServiceKey = AttributeKey<String>("rpc.service")
-        val rpcMethodKey = AttributeKey<String>("rpc.method")
-
+    fun testAuthMetricsCarryRpcAttributesAndContext() = runTest {
+        // verify identity-resolution and signing metrics are tagged with rpc.service/rpc.method and
+        // carry the current telemetry context
         val inner = object : Handler<SdkHttpRequest, Unit> {
             override suspend fun call(request: SdkHttpRequest) = Unit
         }
@@ -132,11 +132,55 @@ class HttpAuthHandlerTest {
             "smithy.client.call.auth.resolve_identity_duration",
             "smithy.client.call.auth.signing_duration",
         ).forEach { name ->
-            val records = provider.recordsFor(name)
-            assertEquals(1, records.size, "expected exactly one $name measurement")
-            val attrs = records.single().attributes
-            assertEquals("TestService", attrs.getOrNull(rpcServiceKey), "$name missing rpc.service attribute")
-            assertEquals("TestOperation", attrs.getOrNull(rpcMethodKey), "$name missing rpc.method attribute")
+            assertMetricHasRpcAttributesAndContext(provider, name)
         }
+    }
+
+    @OptIn(ExperimentalApi::class)
+    @Test
+    fun testEndpointResolutionMetricCarriesRpcAttributesAndContext() = runTest {
+        // verify the endpoint-resolution metric is tagged with rpc.service/rpc.method and carries the
+        // current telemetry context (previously it used operationAttributes and omitted the context)
+        val inner = object : Handler<SdkHttpRequest, Unit> {
+            override suspend fun call(request: SdkHttpRequest) = Unit
+        }
+
+        val provider = RecordingTelemetryProvider()
+        val ctx = ExecutionContext()
+        ctx[SdkClientOption.ServiceName] = "TestService"
+        ctx[SdkClientOption.OperationName] = "TestOperation"
+        ctx[HttpOperationContext.OperationMetrics] = OperationMetrics("TestService", provider)
+
+        val interceptorExec = InterceptorExecutor<Unit, Unit>(ctx, emptyList(), OperationTypeInfo(Unit::class, Unit::class))
+        // seed internal state required
+        interceptorExec.readBeforeExecution(Unit)
+
+        val endpointResolver = EndpointResolver {
+            Endpoint("https://localhost")
+        }
+
+        val op = AuthHandler<Unit, Unit>(inner, interceptorExec, OperationAuthConfig.Anonymous, endpointResolver)
+        val request = SdkHttpRequest(ctx, HttpRequestBuilder())
+        op.call(request)
+
+        assertMetricHasRpcAttributesAndContext(provider, "smithy.client.call.resolve_endpoint_duration")
+    }
+
+    /**
+     * Asserts that exactly one measurement was recorded for [name] and that it carries the rpc.service/rpc.method
+     * attributes and the provider's current telemetry context.
+     */
+    @OptIn(ExperimentalApi::class)
+    private fun assertMetricHasRpcAttributesAndContext(provider: RecordingTelemetryProvider, name: String) {
+        val rpcServiceKey = AttributeKey<String>("rpc.service")
+        val rpcMethodKey = AttributeKey<String>("rpc.method")
+
+        val records = provider.recordsFor(name)
+        assertEquals(1, records.size, "expected exactly one $name measurement")
+        val record = records.single()
+        assertEquals("TestService", record.attributes.getOrNull(rpcServiceKey), "$name missing rpc.service attribute")
+        assertEquals("TestOperation", record.attributes.getOrNull(rpcMethodKey), "$name missing rpc.method attribute")
+        assertNotNull(record.context, "$name missing telemetry context")
+        assertSame(provider.activeContext, record.context, "$name did not carry the current telemetry context")
     }
 }

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/util/RecordingTelemetryProvider.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/util/RecordingTelemetryProvider.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.util
+
+import aws.smithy.kotlin.runtime.ExperimentalApi
+import aws.smithy.kotlin.runtime.collections.Attributes
+import aws.smithy.kotlin.runtime.telemetry.AbstractTelemetryProvider
+import aws.smithy.kotlin.runtime.telemetry.context.AbstractContext
+import aws.smithy.kotlin.runtime.telemetry.context.Context
+import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
+import aws.smithy.kotlin.runtime.telemetry.metrics.AbstractMeter
+import aws.smithy.kotlin.runtime.telemetry.metrics.AbstractMeterProvider
+import aws.smithy.kotlin.runtime.telemetry.metrics.DoubleHistogram
+import aws.smithy.kotlin.runtime.telemetry.metrics.Histogram
+import aws.smithy.kotlin.runtime.telemetry.metrics.Meter
+import aws.smithy.kotlin.runtime.telemetry.metrics.MeterProvider
+import aws.smithy.kotlin.runtime.telemetry.metrics.MonotonicCounter
+
+/**
+ * A single recorded metric measurement captured by [RecordingTelemetryProvider].
+ *
+ * @param name the instrument name (e.g. `smithy.client.call.request_payload_size`)
+ * @param value the recorded value (counter deltas are converted to [Double])
+ * @param attributes the attributes associated with the measurement
+ * @param context the telemetry context associated with the measurement (or `null` if none was passed)
+ */
+internal data class MetricRecord(
+    val name: String,
+    val value: Double,
+    val attributes: Attributes,
+    val context: Context?,
+)
+
+/**
+ * A [aws.smithy.kotlin.runtime.telemetry.TelemetryProvider] test double that records every metric measurement
+ * (histogram or counter) along with the attributes and telemetry context it was emitted with.
+ *
+ * [activeContext] is returned from [ContextManager.current] so tests can assert that the "current" context is
+ * threaded through to metric recordings.
+ */
+@OptIn(ExperimentalApi::class)
+internal class RecordingTelemetryProvider : AbstractTelemetryProvider() {
+    val records = mutableListOf<MetricRecord>()
+
+    /**
+     * A distinct, non-default context instance returned by the [contextManager]. Tests assert recorded metrics
+     * carry this exact instance to prove the current context is propagated.
+     */
+    val activeContext: Context = object : AbstractContext() {}
+
+    override val contextManager: ContextManager = object : ContextManager {
+        override fun current(): Context = activeContext
+    }
+
+    override val meterProvider: MeterProvider = object : AbstractMeterProvider() {
+        override fun getOrCreateMeter(scope: String): Meter = RecordingMeter(records)
+    }
+
+    /**
+     * Returns all recordings for the instrument with the given [name].
+     */
+    fun recordsFor(name: String): List<MetricRecord> = records.filter { it.name == name }
+}
+
+private class RecordingMeter(private val sink: MutableList<MetricRecord>) : AbstractMeter() {
+    override fun createDoubleHistogram(
+        name: String,
+        units: String?,
+        description: String?,
+    ): DoubleHistogram = RecordingDoubleHistogram(name, sink)
+
+    override fun createMonotonicCounter(
+        name: String,
+        units: String?,
+        description: String?,
+    ): MonotonicCounter = RecordingMonotonicCounter(name, sink)
+}
+
+private class RecordingDoubleHistogram(
+    private val name: String,
+    private val sink: MutableList<MetricRecord>,
+) : Histogram<Double> {
+    override fun record(value: Double, attributes: Attributes, context: Context?) {
+        sink += MetricRecord(name, value, attributes, context)
+    }
+}
+
+private class RecordingMonotonicCounter(
+    private val name: String,
+    private val sink: MutableList<MetricRecord>,
+) : MonotonicCounter {
+    override fun add(value: Long, attributes: Attributes, context: Context?) {
+        sink += MetricRecord(name, value.toDouble(), attributes, context)
+    }
+}


### PR DESCRIPTION
## Issue \#

Resolves #1667 

## Description of changes

This changes adds missing metric attributes and telemetry context to various metrics which were previously missing them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
