### PR TITLE
Allow the new retry behavior flag on the standard retry token bucket

### DIFF
--- a/.changes/704d2a32-9d3f-454f-9625-70d337c9e35e.json
+++ b/.changes/704d2a32-9d3f-454f-9625-70d337c9e35e.json
@@ -1,0 +1,6 @@
+{
+  "id": "704d2a32-9d3f-454f-9625-70d337c9e35e",
+  "type": "bugfix",
+  "description": "Allow the new retry behavior flag on the standard retry token bucket to be set by callers so it can be enabled from configuration sources other than the `SMITHY_NEW_RETRIES_2026` setting",
+  "module": "runtime-core"
+}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -2114,6 +2114,7 @@ public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBuc
 	public final fun getRetryCost ()I
 	public final fun getTimeoutRetryCost ()I
 	public final fun getUseCircuitBreakerMode ()Z
+	public final fun getUseNewRetries ()Z
 	public final fun setInitialTryCost (I)V
 	public final fun setInitialTrySuccessIncrement (I)V
 	public final fun setMaxCapacity (I)V
@@ -2121,6 +2122,7 @@ public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBuc
 	public final fun setRetryCost (I)V
 	public final fun setTimeoutRetryCost (I)V
 	public final fun setUseCircuitBreakerMode (Z)V
+	public final fun setUseNewRetries (Z)V
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Companion {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
@@ -184,6 +184,7 @@ public class StandardRetryTokenBucket internal constructor(
         @InternalApi
         override fun toBuilderApplicator(): RetryTokenBucket.Config.Builder.() -> Unit = {
             if (this is Builder) {
+                useNewRetries = this@Config.useNewRetries
                 useCircuitBreakerMode = this@Config.useCircuitBreakerMode
                 initialTryCost = this@Config.initialTryCost
                 initialTrySuccessIncrement = this@Config.initialTrySuccessIncrement
@@ -198,7 +199,7 @@ public class StandardRetryTokenBucket internal constructor(
          * A mutable builder for a [Config]
          */
         public class Builder(platform: PlatformEnvironProvider = PlatformProvider.System) : RetryTokenBucket.Config.Builder {
-            internal val useNewRetries = CoreSettings.resolveNewRetriesEnabled(platform)
+            public var useNewRetries: Boolean = CoreSettings.resolveNewRetriesEnabled(platform)
 
             /**
              * When `true`, indicates that attempts to acquire tokens or schedule retries should fail if all capacity

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
@@ -87,6 +87,25 @@ class StandardRetryTokenBucketTest {
     }
 
     @Test
+    fun testRetryCapacityAdjustmentsWithNewRetries() = runTest {
+        // With new retries enabled, transient errors pay retryCost (not the timeout/throttling cost)
+        mapOf(
+            RetryErrorType.Throttling to DEFAULT_TIMEOUT_RETRY_COST,
+            RetryErrorType.Transient to DEFAULT_RETRY_COST,
+            RetryErrorType.ClientSide to DEFAULT_RETRY_COST,
+            RetryErrorType.ServerSide to DEFAULT_RETRY_COST,
+        ).forEach { (errorType, cost) ->
+            val bucket = tokenBucket(useNewRetries = true)
+
+            assertEquals(10, bucket.capacity)
+            val initialToken = assertTime(0.seconds) { bucket.acquireToken() }
+            assertEquals(10, bucket.capacity)
+            assertTime(0.seconds) { initialToken.scheduleRetry(errorType) }
+            assertEquals(10 - cost, bucket.capacity)
+        }
+    }
+
+    @Test
     fun testRefillOverTime() = runTest {
         val timeSource = TestTimeSource()
 
@@ -126,6 +145,7 @@ private fun TestScope.tokenBucket(
     refillUnitsPerSecond: Int = 10,
     retryCost: Int = DEFAULT_RETRY_COST,
     timeoutRetryCost: Int = DEFAULT_TIMEOUT_RETRY_COST,
+    useNewRetries: Boolean = false,
     timeSource: TimeSource = testTimeSource,
 ): StandardRetryTokenBucket {
     val config = StandardRetryTokenBucket.Config {
@@ -136,6 +156,7 @@ private fun TestScope.tokenBucket(
         this.refillUnitsPerSecond = refillUnitsPerSecond
         this.retryCost = retryCost
         this.timeoutRetryCost = timeoutRetryCost
+        this.useNewRetries = useNewRetries
     }
     return StandardRetryTokenBucket(config, timeSource)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Allow the new retry behavior flag on the standard retry token bucket


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
