### PR TITLE
perf(cbor): string optimization

### DIFF
--- a/.changes/66cf9759-1375-498d-83f8-5e7e33f648bc.json
+++ b/.changes/66cf9759-1375-498d-83f8-5e7e33f648bc.json
@@ -1,0 +1,6 @@
+{
+  "id": "66cf9759-1375-498d-83f8-5e7e33f648bc",
+  "type": "misc",
+  "description": "Optimize CBOR text string decoding by reading UTF-8 directly from the buffer instead of copying into an intermediate byte array",
+  "module": "serde-cbor"
+}

--- a/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
+++ b/runtime/serde/serde-cbor/common/src/aws/smithy/kotlin/runtime/serde/cbor/encoding/Collections.kt
@@ -32,7 +32,7 @@ internal class TextString(val value: String) : Value {
             TextString(sb.toString())
         } else {
             val length = decodeArgument(buffer).toLong()
-            TextString(buffer.readByteArray(length).decodeToString())
+            TextString(buffer.readUtf8(length))
         }
     }
 }


### PR DESCRIPTION
Decode definite-length CBOR text strings (major type 3) by reading **directly** into a `String` with `SdkBufferedSource.readUtf8(length)` instead of allocating a full-size intermediate `ByteArray` (`readByteArray(length)`), decoding it to a `String` with `decodeToString()`, and discarding the array. This eliminates one throwaway `ByteArray` allocation per string value **and** per generic map key — the highest-volume types on the decode path. Decoding is value-for-value identical: both paths substitute U+FFFD on malformed UTF-8, so well-formed AWS payloads decode exactly as before. The length prefix is still consumed by `decodeArgument` first, so CBOR framing is unchanged.

## Description of changes

- **Strings** (`Collections.kt`): the definite-length `TextString.decode` branch now reads straight into a `String` via `buffer.readUtf8(length)` instead of `buffer.readByteArray(length).decodeToString()`. The length prefix (`decodeArgument(buffer).toLong()`) is unchanged, and the indefinite-length path (`Minor.INDEFINITE`, chunk concatenation via `StringBuilder`) is left untouched.

## Benchmark results

Measured with the serde CBOR benchmarks (`rpcv2Cbor`), 5 paired instances per benchmark. Negative `Δ%` means the target (this change) is faster.

```
--- Protocol: rpcv2Cbor  (mean ns; Δ%<0 = target faster) ---
Benchmark                                      Base     Target    Delta%    t-stat  Npair
---------------------------------------- ---------- ---------- --------- --------- ------
GetItemOutputBinary_L                      104454.9   100666.6    -3.63%   -2.75**      5
GetItemOutputBinary_M                       17269.9    16549.8    -4.17%   -2.73**      5
GetItemOutputBinary_S                        5320.9     5160.0    -3.02%     -1.45      5
GetItemOutput_Baseline                        774.6      814.4    +5.15%      1.58      5
GetItemOutput_L                            107032.7   102186.4    -4.53%  -4.77***      5
GetItemOutput_M                             17592.9    16888.0    -4.01%     -1.86      5
GetItemOutput_S                              5807.4     5569.2    -4.10%    -2.17*      5
PutItemRequest_Baseline                      1691.0     1669.2    -1.28%     -0.70      5
PutItemRequest_BinaryData_L                 14755.9    14758.8    +0.02%      0.01      5
PutItemRequest_BinaryData_M                  4859.5     4924.4    +1.34%      0.62      5
PutItemRequest_BinaryData_S                  1913.9     1954.5    +2.12%      1.61      5
PutItemRequest_MixedItem_L                  36072.3    35788.1    -0.79%     -0.57      5
PutItemRequest_MixedItem_M                  13657.4    13523.5    -0.98%     -0.83      5
PutItemRequest_MixedItem_S                   4037.3     4058.0    +0.51%      0.81      5
PutItemRequest_Nested_L                      8084.2     8001.1    -1.03%     -0.79      5
PutItemRequest_Nested_M                      3664.8     3528.4    -3.72%     -1.45      5
PutItemRequest_ShallowMap_L                 43803.6    42871.6    -2.13%     -1.12      5
PutItemRequest_ShallowMap_M                 16034.1    15845.4    -1.18%     -0.66      5
PutItemRequest_ShallowMap_S                  4658.6     4580.6    -1.67%     -0.85      5
```

### Highlights

- Deserialization-dominated read paths benefit most: `GetItemOutput_L` improves **−4.5%** (`***`), `GetItemOutputBinary_L/M` improve **−3.6% to −4.2%** (`**`), and the remaining `GetItemOutput` variants show **−3.0% to −4.1%** — directly reflecting the eliminated throwaway `ByteArray` allocation and second copy per decoded string and map key.
- Serialization-dominated `PutItemRequest_*` paths are essentially flat (all statistically insignificant), as expected — this change targets the deserialize path and leaves encoding untouched.
- The `GetItemOutput_Baseline` +5.15% is statistically insignificant (t = 1.58) and reflects run-to-run variance on a trivially small payload with minimal string content.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
