### PR TITLE
fix: upgrade Smithy version to pick up bugfix for endpoint ruleset trimming

### DIFF
--- a/.changes/a4b16059-858b-449b-8df4-066b889a99c3.json
+++ b/.changes/a4b16059-858b-449b-8df4-066b889a99c3.json
@@ -1,0 +1,8 @@
+{
+    "id": "a4b16059-858b-449b-8df4-066b889a99c3",
+    "type": "bugfix",
+    "description": "Upgrade to Smithy [v1.73.0](https://github.com/smithy-lang/smithy/releases/tag/1.73.0) to pick up [bugfix for endpoint ruleset trimming](https://github.com/smithy-lang/smithy/pull/3219)",
+    "issues": [
+        "https://github.com/smithy-lang/smithy/issues/3190"
+    ]
+}

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestRequestGenerator.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestRequestGenerator.kt
@@ -21,12 +21,15 @@ import aws.smithy.kotlin.codegen.rendering.ShapeValueGenerator
 import aws.smithy.kotlin.codegen.rendering.endpoints.EndpointProviderGenerator
 import aws.smithy.kotlin.codegen.rendering.serde.CborSerdeDescriptorGenerator
 import aws.smithy.kotlin.codegen.rendering.serde.DeserializeStructGenerator
+import aws.smithy.kotlin.codegen.rendering.serde.DeserializeUnionGenerator
 import aws.smithy.kotlin.codegen.rendering.serde.documentDeserializer
 import aws.smithy.kotlin.codegen.utils.getOrNull
+import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
@@ -66,7 +69,7 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
         renderOperationBlock(test)
     }
 
-    private fun renderStructDeserializer(writer: KotlinWriter, shape: Shape): Symbol {
+    private fun renderDocumentDeserializer(writer: KotlinWriter, shape: Shape): Symbol {
         val symbol = ctx.symbolProvider.toSymbol(shape)
         val deserializeFnName = "deserialize" + StringUtils.capitalize(symbol.name) + "Document"
         return shape.documentDeserializer(ctx.settings, symbol) { blockWriter ->
@@ -74,22 +77,48 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
                 val renderingCtx = RenderingContext(blockWriter, shape, model, symbolProvider, ctx.settings)
                 val descriptorGenerator = CborSerdeDescriptorGenerator(renderingCtx)
 
-                val deserializeStructGenerator = DeserializeStructGenerator(
-                    ctx,
-                    shape.members().toMutableList(),
-                    blockWriter,
-                    TimestampFormatTrait.Format.EPOCH_SECONDS,
-                )
+                val deserializeDocumentGenerator = when (shape) {
+                    is StructureShape -> DeserializeStructGenerator(
+                        ctx,
+                        shape.members().toMutableList(),
+                        blockWriter,
+                        TimestampFormatTrait.Format.EPOCH_SECONDS,
+                    )
 
-                blockWriter.write("val builder = #T.Builder()", symbol)
+                    is UnionShape -> DeserializeUnionGenerator(
+                        ctx,
+                        symbol.name,
+                        shape.members().toMutableList(),
+                        blockWriter,
+                        TimestampFormatTrait.Format.EPOCH_SECONDS,
+                    )
+
+                    else -> throw CodegenException("Unexpected shape type ${shape.type}, expected a structure or union")
+                }
+
+                if (shape is UnionShape) {
+                    blockWriter.write("var value: #T? = null", symbol)
+                } else {
+                    blockWriter.write("val builder = #T.Builder()", symbol)
+                }
+
                 blockWriter.write("")
 
                 blockWriter.call { descriptorGenerator.render() }
-                blockWriter.call { deserializeStructGenerator.render() }
+                blockWriter.call { deserializeDocumentGenerator.render() }
 
                 blockWriter.write("")
-                blockWriter.write("builder.correctErrors()")
-                blockWriter.write("return builder.build()")
+
+                if (shape is UnionShape) {
+                    blockWriter.write(
+                        "return value ?: throw #T(#S)",
+                        RuntimeTypes.Serde.DeserializationException,
+                        "Deserialized union value unexpectedly null: ${symbol.name}",
+                    )
+                } else {
+                    blockWriter.write("builder.correctErrors()")
+                    blockWriter.write("return builder.build()")
+                }
             }
         }.also {
             writer.addImport(it)
@@ -111,9 +140,9 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
 
                 val serdeIndex = SerdeIndex.of(ctx.model)
                 serdeIndex.requiresDocumentDeserializer(inputShape).forEach {
-                    renderStructDeserializer(writer, it)
+                    renderDocumentDeserializer(writer, it)
                 }
-                val inputDeserializer = renderStructDeserializer(writer, inputShape)
+                val inputDeserializer = renderDocumentDeserializer(writer, inputShape)
 
                 writer.write("")
                 writer.withBlock("suspend fun assertCborBodiesEqual(expected: #1T?, actual: #1T?) {", "}", RuntimeTypes.Http.HttpBody) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ publish-plugin-version = "2.1.1"
 smithy-gradle-plugin-version = "1.5.0"
 
 # codegen
-smithy-version = "1.72.1"
+smithy-version = "1.73.0"
 
 # testing
 junit-version = "5.14.4"


### PR DESCRIPTION
## Issue \#

Fixes workaround for https://github.com/smithy-lang/smithy/issues/3190

## Description of changes

This change upgrades to Smithy [**v1.73.0**](https://github.com/smithy-lang/smithy/releases/tag/1.73.0) to pick up the [bugfix for endpoint ruleset trimming](https://github.com/smithy-lang/smithy/pull/3219) noted in https://github.com/smithy-lang/smithy/issues/3190. After this change is published, we should be able to remove [the workaround for the Smithy bug that was added to **aws-sdk-kotlin**](https://github.com/aws/aws-sdk-kotlin/pull/1932).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
