### PR TITLE
fix: remove experimental annotation from telemetry interfaces/types

### DIFF
--- a/.changes/88a35575-faa4-4bd9-b395-725ef38725cb.json
+++ b/.changes/88a35575-faa4-4bd9-b395-725ef38725cb.json
@@ -1,0 +1,5 @@
+{
+    "id": "88a35575-faa4-4bd9-b395-725ef38725cb",
+    "type": "bugfix",
+    "description": "`TelemetryProvider` and related types are no longer experimental"
+}

--- a/runtime/auth/aws-signing-default/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/DefaultAwsSignerJVM.kt
+++ b/runtime/auth/aws-signing-default/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/DefaultAwsSignerJVM.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.auth.awssigning
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
@@ -33,7 +32,6 @@ private val AwsSigningAlgorithm.signatureCalculator
         AwsSigningAlgorithm.SIGV4_ASYMMETRIC -> SignatureCalculator.SigV4a
     }
 
-@OptIn(ExperimentalApi::class)
 internal class DefaultAwsSignerImpl(
     private val canonicalizer: Canonicalizer = Canonicalizer.Default,
     private val requestMutator: RequestMutator = RequestMutator.Default,

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/AbstractTelemetryProvider.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/AbstractTelemetryProvider.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.telemetry
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
 import aws.smithy.kotlin.runtime.telemetry.logging.LoggerProvider
 import aws.smithy.kotlin.runtime.telemetry.metrics.MeterProvider
@@ -16,15 +15,8 @@ import aws.smithy.kotlin.runtime.telemetry.trace.TracerProvider
  * unless overridden in a subclass.
  */
 public abstract class AbstractTelemetryProvider : TelemetryProvider {
-    @ExperimentalApi
     override val meterProvider: MeterProvider = MeterProvider.None
-
-    @ExperimentalApi
     override val tracerProvider: TracerProvider = TracerProvider.None
-
-    @ExperimentalApi
     override val loggerProvider: LoggerProvider = LoggerProvider.None
-
-    @ExperimentalApi
     override val contextManager: ContextManager = ContextManager.None
 }

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/TelemetryProvider.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/TelemetryProvider.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.telemetry
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
 import aws.smithy.kotlin.runtime.telemetry.logging.LoggerProvider
@@ -26,24 +25,20 @@ public interface TelemetryProvider {
     /**
      * Get the [TracerProvider] used to create new [aws.smithy.kotlin.runtime.telemetry.trace.Tracer] instances
      */
-    @ExperimentalApi
     public val tracerProvider: TracerProvider
 
     /**
      * Get the [MeterProvider] used to create new [aws.smithy.kotlin.runtime.telemetry.metrics.Meter] instances
      */
-    @ExperimentalApi
     public val meterProvider: MeterProvider
 
     /**
      * Get the [LoggerProvider] used to create new [aws.smithy.kotlin.runtime.telemetry.logging.Logger] instances
      */
-    @ExperimentalApi
     public val loggerProvider: LoggerProvider
 
     /**
      * Get the [ContextManager] used to get the current [Context]
      */
-    @ExperimentalApi
     public val contextManager: ContextManager
 }

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.telemetry.logging
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.telemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.trace.SpanContext
@@ -69,7 +68,6 @@ public suspend inline fun <R> withLogCtx(
  * @param content A lambda which provides the content of the message. This content does not need to include any data
  * from the exception (if any), which may be concatenated later based on probe behavior.
  */
-@OptIn(ExperimentalApi::class)
 @InternalApi
 public fun CoroutineContext.log(
     level: LogLevel,
@@ -215,7 +213,6 @@ public inline fun <reified T> CoroutineContext.trace(ex: Throwable? = null, noin
  * Get a [Logger] instance using the current [LoggerProvider] configured in this [CoroutineContext]
  * @param sourceComponent The name of the component to create a logger for
  */
-@OptIn(ExperimentalApi::class)
 @InternalApi
 public fun CoroutineContext.logger(sourceComponent: String): Logger {
     val logger = this.telemetryProvider.loggerProvider.getOrCreateLogger(sourceComponent)

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExt.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.telemetry.trace
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.collections.Attributes
 import aws.smithy.kotlin.runtime.collections.emptyAttributes
@@ -60,7 +59,6 @@ public suspend inline fun <R> Tracer.withSpan(
  * Executes [block] within the scope of [TraceSpan]. The [block] of code is executed
  * with a new coroutine context that contains the [span] set in the context.
  */
-@OptIn(ExperimentalApi::class)
 @InternalApi
 public suspend inline fun <R> withSpan(
     span: TraceSpan,
@@ -109,7 +107,6 @@ public suspend inline fun <reified T, R> withSpan(
  * within the scope of the new span. The [block] of code is executed with a new coroutine
  * context that contains the newly created span set.
  */
-@OptIn(ExperimentalApi::class)
 @InternalApi
 public suspend inline fun <R> withSpan(
     sourceComponent: String,

--- a/runtime/observability/telemetry-defaults/common/src/aws/smithy/kotlin/runtime/telemetry/DefaultTelemetryProvider.kt
+++ b/runtime/observability/telemetry-defaults/common/src/aws/smithy/kotlin/runtime/telemetry/DefaultTelemetryProvider.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.telemetry
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
 import aws.smithy.kotlin.runtime.telemetry.logging.DefaultLoggerProvider
 import aws.smithy.kotlin.runtime.telemetry.logging.LoggerProvider
@@ -16,7 +15,6 @@ import aws.smithy.kotlin.runtime.telemetry.trace.TracerProvider
  * A telemetry provider that uses the default logger for a platform if one exists (e.g. SLF4J on JVM) and
  * is a no-op for other telemetry signals.
  */
-@OptIn(ExperimentalApi::class)
 public object DefaultTelemetryProvider : TelemetryProvider {
     override val loggerProvider: LoggerProvider = DefaultLoggerProvider
     override val tracerProvider: TracerProvider = TracerProvider.None

--- a/runtime/observability/telemetry-provider-emf/common/src/aws/smithy/kotlin/runtime/telemetry/emf/EmfTelemetryProvider.kt
+++ b/runtime/observability/telemetry-provider-emf/common/src/aws/smithy/kotlin/runtime/telemetry/emf/EmfTelemetryProvider.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.telemetry.emf
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
 import aws.smithy.kotlin.runtime.telemetry.logging.LoggerProvider
@@ -29,7 +28,6 @@ import aws.smithy.kotlin.runtime.util.PlatformProvider
  * }
  * ```
  */
-@ExperimentalApi
 public class EmfTelemetryProvider private constructor(builder: Builder) : TelemetryProvider {
     override val meterProvider: MeterProvider = EmfMeterProvider(
         namespace = builder.namespace,

--- a/runtime/observability/telemetry-provider-emf/common/test/aws/smithy/kotlin/runtime/telemetry/emf/EmfInstrumentsTest.kt
+++ b/runtime/observability/telemetry-provider-emf/common/test/aws/smithy/kotlin/runtime/telemetry/emf/EmfInstrumentsTest.kt
@@ -4,14 +4,12 @@
  */
 package aws.smithy.kotlin.runtime.telemetry.emf
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.collections.attributesOf
 import aws.smithy.kotlin.runtime.collections.emptyAttributes
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalApi::class)
 class EmfInstrumentsTest {
     @Test
     fun doubleHistogramEmitsEmf() {

--- a/runtime/observability/telemetry-provider-emf/common/test/aws/smithy/kotlin/runtime/telemetry/emf/EmfTelemetryProviderTest.kt
+++ b/runtime/observability/telemetry-provider-emf/common/test/aws/smithy/kotlin/runtime/telemetry/emf/EmfTelemetryProviderTest.kt
@@ -4,12 +4,10 @@
  */
 package aws.smithy.kotlin.runtime.telemetry.emf
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
-@OptIn(ExperimentalApi::class)
 class EmfTelemetryProviderTest {
     @Test
     fun rejectsEmptyNamespace() {

--- a/runtime/observability/telemetry-provider-micrometer/jvm/src/aws/smithy/kotlin/runtime/telemetry/micrometer/MicrometerTelemetryProvider.kt
+++ b/runtime/observability/telemetry-provider-micrometer/jvm/src/aws/smithy/kotlin/runtime/telemetry/micrometer/MicrometerTelemetryProvider.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.telemetry.micrometer
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.telemetry.GlobalTelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
@@ -23,7 +22,6 @@ import io.micrometer.core.instrument.Metrics
  * A provider is taken explicitly because Micrometer does not provide a logging API, only a log bridge for
  * existing logging implementations.
  */
-@ExperimentalApi
 public class MicrometerTelemetryProvider(
     meterRegistry: MeterRegistry = Metrics.globalRegistry,
     override val loggerProvider: LoggerProvider = GlobalTelemetryProvider.instance.loggerProvider,

--- a/runtime/observability/telemetry-provider-otel/jvm/src/aws/smithy/kotlin/runtime/telemetry/otel/OpenTelemetryProvider.kt
+++ b/runtime/observability/telemetry-provider-otel/jvm/src/aws/smithy/kotlin/runtime/telemetry/otel/OpenTelemetryProvider.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.telemetry.otel
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.telemetry.GlobalTelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
@@ -22,7 +21,6 @@ import io.opentelemetry.api.OpenTelemetry
  * A provider is taken explicitly because OpenTelemetry does not provide a logging API, only a log bridge for
  * existing logging implementations.
  */
-@ExperimentalApi
 public class OpenTelemetryProvider(
     private val otel: OpenTelemetry,
     override val loggerProvider: LoggerProvider = GlobalTelemetryProvider.instance.loggerProvider,

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/HttpEngineEventListener.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/HttpEngineEventListener.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.engine.okhttp
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.http.engine.EngineAttributes
 import aws.smithy.kotlin.runtime.http.engine.internal.HttpClientMetrics
@@ -31,7 +30,6 @@ import kotlin.time.TimeSource
 internal const val TELEMETRY_SCOPE = "aws.smithy.kotlin.runtime.http.engine.okhttp"
 
 // see https://square.github.io/okhttp/features/events/#eventlistener for example callback flow
-@OptIn(ExperimentalApi::class)
 @InternalApi
 public class HttpEngineEventListener(
     private val pool: ConnectionPool,

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/MetricsInterceptorTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/MetricsInterceptorTest.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.engine.okhttp
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.collections.emptyAttributes
 import aws.smithy.kotlin.runtime.http.engine.internal.HttpClientMetrics
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
@@ -28,7 +27,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
-@OptIn(ExperimentalApi::class)
 class MetricsInterceptorTest {
     private val metricReader = InMemoryMetricReader.create()
     private val sdkMeterProvider = SdkMeterProvider.builder()

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.engine.internal
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.collections.Attributes
 import aws.smithy.kotlin.runtime.collections.attributesOf
@@ -34,7 +33,6 @@ public object HttpClientMetricAttributes {
  * @param scope the instrumentation scope
  * @param provider the telemetry provider to instrument with
  */
-@OptIn(ExperimentalApi::class)
 @InternalApi
 public class HttpClientMetrics(
     scope: String,

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.interceptors
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
 import aws.smithy.kotlin.runtime.client.ProtocolResponseInterceptorContext
 import aws.smithy.kotlin.runtime.client.RequestInterceptorContext
@@ -31,7 +30,6 @@ import kotlin.time.TimeSource
  * @param operation the name of the operation
  * @param timeSource the time source to use for measuring elapsed time
  */
-@OptIn(ExperimentalApi::class)
 internal class OperationTelemetryInterceptor(
     private val metrics: OperationMetrics,
     private val service: String,

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.operation
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.metrics.DoubleHistogram
@@ -16,7 +15,6 @@ import aws.smithy.kotlin.runtime.telemetry.metrics.MonotonicCounter
  * @param scope the instrumentation scope
  * @param provider the telemetry provider to instrument with
  */
-@OptIn(ExperimentalApi::class)
 @InternalApi
 public class OperationMetrics(
     scope: String,

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationTelemetry.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationTelemetry.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.http.operation
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.client.*
 import aws.smithy.kotlin.runtime.collections.*
@@ -51,7 +50,6 @@ public inline fun <I, O> SdkHttpOperationBuilder<I, O>.telemetry(block: SdkOpera
  * @return the span for the operation and the additional coroutine context to execute the operation with containing
  * telemetry elements.
  */
-@OptIn(ExperimentalApi::class)
 internal fun <I, O> SdkHttpOperation<I, O>.instrument(): Pair<TraceSpan, CoroutineContext> {
     val serviceName = checkNotNull(context.serviceName)
     val opName = checkNotNull(context.operationName)

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.http.operation
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.businessmetrics.BusinessMetrics
 import aws.smithy.kotlin.runtime.businessmetrics.SmithyBusinessMetric
@@ -287,7 +286,6 @@ internal class AuthHandler<Input, Output>(
             request.context.getOrNull(SdkClientOption.OperationName)?.let { "rpc.method" to it }
         }
 
-        @OptIn(ExperimentalApi::class)
         val telemetryCtx = request.context.operationMetrics.provider.contextManager.current()
 
         // properties need to propagate from AuthOption to signer and identity provider

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptorTest.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.interceptors
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.collections.AttributeKey
 import aws.smithy.kotlin.runtime.collections.get
 import aws.smithy.kotlin.runtime.http.Headers
@@ -47,7 +46,6 @@ private val RESPONSE_BODY = "response-payload-that-is-longer".encodeToByteArray(
 private object TelemetryTestInput
 private data class TelemetryTestOutput(val body: HttpBody)
 
-@OptIn(ExperimentalApi::class)
 class OperationTelemetryInterceptorTest {
     private fun runOperation(provider: RecordingTelemetryProvider, withTimeToFirstByte: Boolean) = runTest {
         val op = SdkHttpOperation.build<TelemetryTestInput, TelemetryTestOutput> {

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.http.operation
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
 import aws.smithy.kotlin.runtime.client.SdkClientOption
@@ -105,7 +104,6 @@ class HttpAuthHandlerTest {
         assertEquals(Host.Domain("localhost"), request.subject.url.host)
     }
 
-    @OptIn(ExperimentalApi::class)
     @Test
     fun testAuthMetricsCarryRpcAttributesAndContext() = runTest {
         // verify identity-resolution and signing metrics are tagged with rpc.service/rpc.method and
@@ -136,7 +134,6 @@ class HttpAuthHandlerTest {
         }
     }
 
-    @OptIn(ExperimentalApi::class)
     @Test
     fun testEndpointResolutionMetricCarriesRpcAttributesAndContext() = runTest {
         // verify the endpoint-resolution metric is tagged with rpc.service/rpc.method and carries the
@@ -170,7 +167,6 @@ class HttpAuthHandlerTest {
      * Asserts that exactly one measurement was recorded for [name] and that it carries the rpc.service/rpc.method
      * attributes and the provider's current telemetry context.
      */
-    @OptIn(ExperimentalApi::class)
     private fun assertMetricHasRpcAttributesAndContext(provider: RecordingTelemetryProvider, name: String) {
         val rpcServiceKey = AttributeKey<String>("rpc.service")
         val rpcMethodKey = AttributeKey<String>("rpc.method")

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/util/RecordingTelemetryProvider.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/util/RecordingTelemetryProvider.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.util
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.collections.Attributes
 import aws.smithy.kotlin.runtime.telemetry.AbstractTelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.context.AbstractContext
@@ -40,7 +39,6 @@ internal data class MetricRecord(
  * [activeContext] is returned from [ContextManager.current] so tests can assert that the "current" context is
  * threaded through to metric recordings.
  */
-@OptIn(ExperimentalApi::class)
 internal class RecordingTelemetryProvider : AbstractTelemetryProvider() {
     val records = mutableListOf<MetricRecord>()
 


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

The telemetry system has been stable for quite a long time and shouldn't be marked as "experimental" anymore.

**Companion PR**: https://github.com/aws/aws-sdk-kotlin/pull/1978

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
