### PR TITLE
Fix byte count

### DIFF
--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
@@ -15,9 +15,6 @@ import aws.smithy.kotlin.runtime.serde.cbor.encodeMajorMinor
  */
 internal class TextString(val value: String) : Value {
     override fun encode(into: SdkBufferedSink) {
-        // Encode the UTF-8 bytes once and use their length for the CBOR length argument. The CBOR text
-        // string length is a *byte* count (RFC 8949 §3.1), so we must not use `value.length` which is a
-        // UTF-16 code-unit count and diverges for any multibyte character.
         val bytes = value.encodeToByteArray()
         into.write(encodeArgument(Major.STRING, bytes.size.toULong()))
         into.write(bytes)

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
@@ -15,8 +15,12 @@ import aws.smithy.kotlin.runtime.serde.cbor.encodeMajorMinor
  */
 internal class TextString(val value: String) : Value {
     override fun encode(into: SdkBufferedSink) {
-        into.write(encodeArgument(Major.STRING, value.length.toULong()))
-        into.write(value.encodeToByteArray())
+        // Encode the UTF-8 bytes once and use their length for the CBOR length argument. The CBOR text
+        // string length is a *byte* count (RFC 8949 §3.1), so we must not use `value.length` which is a
+        // UTF-16 code-unit count and diverges for any multibyte character.
+        val bytes = value.encodeToByteArray()
+        into.write(encodeArgument(Major.STRING, bytes.size.toULong()))
+        into.write(bytes)
     }
 
     internal companion object {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
CBOR text string length is a byte count (RFC 8949 3.1), but the encoder used value.length (UTF-16 code-unit count). Multibyte strings produced invalid, non-round-trippable CBOR. Encode UTF-8 bytes once and use their size for the length argument. Byte-identical for ASCII inputs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
