### PR TITLE
chore: remap the transform rules for codegen packages from MAJOR.x to MAJOR.0.x to match all other packages

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -29,11 +29,7 @@
   },
   "packageHandlingRules": {
     "versioning": {
-      "defaultVersionLayout": "{MAJOR}.0.x",
-      "overrides": {
-        "aws.smithy.kotlin:aws-codegen": "{MAJOR}.x",
-        "aws.smithy.kotlin:codegen": "{MAJOR}.x"
-      }
+      "defaultVersionLayout": "{MAJOR}.0.x"
     },
     "rename": {
         "aws.smithy.kotlin:aws-codegen": "AwsSmithyAwsKotlinCodegen",


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Changes the Brazil version mapping for codegen packages to `MAJOR.0.x` to match all other packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
