### PR TITLE
Fix cbor serde

### DIFF
--- a/.changes/2049bc8a-cd89-4d1e-bb4a-84c1f7c3349e.json
+++ b/.changes/2049bc8a-cd89-4d1e-bb4a-84c1f7c3349e.json
@@ -1,0 +1,6 @@
+{
+  "id": "2049bc8a-cd89-4d1e-bb4a-84c1f7c3349e",
+  "type": "bugfix",
+  "description": "Fix decoding of CBOR timestamps encoded as negative integers, which previously decoded with the wrong sign for pre-epoch instants",
+  "module": "serde-cbor"
+}

--- a/.changes/4fc67136-9c96-448b-a621-1b94c3ef2fcc.json
+++ b/.changes/4fc67136-9c96-448b-a621-1b94c3ef2fcc.json
@@ -1,0 +1,6 @@
+{
+  "id": "4fc67136-9c96-448b-a621-1b94c3ef2fcc",
+  "type": "bugfix",
+  "description": "Decode CBOR string, byte-string, and collection lengths as a `Long` so large lengths are no longer silently truncated to `Int`",
+  "module": "serde-cbor"
+}

--- a/.changes/98b59b85-7aa6-499a-8fa3-6c528d6ef09c.json
+++ b/.changes/98b59b85-7aa6-499a-8fa3-6c528d6ef09c.json
@@ -1,0 +1,6 @@
+{
+  "id": "98b59b85-7aa6-499a-8fa3-6c528d6ef09c",
+  "type": "bugfix",
+  "description": "Encode and decode CBOR negative bignums using the RFC 8949 unsigned magnitude representation instead of a signed two's-complement encoding, fixing interoperability for negative `BigInteger` values",
+  "module": "serde-cbor"
+}

--- a/.changes/de6ada71-1c76-44ee-bc75-5a05b0ec3726.json
+++ b/.changes/de6ada71-1c76-44ee-bc75-5a05b0ec3726.json
@@ -1,0 +1,6 @@
+{
+  "id": "de6ada71-1c76-44ee-bc75-5a05b0ec3726",
+  "type": "bugfix",
+  "description": "Encode CBOR text string lengths as a UTF-8 byte count instead of a UTF-16 code-unit count, so multibyte strings produce valid RFC 8949 output",
+  "module": "serde-cbor"
+}

--- a/.changes/e23080a4-5cde-4d09-b047-ccfbd5b0857c.json
+++ b/.changes/e23080a4-5cde-4d09-b047-ccfbd5b0857c.json
@@ -1,0 +1,6 @@
+{
+  "id": "e23080a4-5cde-4d09-b047-ccfbd5b0857c",
+  "type": "bugfix",
+  "description": "Fix CBOR decimal fraction encoding and decoding to use the RFC 8949 scale exponent, correcting the transmitted value for `BigDecimal`s whose mantissa has more than one significant digit",
+  "module": "serde-cbor"
+}

--- a/.changes/eab4cb84-2a49-447a-a435-48efb8b34bb0.json
+++ b/.changes/eab4cb84-2a49-447a-a435-48efb8b34bb0.json
@@ -1,6 +1,6 @@
 {
   "id": "eab4cb84-2a49-447a-a435-48efb8b34bb0",
   "type": "bugfix",
-  "description": "Fix CBOR serialization and deserialization to be RFC 8949 compliant on the wire. Text string lengths now use the UTF-8 byte count instead of the UTF-16 code-unit count. Negative bignums, negative-integer timestamps, and decimal fractions now encode and decode using the correct RFC representation instead of a self-consistent but non-interoperable one. Floating-point values encoded as CBOR integers are converted numerically rather than misinterpreted as raw IEEE-754 bits, and byte-string/collection lengths are no longer truncated to `Int`",
+  "description": "Fix CBOR encoding and decoding of text strings, negative bignums, negative-integer timestamps, decimal fractions, integer-encoded floats, and large lengths to be RFC 8949 compliant on the wire",
   "module": "serde-cbor"
 }

--- a/.changes/eab4cb84-2a49-447a-a435-48efb8b34bb0.json
+++ b/.changes/eab4cb84-2a49-447a-a435-48efb8b34bb0.json
@@ -1,0 +1,6 @@
+{
+  "id": "eab4cb84-2a49-447a-a435-48efb8b34bb0",
+  "type": "bugfix",
+  "description": "Fix CBOR serialization and deserialization to be RFC 8949 compliant on the wire. Text string lengths now use the UTF-8 byte count instead of the UTF-16 code-unit count. Negative bignums, negative-integer timestamps, and decimal fractions now encode and decode using the correct RFC representation instead of a self-consistent but non-interoperable one. Floating-point values encoded as CBOR integers are converted numerically rather than misinterpreted as raw IEEE-754 bits, and byte-string/collection lengths are no longer truncated to `Int`",
+  "module": "serde-cbor"
+}

