### PR TITLE
fix: remove require validation for optional paramater

### DIFF
--- a/.changes/e31b4eb0-a1de-4ed6-98cc-d8a427a3353f.json
+++ b/.changes/e31b4eb0-a1de-4ed6-98cc-d8a427a3353f.json
@@ -1,0 +1,8 @@
+{
+  "id": "e31b4eb0-a1de-4ed6-98cc-d8a427a3353f",
+  "type": "bugfix",
+  "description": "Remove client-side non-blank validation for HTTP query-bound members to match the Smithy specification. Optional query parameters left unset no longer cause an `IllegalArgumentException` during request serialization.",
+  "issues": [
+    "https://github.com/aws/aws-sdk-kotlin/issues/1974"
+  ]
+}

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -590,7 +590,6 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 "}",
                 RuntimeTypes.Core.Text.Encoding.PercentEncoding,
             ) {
-
                 renderStringValuesMapParameters(ctx, queryBindings, writer)
 
                 queryMapBindings.forEach {

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -590,8 +590,6 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 "}",
                 RuntimeTypes.Core.Text.Encoding.PercentEncoding,
             ) {
-                // render length check if applicable
-                queryBindings.forEach { binding -> renderNonBlankGuard(ctx, binding.member, writer) }
 
                 renderStringValuesMapParameters(ctx, queryBindings, writer)
 

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -573,7 +573,6 @@ internal class SmokeTestOperationDeserializer: HttpDeserializer.NonStreaming<Smo
                 add(PercentEncoding.SmithyLabel.encode(input.baz.toString()))
             }
             parameters.decodedParameters(PercentEncoding.SmithyLabel) {
-                require(input.garply?.isNotBlank() == true) { "garply is bound to the URI and must be a non-blank value" }
                 if (input.corge != null) add("corge", input.corge)
                 if (input.garply != null) add("garply", input.garply)
                 if (input.grault != null) add("grault", input.grault)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
Resolve https://github.com/aws/aws-sdk-kotlin/issues/1974

## Description of changes
Remove client-side non-blank validation for HTTP query-bound members to match the Smithy specification. Optional query parameters left unset no longer cause an `IllegalArgumentException` during request serialization.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
