### PR TITLE
chore: add support for external PR CI

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,58 @@
+# Branch protection configuration
+
+## Required status check
+
+Configure **exactly one** required status context on protected branches:
+
+- **`required`** — the aggregate job.
+
+This single context is produced under the same name on both PR origins, so one
+branch-protection rule covers both.
+
+## How the two origins produce it
+
+### Fork PRs (privileged path)
+Fork PRs run through the privileged entrypoint `external-pr-ci.yml`
+(`pull_request_target`, gated on the `safe-to-test` label and a verified fork
+head). The entrypoint calls each in-scope workflow as a reusable
+`workflow_call`, so their job contexts are **prefixed by the caller job name**:
+
+- `ci / jvm (17)`, `ci / linux`, `ci / all-platforms`, `ci / protocol-tests`,
+  `ci / downstream`, ...
+- `changelog / changelog-verification`
+- `required` (the entrypoint's aggregate job)
+
+Note: `macos` and `windows` use no credentials/kat and already pass on forks.
+They are guarded with `if: ${{ github.event_name != 'workflow_call' }}` so they
+run **only** on the unprivileged (same-repo) path and are skipped when
+`continuous-integration.yml` is invoked via `workflow_call` from the entrypoint.
+This avoids duplicate runs.
+
+### Same-repo PRs (unprivileged path)
+Same-repo PRs run the in-scope workflows directly via their own `pull_request` /
+`merge_group` triggers, producing **unprefixed** contexts:
+
+- `jvm (17)`, `macos (macos-15-large)`, `windows`, `linux`, `all-platforms`,
+  `protocol-tests`, `downstream`
+- `changelog-verification`
+- `required` — produced by `ci-required.yml`, under the **same name** as the
+  entrypoint's aggregate.
+
+## Why only the aggregate is marked required
+
+A status context that can be produced by only one origin must **not** be marked
+required: it would never appear on PRs from the other origin and would block
+them forever. Because fork contexts are caller-prefixed (`ci / jvm (17)`) while
+same-repo contexts are unprefixed (`jvm (17)`), no individual job name is common
+to both origins. Only the aggregate `required` job shares one name across both
+paths, so it is the single safe required context.
+
+### Limitation of `ci-required.yml`
+
+`ci-required.yml` only reproduces the `required` context name on the same-repo
+path — it does **not** itself gate the individual same-repo checks. Those checks
+(`jvm`, `linux`, etc.) remain independently required by virtue of being part of
+the same-repo PR run; the aggregate does not aggregate their results on the
+same-repo path. If you need same-repo individual checks enforced, keep them as
+independently required contexts in addition to the aggregate, or convert
+`ci-required.yml` into a `needs:`-based aggregation of the same-repo jobs.

--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -12,6 +12,15 @@ on:
       - '*-main'
   merge_group:
     types: [checks_requested]
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 jobs:
   changelog-verification:
@@ -27,3 +36,5 @@ jobs:
 
       - name: Verify changelog
         uses: aws/aws-kotlin-repo-tools/.github/actions/changelog-verification@main
+        with:
+          ref: ${{ inputs.ref }}

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -5,6 +5,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 jobs:
   required:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -1,0 +1,13 @@
+name: CI Required
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  required:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate required checks
+        run: echo "Same-repo aggregate required check succeeded"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,15 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 permissions:
   id-token: write
@@ -43,6 +52,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           path: 'smithy-kotlin'
 
       - name: Setup build
@@ -95,6 +105,7 @@ jobs:
   # macOS ARM images build and test for targets: jvm, macosArm64, iosSimulatorArm64, watchosSimulatorArm65, tvosSimulatorArm64
   # macos x64 images build and test for targets: jvm, macosX64, iosX64, tvosX64, watchosX64
   macos:
+    if: ${{ github.event_name != 'workflow_call' }}
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +117,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           path: 'smithy-kotlin'
 
       - name: Setup build
@@ -175,6 +187,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           path: 'smithy-kotlin'
 
       - name: Configure AWS Credentials
@@ -222,11 +235,13 @@ jobs:
 
   # windows JVM
   windows:
+    if: ${{ github.event_name != 'workflow_call' }}
     runs-on: windows-2022
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           path: 'smithy-kotlin'
 
       - name: Setup build
@@ -259,6 +274,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           path: 'smithy-kotlin'
 
       - name: Setup build
@@ -328,6 +344,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           path: 'smithy-kotlin'
 
       - name: Setup build
@@ -386,6 +403,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v4
       with:
+        ref: ${{ inputs.ref }}
         path: 'smithy-kotlin'
 
     - name: Setup build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ permissions:
 
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:
-  group: ci-pr-${{ github.ref }}
+  group: ci-pr-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -105,7 +105,7 @@ jobs:
   # macOS ARM images build and test for targets: jvm, macosArm64, iosSimulatorArm64, watchosSimulatorArm65, tvosSimulatorArm64
   # macos x64 images build and test for targets: jvm, macosX64, iosX64, tvosX64, watchosX64
   macos:
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'pull_request_target' }}
     strategy:
       fail-fast: false
       matrix:
@@ -235,7 +235,7 @@ jobs:
 
   # windows JVM
   windows:
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'pull_request_target' }}
     runs-on: windows-2022
     steps:
       - name: Checkout sources

--- a/.github/workflows/external-pr-ci.yml
+++ b/.github/workflows/external-pr-ci.yml
@@ -1,0 +1,68 @@
+name: External PR CI (privileged)
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: external-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      approved: ${{ steps.check.outputs.approved }}
+    steps:
+      - name: Revoke approval on new commits
+        if: ${{ github.event.action == 'synchronize' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label safe-to-test || true
+      - name: Determine whether to run
+        id: check
+        run: |
+          if [ "${{ github.event.action }}" == "labeled" ] && \
+             [ "${{ github.event.label.name }}" == "safe-to-test" ] && \
+             [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  ci:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/continuous-integration.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  changelog:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/changelog-verification.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  required:
+    if: ${{ always() }}
+    needs: [ci, changelog]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]; then
+            echo "One or more required jobs failed or were cancelled"
+            exit 1
+          fi
+          echo "All required jobs succeeded"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Add support for external PRs to successfully execute CI workflows after being approved by a maintainer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