--- a/.changes/eab4cb84-2a49-447a-a435-48efb8b34bb0.json
+++ b/.changes/eab4cb84-2a49-447a-a435-48efb8b34bb0.json
@@ -1,6 +1,0 @@
-{
-  "id": "eab4cb84-2a49-447a-a435-48efb8b34bb0",
-  "type": "bugfix",
-  "description": "Fix CBOR encoding and decoding of text strings, negative bignums, negative-integer timestamps, decimal fractions, integer-encoded floats, and large lengths to be RFC 8949 compliant on the wire",
-  "module": "serde-cbor"
-}

--- a/.changes/f040019d-5596-40bb-86f0-c3794b624677.json
+++ b/.changes/f040019d-5596-40bb-86f0-c3794b624677.json
@@ -1,0 +1,6 @@
+{
+  "id": "f040019d-5596-40bb-86f0-c3794b624677",
+  "type": "bugfix",
+  "description": "Convert CBOR floating-point values that arrive encoded as integers numerically instead of misinterpreting the integer as raw IEEE-754 bits",
+  "module": "serde-cbor"
+}

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializer.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializer.kt
@@ -91,17 +91,16 @@ internal class CborPrimitiveDeserializer(private val buffer: SdkBufferedSource) 
     override fun deserializeLong(): Long = deserializeNumber { it.toLong() }
 
     private inline fun <reified T : Number> deserializeFloatingPoint(cast: (Number) -> T): T {
-        val number = when (peekMinorByte(buffer)) {
-            Minor.FLOAT16.value -> Float16.decode(buffer).value
-            Minor.FLOAT32.value -> Float32.decode(buffer).value
-            Minor.FLOAT64.value -> Float64.decode(buffer).value
-            else -> {
-                when (T::class) {
-                    Float::class -> Float.fromBits(decodeArgument(buffer).toInt())
-                    Double::class -> Double.fromBits(decodeArgument(buffer).toLong())
-                    else -> throw DeserializationException("Unsupported floating point type: ${T::class}")
-                }
+        val number: Number = when (val major = peekMajor(buffer)) {
+            Major.TYPE_7 -> when (val minor = peekMinorByte(buffer)) {
+                Minor.FLOAT16.value -> Float16.decode(buffer).value
+                Minor.FLOAT32.value -> Float32.decode(buffer).value
+                Minor.FLOAT64.value -> Float64.decode(buffer).value
+                else -> throw DeserializationException("Unexpected minor value $minor decoding CBOR floating point for major type 7.")
             }
+            Major.U_INT -> UInt.decode(buffer).value.toLong()
+            Major.NEG_INT -> -(NegInt.decode(buffer).value.toLong())
+            else -> throw DeserializationException("Expected floating point or integer major type for CBOR floating point number, got $major.")
         }
         return cast(number)
     }

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
@@ -31,10 +31,10 @@ internal class TextString(val value: String) : Value {
 
             TextString(sb.toString())
         } else {
-            val length = decodeArgument(buffer).toInt()
+            val length = decodeArgument(buffer).toLong()
 
             val bytes = SdkBuffer().use {
-                buffer.readFully(it, length.toLong())
+                buffer.readFully(it, length)
                 it.readByteArray()
             }
 
@@ -64,10 +64,10 @@ internal class ByteString(val value: ByteArray) : Value {
 
             ByteString(tempBuffer.readByteArray())
         } else {
-            val length = decodeArgument(buffer).toInt()
+            val length = decodeArgument(buffer).toLong()
 
             val bytes = SdkBuffer().use {
-                buffer.readFully(it, length.toLong())
+                buffer.readFully(it, length)
                 it.readByteArray()
             }
 
@@ -88,7 +88,7 @@ internal class List(val value: kotlin.collections.List<Value>) : Value {
 
     internal companion object {
         internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): List {
-            val length = decodeArgument(buffer).toInt()
+            val length = decodeArgument(buffer).toLong()
             val valuesList = mutableListOf<Value>()
 
             for (i in 0 until length) {
@@ -151,7 +151,7 @@ internal class Map(val value: kotlin.collections.Map<Value, Value>) : Value {
     internal companion object {
         internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): Map {
             val valueMap = mutableMapOf<Value, Value>()
-            val length = decodeArgument(buffer).toInt()
+            val length = decodeArgument(buffer).toLong()
 
             for (i in 0 until length) {
                 val key = Value.decode(buffer, depth + 1)

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
@@ -15,9 +15,6 @@ import aws.smithy.kotlin.runtime.serde.cbor.encodeMajorMinor
  */
 internal class TextString(val value: String) : Value {
     override fun encode(into: SdkBufferedSink) {
-        // Encode the UTF-8 bytes once and use their length for the CBOR length argument. The CBOR text
-        // string length is a *byte* count (RFC 8949 §3.1), so we must not use `value.length` which is a
-        // UTF-16 code-unit count and diverges for any multibyte character.
         val bytes = value.encodeToByteArray()
         into.write(encodeArgument(Major.STRING, bytes.size.toULong()))
         into.write(bytes)

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
@@ -15,8 +15,12 @@ import aws.smithy.kotlin.runtime.serde.cbor.encodeMajorMinor
  */
 internal class TextString(val value: String) : Value {
     override fun encode(into: SdkBufferedSink) {
-        into.write(encodeArgument(Major.STRING, value.length.toULong()))
-        into.write(value.encodeToByteArray())
+        // Encode the UTF-8 bytes once and use their length for the CBOR length argument. The CBOR text
+        // string length is a *byte* count (RFC 8949 §3.1), so we must not use `value.length` which is a
+        // UTF-16 code-unit count and diverges for any multibyte character.
+        val bytes = value.encodeToByteArray()
+        into.write(encodeArgument(Major.STRING, bytes.size.toULong()))
+        into.write(bytes)
     }
 
     internal companion object {

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Tag.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Tag.kt
@@ -72,7 +72,7 @@ internal class Timestamp(val value: Instant) : Value {
                     Instant.fromEpochSeconds(timestamp)
                 }
                 Major.NEG_INT -> {
-                    val negativeTimestamp: Long = NegInt.decode(buffer).value.toLong()
+                    val negativeTimestamp: Long = -(NegInt.decode(buffer).value.toLong())
                     Instant.fromEpochSeconds(negativeTimestamp)
                 }
                 Major.TYPE_7 -> {
@@ -113,7 +113,13 @@ internal class BigNum(val value: BigInteger) : Value {
  */
 internal class NegBigNum(val value: BigInteger) : Value {
     override fun encode(into: SdkBufferedSink) {
-        val bytes = (value - BigInteger("1")).toByteArray()
+        val magnitude = BigInteger("-1") - value
+        val twosComplement = magnitude.toByteArray()
+        val bytes = if (twosComplement.size > 1 && twosComplement[0] == 0.toByte()) {
+            twosComplement.copyOfRange(1, twosComplement.size)
+        } else {
+            twosComplement
+        }
         Tag(3u, ByteString(bytes)).encode(into)
     }
 
@@ -121,9 +127,8 @@ internal class NegBigNum(val value: BigInteger) : Value {
         internal fun decode(buffer: SdkBufferedSource, depth: Int = 0): NegBigNum {
             val bytes = ByteString.decode(buffer, depth).value
 
-            // note: CBOR encoding implies (-1 - $value), add one to get the real value.
-            val bigInteger = BigInteger(bytes) + BigInteger("1")
-            return NegBigNum(bigInteger)
+            val magnitude = BigInteger(byteArrayOf(0) + bytes)
+            return NegBigNum(BigInteger("-1") - magnitude)
         }
     }
 }
@@ -134,7 +139,8 @@ internal class NegBigNum(val value: BigInteger) : Value {
  */
 internal class DecimalFraction(val value: BigDecimal) : Value {
     override fun encode(into: SdkBufferedSink) {
-        val cborExponent = -value.exponent // CBOR has inverted exponent semantics
+        val mantissaDigits = value.mantissa.toString().trimStart('-').length
+        val cborExponent = value.exponent - (mantissaDigits - 1)
 
         val exponent = if (cborExponent < 0) {
             NegInt(cborExponent.absoluteValue.toULong())
@@ -177,14 +183,15 @@ internal class DecimalFraction(val value: BigDecimal) : Value {
                 else -> throw DeserializationException("Expected UInt, NegInt, or Tag for CBOR decimal fraction mantissa, got $mantissaValue")
             }
 
-            val exponent = when (exponentValue) {
+            val cborExponent = when (exponentValue) {
                 is UInt -> exponentValue.value.toInt()
                 is NegInt -> -exponentValue.value.toInt()
                 else -> throw DeserializationException("Expected integer for CBOR decimal fraction exponent value, got $exponentValue.")
             }
 
+            val mantissaDigits = mantissa.toString().trimStart('-').length
             return try {
-                DecimalFraction(BigDecimal(mantissa, -exponent))
+                DecimalFraction(BigDecimal(mantissa, cborExponent + (mantissaDigits - 1)))
             } catch (iae: IllegalArgumentException) {
                 throw DeserializationException("Cannot deserialize unsupported BigDecimal value", iae)
             }

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerSuccessTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborDeserializerSuccessTest.kt
@@ -4,12 +4,16 @@
  */
 package aws.smithy.kotlin.runtime.serde.cbor
 
+import aws.smithy.kotlin.runtime.content.BigDecimal
+import aws.smithy.kotlin.runtime.content.BigInteger
 import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.serde.SdkFieldDescriptor
 import aws.smithy.kotlin.runtime.serde.SerialKind
 import aws.smithy.kotlin.runtime.serde.cbor.encoding.NegInt
 import aws.smithy.kotlin.runtime.serde.deserializeList
 import aws.smithy.kotlin.runtime.serde.deserializeMap
+import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.TimestampFormat
 import kotlin.test.*
 
 class CborDeserializerSuccessTest {
@@ -2652,5 +2656,56 @@ class CborDeserializerSuccessTest {
         assertEquals(1, actual.size)
         assertEquals("foo", actual.entries.first().key)
         assertEquals(-1, actual.entries.first().value)
+    }
+
+    @Test
+    fun `negative bignum - rfc unsigned magnitude`() {
+        mapOf(
+            "c34201f3" to "-500", // n = 499 = 0x01f3
+            "c34100" to "-1", // n = 0 (single 0x00 byte)
+            "c341ff" to "-256", // n = 255 = 0xff
+        ).forEach { (hex, expected) ->
+            val deserializer = CborPrimitiveDeserializer(SdkBuffer().apply { write(hex.hexToByteArray()) })
+            assertEquals(BigInteger(expected), deserializer.deserializeBigInteger(), "decoding $hex")
+        }
+    }
+
+    @Test
+    fun `timestamp - negative integer`() {
+        mapOf(
+            "c120" to -1L, // negint -1
+            "c13a3b9ac9ff" to -1000000000L, // negint -1000000000
+        ).forEach { (hex, epochSeconds) ->
+            val deserializer = CborPrimitiveDeserializer(SdkBuffer().apply { write(hex.hexToByteArray()) })
+            assertEquals(
+                Instant.fromEpochSeconds(epochSeconds),
+                deserializer.deserializeInstant(TimestampFormat.EPOCH_SECONDS),
+                "decoding $hex",
+            )
+        }
+    }
+
+    @Test
+    fun `decimal fraction - rfc scale exponent`() {
+        mapOf(
+            "c482200b" to "1.1", // 4([-1, 11])
+            "c482221a0001e240" to "123.456", // 4([-3, 123456])
+        ).forEach { (hex, expected) ->
+            val deserializer = CborPrimitiveDeserializer(SdkBuffer().apply { write(hex.hexToByteArray()) })
+            assertEquals(BigDecimal(expected), deserializer.deserializeBigDecimal(), "decoding $hex")
+        }
+    }
+
+    @Test
+    fun `floating point - encoded as integer`() {
+        mapOf(
+            "01" to 1.0, // uint 1
+            "20" to -1.0, // negint -1
+            "1903e8" to 1000.0, // uint 1000 (>=2-byte arg)
+        ).forEach { (hex, expected) ->
+            fun deserializer() = CborPrimitiveDeserializer(SdkBuffer().apply { write(hex.hexToByteArray()) })
+            assertEquals(expected.toFloat(), deserializer().deserializeFloat(), "decoding $hex as float")
+            assertEquals(expected, deserializer().deserializeDouble(), "decoding $hex as double")
+        }
     }
 }

--- a/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborSerializerTest.kt
+++ b/runtime/serde/serde-cbor/common/test/aws/smithy/kotlin/runtime/serde/cbor/CborSerializerTest.kt
@@ -200,6 +200,20 @@ class CborSerializerTest {
     }
 
     @Test
+    fun testNegativeBigIntegerRfcEncoding() {
+        mapOf(
+            "-500" to "c34201f3", // n = 499 = 0x01f3
+            "-1" to "c34100", // n = 0
+            "-256" to "c341ff", // n = 255 = 0xff
+            "-18446744073709551617" to "c349010000000000000000", // n = 2^64 (mirror of the positive RFC example)
+        ).forEach { (input, expectedHex) ->
+            val serializer = CborSerializer()
+            serializer.serializeBigInteger(BigInteger(input))
+            assertEquals(expectedHex, serializer.toByteArray().toHexString(), "encoding $input")
+        }
+    }
+
+    @Test
     fun testBigDecimal() {
         val tests = listOf(
             BigDecimal("-123453450934503474823945734895.4563458734895738978902384902384908"),
@@ -237,6 +251,19 @@ class CborSerializerTest {
         // Test taken from CBOR RFC: https://www.rfc-editor.org/rfc/rfc8949.html#section-3.4.4
         serializer.serializeBigDecimal(BigDecimal("273.15"))
         assertEquals("c48221196ab3", serializer.toByteArray().toHexString())
+    }
+
+    @Test
+    fun testBigDecimalRfcEncoding() {
+        mapOf(
+            "1.1" to "c482200b", // [-1, 11]  (NOT 11, which the scientific-exponent bug would emit)
+            "13" to "c482000d", // [0, 13]
+            "123.456" to "c482221a0001e240", // [-3, 123456]
+        ).forEach { (input, expectedHex) ->
+            val serializer = CborSerializer()
+            serializer.serializeBigDecimal(BigDecimal(input))
+            assertEquals(expectedHex, serializer.toByteArray().toHexString(), "encoding $input")
+        }
     }
 
     @Test


### PR DESCRIPTION

Six CBOR encoding/decoding bugs produced non-interoperable wire bytes. Each bug was masked by round-trip tests because the encoder and decoder shared the same non-standard convention — so data survived a self-round-trip while the on-the-wire format was wrong.

This PR fixes all six and adds unit tests to assert the wire format directly.

## Issue

## Description of changes

1. **Text string length is a UTF-8 byte count, not a UTF-16 code-unit count**

   `TextString.encode` used `value.length` (UTF-16 code units) for the CBOR length argument, so any multibyte string produced invalid, non-round-trippable CBOR. It now encodes the UTF-8 bytes once and uses their size. Byte-identical for ASCII. This is the single choke point for all text (struct field names, map keys, `Char`, string values).

2. **Negative bignum (tag 3) uses the unsigned magnitude**

   Per RFC 8949 §3.4.3, the tag-3 content is the unsigned magnitude *n* where value = −1 − *n*. `NegBigNum.encode` emitted the signed two's-complement of `value - 1`, and `decode` read it back as signed — so −500 serialized to `c342fe0b` (which is −65036) instead of `c34201f3`. Encode now writes the minimal unsigned big-endian magnitude; decode interprets the byte string as unsigned.

3. **Negative-integer timestamps keep their sign**

   `Timestamp.decode`'s `NEG_INT` branch passed `NegInt.value` (a positive magnitude) to `Instant.fromEpochSeconds` without negating, so a pre-1970 integer timestamp decoded with the wrong sign (`0xC1 0x20` → 1970-01-01T00:00:01Z instead of 1969-12-31T23:59:59Z). Now negated, consistent with `deserializeNumber` and `DecimalFraction`.

4. **Decimal fraction (tag 4) uses the scale exponent**

   A CBOR decimal fraction is mantissa × 10^exponent with the full unscaled-integer mantissa (RFC 8949 §3.4.4). The code used `∓value.exponent`, but this codebase's `BigDecimal.exponent` is a scientific exponent (`digits(mantissa) - 1 - scale`), which differs from the CBOR scale exponent by `digits(mantissa) - 1`. This was only correct when `2·scale == digits - 1` — true for the one prior test vector (273.15) by coincidence — so e.g., 1.1 was encoded as 11.

5. **Floating-point decode dispatches on the major type first** 

   `deserializeFloatingPoint` switched on the minor byte alone, but the FLOAT16/32/64 minor values (25/26/27) are identical to the integer argument-size markers ARG_2/4/8 — so an integer with a ≥2-byte argument (e.g., uint 1000) was misrouted into `Float16.decode`, and small integers hit `Float.fromBits(value)` (reinterpreting the integer's value as raw IEEE-754 bits). It now dispatches on the major type: type 7 → float decoders; unsigned/negative int → numeric conversion (a whole-valued float may legitimately arrive in compact integer form).

6. **Decode lengths are no longer truncated to Int**

   `TextString`/`ByteString`/`List`/`Map` decode narrowed the `ULong` length via `.toInt()`, so a length of 2³² silently truncated to 0 (reading zero bytes and misaligning the rest of the stream). Now kept as `Long`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
